### PR TITLE
fix type hint (#569)

### DIFF
--- a/spikingjelly/activation_based/auto_cuda/cfunction.py
+++ b/spikingjelly/activation_based/auto_cuda/cfunction.py
@@ -1,16 +1,19 @@
-def wrap_return_codes(y: str or None, codes: str):
+from typing import Optional
+
+
+def wrap_return_codes(y: Optional[str], codes: str):
     if y is None:
         return f'({codes})'
     else:
         return f'{y} = {codes};'
 
 
-def float2half2(y: str or None, x: str):
+def float2half2(y: Optional[str], x: str):
     codes = f'__float2half2_rn({x})'
     return wrap_return_codes(y, codes)
 
 
-def constant(y: str or None, x: float, dtype: str):
+def constant(y: Optional[str], x: float, dtype: str):
     if dtype == 'float':
         codes = f'{x}f'
     elif dtype == 'half2':
@@ -22,7 +25,7 @@ def constant(y: str or None, x: float, dtype: str):
 
 
 
-def abs(y: str or None, x: str, dtype: str):
+def abs(y: Optional[str], x: str, dtype: str):
     if dtype == 'float':
         codes = f'fabsf({x})'
     elif dtype == 'half2':
@@ -32,7 +35,7 @@ def abs(y: str or None, x: str, dtype: str):
     return wrap_return_codes(y, codes)
 
 
-def power(z: str or None, x: str, y: str, dtype: str):
+def power(z: Optional[str], x: str, y: str, dtype: str):
     if dtype == 'float':
         codes = f'__powf({x, y})'
     elif dtype == 'half2':
@@ -42,7 +45,7 @@ def power(z: str or None, x: str, y: str, dtype: str):
         raise NotImplementedError(dtype)
     return wrap_return_codes(z, codes)
 
-def if_else(z: str or None, x: str, y: str, mask: str, dtype: str):
+def if_else(z: Optional[str], x: str, y: str, mask: str, dtype: str):
     # z = x * mask + y * (1. - mask)
     if dtype == 'float':
         codes = f'{x} * {mask} + {y} * (1.0f - {mask})'
@@ -53,7 +56,7 @@ def if_else(z: str or None, x: str, y: str, mask: str, dtype: str):
 
     return wrap_return_codes(z, codes)
 
-def if_else_else(w: str or None, x: str, y: str, z: str, mask_x: str, mask_y: str, dtype: str):
+def if_else_else(w: Optional[str], x: str, y: str, z: str, mask_x: str, mask_y: str, dtype: str):
     # w = mask_x * x + mask_y * y + (1. - mask_x * mask_y) * z
     if dtype == 'float':
         codes = f'{mask_x} * {x} + {mask_y} * {y} + (1. - {mask_x} * {mask_y}) * {z}'
@@ -64,7 +67,7 @@ def if_else_else(w: str or None, x: str, y: str, z: str, mask_x: str, mask_y: st
 
 
 
-def greater_equal(z: str or None, x: str, y: str, dtype: str):
+def greater_equal(z: Optional[str], x: str, y: str, dtype: str):
     if dtype == 'float':
         codes = f'(float) ({x} >= {y})'
     elif dtype == 'half2':
@@ -73,7 +76,7 @@ def greater_equal(z: str or None, x: str, y: str, dtype: str):
         raise NotImplementedError(dtype)
     return wrap_return_codes(z, codes)
 
-def greater_than(z: str or None, x: str, y: str, dtype: str):
+def greater_than(z: Optional[str], x: str, y: str, dtype: str):
     if dtype == 'float':
         codes = f'(float) ({x} > {y})'
     elif dtype == 'half2':
@@ -82,7 +85,7 @@ def greater_than(z: str or None, x: str, y: str, dtype: str):
         raise NotImplementedError(dtype)
     return wrap_return_codes(z, codes)
 
-def minimal(z: str or None, x: str, y: str, dtype: str):
+def minimal(z: Optional[str], x: str, y: str, dtype: str):
     if dtype == 'float':
         codes = f'min({x}, {y})'
     elif dtype == 'half2':
@@ -91,7 +94,7 @@ def minimal(z: str or None, x: str, y: str, dtype: str):
         raise NotImplementedError(dtype)
     return wrap_return_codes(z, codes)
 
-def maximum(z: str or None, x: str, y: str, dtype: str):
+def maximum(z: Optional[str], x: str, y: str, dtype: str):
     if dtype == 'float':
         codes = f'max({x}, {y})'
     elif dtype == 'half2':
@@ -100,7 +103,7 @@ def maximum(z: str or None, x: str, y: str, dtype: str):
         raise NotImplementedError(dtype)
     return wrap_return_codes(z, codes)
 
-def add(z: str or None, x: str, y: str, dtype: str):
+def add(z: Optional[str], x: str, y: str, dtype: str):
     if dtype == 'float':
 
         if x == '0.0f':
@@ -126,7 +129,7 @@ def add(z: str or None, x: str, y: str, dtype: str):
     return wrap_return_codes(z, codes)
 
 
-def sub(z: str or None, x: str, y: str, dtype: str):
+def sub(z: Optional[str], x: str, y: str, dtype: str):
     if dtype == 'float':
 
         if y == '0.0f':
@@ -146,7 +149,7 @@ def sub(z: str or None, x: str, y: str, dtype: str):
     return wrap_return_codes(z, codes)
 
 
-def mul(z: str or None, x: str, y: str, dtype: str):
+def mul(z: Optional[str], x: str, y: str, dtype: str):
     if dtype == 'float':
 
         if x == '1.0f':
@@ -175,7 +178,7 @@ def mul(z: str or None, x: str, y: str, dtype: str):
     return wrap_return_codes(z, codes)
 
 
-def div(z: str or None, x: str, y: str, dtype: str):
+def div(z: Optional[str], x: str, y: str, dtype: str):
     if dtype == 'float':
 
         if y == '1.0f':
@@ -193,7 +196,7 @@ def div(z: str or None, x: str, y: str, dtype: str):
     return wrap_return_codes(z, codes)
 
 
-def neg(y: str or None, x: str, dtype: str):
+def neg(y: Optional[str], x: str, dtype: str):
     if dtype == 'float':
         codes = f'- {x}'
     elif dtype == 'half2':
@@ -203,7 +206,7 @@ def neg(y: str or None, x: str, dtype: str):
     return wrap_return_codes(y, codes)
 
 
-def heaviside(y: str or None, x: str, dtype: str):
+def heaviside(y: Optional[str], x: str, dtype: str):
     if dtype == 'float':
         codes = f'{x} >= 0.0f ? 1.0f: 0.0f'
     elif dtype == 'half2':
@@ -213,7 +216,7 @@ def heaviside(y: str or None, x: str, dtype: str):
     return wrap_return_codes(y, codes)
 
 
-def exp(y: str or None, x: str, dtype: str):
+def exp(y: Optional[str], x: str, dtype: str):
     if dtype == 'float':
         codes = f'expf({x})'
     elif dtype == 'half2':
@@ -223,7 +226,7 @@ def exp(y: str or None, x: str, dtype: str):
     return wrap_return_codes(y, codes)
 
 
-def sigmoid(y: str or None, x: str, alpha: float, dtype: str):
+def sigmoid(y: Optional[str], x: str, alpha: float, dtype: str):
     alpha = constant(None, alpha, dtype)
     if dtype == 'float':
         codes = f'1.0f / (1.0f + expf(- {alpha} * {x}))'

--- a/spikingjelly/activation_based/auto_cuda/neuron_kernel.py
+++ b/spikingjelly/activation_based/auto_cuda/neuron_kernel.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import torch
 import torch.nn.functional as F
 import numpy as np
@@ -407,7 +408,7 @@ class NeuronATGFBase:
 
 class IFNodeATGF(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, x_seq: torch.Tensor, v_init: torch.Tensor, v_th: float, v_reset: float or None,
+    def forward(ctx, x_seq: torch.Tensor, v_init: torch.Tensor, v_th: float, v_reset: Optional[float],
                 forward_kernel: IFNodeFPTTKernel, backward_kernel: IFNodeBPTTKernel):
         py_dict = {
             'x_seq': x_seq,
@@ -495,7 +496,7 @@ class LIFNodeBPTTKernel(NeuronBPTTKernel):
 
 class LIFNodeATGF(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, x_seq: torch.Tensor, v_init: torch.Tensor, v_th: float, v_reset: float or None, decay: float,
+    def forward(ctx, x_seq: torch.Tensor, v_init: torch.Tensor, v_th: float, v_reset: Optional[float], decay: float,
                 forward_kernel: LIFNodeFPTTKernel, backward_kernel: LIFNodeBPTTKernel):
         py_dict = {
             'x_seq': x_seq,
@@ -691,7 +692,7 @@ class ParametricLIFNodeBPTTKernel(NeuronBPTTKernel):
 
 class ParametricLIFNodeATGF(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, x_seq: torch.Tensor, v_init: torch.Tensor, v_th: float, v_reset: float or None, decay: torch.Tensor, forward_kernel: ParametricLIFNodeFPTTKernel, backward_kernel: ParametricLIFNodeBPTTKernel):
+    def forward(ctx, x_seq: torch.Tensor, v_init: torch.Tensor, v_th: float, v_reset: Optional[float], decay: torch.Tensor, forward_kernel: ParametricLIFNodeFPTTKernel, backward_kernel: ParametricLIFNodeBPTTKernel):
         if x_seq.dtype == torch.float16 and v_init.numel() % 2 != 0:
             raise ValueError('When using the the PLIF neuron with half2 cupy backend, the numer of neurons should be even to avoid the wrong gradient of tau caused by padding!')
         py_dict = {

--- a/spikingjelly/activation_based/auto_cuda/ss_neuron_kernel.py
+++ b/spikingjelly/activation_based/auto_cuda/ss_neuron_kernel.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import torch
 import torch.nn.functional as F
 import numpy as np
@@ -376,7 +377,7 @@ class IFNodeBPKernel(NeuronBPKernel):
     
 class IFNodeATGF(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, x: torch.Tensor, v: torch.Tensor, v_th: float, v_reset: float or None,
+    def forward(ctx, x: torch.Tensor, v: torch.Tensor, v_th: float, v_reset: Optional[float],
                 forward_kernel: IFNodeFPKernel, backward_kernel: IFNodeBPKernel):
         py_dict = {
             'x': x,
@@ -459,7 +460,7 @@ class LIFNodeBPKernel(NeuronBPKernel):
         
 class LIFNodeATGF(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, x: torch.Tensor, v: torch.Tensor, v_th: float, v_reset: float or None, decay: float,
+    def forward(ctx, x: torch.Tensor, v: torch.Tensor, v_th: float, v_reset: Optional[float], decay: float,
                 forward_kernel: LIFNodeFPKernel, backward_kernel: LIFNodeBPKernel):
         py_dict = {
             'x': x,

--- a/spikingjelly/activation_based/cuda_utils.py
+++ b/spikingjelly/activation_based/cuda_utils.py
@@ -3,7 +3,7 @@ import torch
 import time
 import numpy as np
 from .. import configure
-from typing import Callable
+from typing import Callable, Union
 try:
     import cupy
 except BaseException as e:
@@ -38,7 +38,7 @@ def cpu_timer(f: Callable, *args, **kwargs):
     f(*args, **kwargs)
     return time.perf_counter() - start
 
-def cuda_timer(device: torch.device or int, f: Callable, *args, **kwargs):
+def cuda_timer(device: Union[torch.device, int], f: Callable, *args, **kwargs):
     """
     * :ref:`API in English <cuda_timer-en>`
 
@@ -47,7 +47,7 @@ def cuda_timer(device: torch.device or int, f: Callable, *args, **kwargs):
     计算在CUDA上执行 ``f(*args, **kwargs)`` 所需的时间
 
     :param device: ``f`` 运行的CUDA设备
-    :type device: torch.device or int
+    :type device: Union[torch.device, int]
     :param f: 函数
     :type f: Callable
     :return: 用时，单位是毫秒
@@ -60,7 +60,7 @@ def cuda_timer(device: torch.device or int, f: Callable, *args, **kwargs):
     Returns the used time for calling ``f(*args, **kwargs)`` in CUDA
 
     :param device: on which cuda device that ``f`` is running
-    :type device: torch.device or int
+    :type device: Union[torch.device, int]
     :param f: a function
     :type f: Callable
     :return: used time in milliseconds
@@ -75,7 +75,7 @@ def cuda_timer(device: torch.device or int, f: Callable, *args, **kwargs):
     torch.cuda.synchronize(device)
     return start.elapsed_time(end)
 
-def cal_fun_t(n: int, device: str or torch.device or int, f: Callable, *args, **kwargs):
+def cal_fun_t(n: int, device: Union[str, torch.device, int], f: Callable, *args, **kwargs):
     """
     * :ref:`API in English <cal_fun_t-en>`
 
@@ -90,7 +90,7 @@ def cal_fun_t(n: int, device: str or torch.device or int, f: Callable, *args, **
     :param n: 重复的次数
     :type n: int
     :param device: ``f`` 执行的设备，可以为 'cpu' 或CUDA设备
-    :type device: str or torch.device or int
+    :type device: Union[str, torch.device, int]
     :param f: 函数
     :type f: Callable
     :return: 用时，单位是毫秒
@@ -111,7 +111,7 @@ def cal_fun_t(n: int, device: str or torch.device or int, f: Callable, *args, **
     :param n: repeat times
     :type n: int
     :param device: on which cuda device that ``f`` is running. It can be 'cpu' or a cuda deivce
-    :type device: str or torch.device or int
+    :type device: Union[str, torch.device, int]
     :param f: function
     :type f: Callable
     :return: used time in milliseconds

--- a/spikingjelly/activation_based/functional.py
+++ b/spikingjelly/activation_based/functional.py
@@ -4,7 +4,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import math
-from typing import Callable
+from typing import Callable, Union
 
 from . import neuron, base
 
@@ -106,7 +106,7 @@ def set_step_mode(net: nn.Module, step_mode: str):
                 m.step_mode = step_mode
 
 
-def set_backend(net: nn.Module, backend: str, instance: object or tuple = (nn.Module, )):
+def set_backend(net: nn.Module, backend: str, instance: Union[nn.Module, tuple[nn.Module, ...]] = (nn.Module, )):
     """
     * :ref:`API in English <set_backend-en>`
 
@@ -117,7 +117,7 @@ def set_backend(net: nn.Module, backend: str, instance: object or tuple = (nn.Mo
     :param backend: 使用哪个后端
     :type backend: str
     :param instance: 类型为 ``instance`` 的模块后端会被改变
-    :type instance: nn.Module or tuple[nn.Module]
+    :type instance: Union[nn.Module, tuple[nn.Module, ...]]
     :return: None
 
     将 ``net`` 中 所有类型为 ``instance`` 的模块后端更改为 ``backend``
@@ -131,7 +131,7 @@ def set_backend(net: nn.Module, backend: str, instance: object or tuple = (nn.Mo
     :param backend: the backend to be set
     :type backend: str
     :param instance: the backend of which instance will be changed
-    :type instance: nn.Module or tuple[nn.Module]
+    :type instance: Union[nn.Module, tuple[nn.Module, ...]]
     :return: None
 
     Sets backends of all modules whose instance is ``instance`` in ``net`` to ``backend``
@@ -522,7 +522,7 @@ def first_spike_index(spikes: Tensor):
         return spikes.cumsum(dim=-1).cumsum(dim=-1) == 1
 
 
-def multi_step_forward(x_seq: Tensor, single_step_module: nn.Module or list[nn.Module] or tuple[nn.Module] or nn.Sequential or Callable):
+def multi_step_forward(x_seq: Tensor, single_step_module: Union[nn.Module, list[nn.Module], tuple[nn.Module], nn.Sequential, Callable]):
     """
     * :ref:`API in English <multi_step_forward-en>`
 
@@ -531,7 +531,7 @@ def multi_step_forward(x_seq: Tensor, single_step_module: nn.Module or list[nn.M
     :param x_seq: ``shape=[T, batch_size, ...]`` 的输入tensor
     :type x_seq: Tensor
     :param single_step_module: 一个或多个单步模块
-    :type single_step_module: torch.nn.Module or list[nn.Module] or tuple[nn.Module] or torch.nn.Sequential or Callable
+    :type single_step_module: Union[nn.Module, list[nn.Module], tuple[nn.Module], nn.Sequential, Callable]
     :return: ``shape=[T, batch_size, ...]`` 的输出tensor
     :rtype: torch.Tensor
 
@@ -544,7 +544,7 @@ def multi_step_forward(x_seq: Tensor, single_step_module: nn.Module or list[nn.M
     :param x_seq: the input tensor with ``shape=[T, batch_size, ...]``
     :type x_seq: torch.Tensor
     :param single_step_module: one or many single-step modules
-    :type single_step_module: torch.nn.Module or list[nn.Module] or tuple[nn.Module] or torch.nn.Sequential or Callable
+    :type single_step_module: Union[nn.Module, list[nn.Module], tuple[nn.Module], nn.Sequential, Callable]
     :return: the output tensor with ``shape=[T, batch_size, ...]``
     :rtype: torch.torch.Tensor
 
@@ -565,7 +565,7 @@ def multi_step_forward(x_seq: Tensor, single_step_module: nn.Module or list[nn.M
     return torch.stack(y_seq)
 
 
-def t_last_multi_step_forward(x_seq: Tensor, single_step_module: nn.Module or list[nn.Module] or tuple[nn.Module] or nn.Sequential or Callable):
+def t_last_multi_step_forward(x_seq: Tensor, single_step_module: Union[nn.Module, list[nn.Module], tuple[nn.Module], nn.Sequential, Callable]):
     """
     * :ref:`API in English <t_last_multi_step_forward-en>`
 
@@ -574,7 +574,7 @@ def t_last_multi_step_forward(x_seq: Tensor, single_step_module: nn.Module or li
     :param x_seq: ``shape=[batch_size, ..., T]`` 的输入tensor
     :type x_seq: Tensor
     :param single_step_module: 一个或多个单步模块
-    :type single_step_module: torch.nn.Module or list[nn.Module] or tuple[nn.Module] or torch.nn.Sequential or Callable
+    :type single_step_module: Union[nn.Module, list[nn.Module], tuple[nn.Module], nn.Sequential, Callable]
     :return: ``shape=[batch_size, ..., T]`` 的输出tensor
     :rtype: torch.Tensor
 
@@ -587,7 +587,7 @@ def t_last_multi_step_forward(x_seq: Tensor, single_step_module: nn.Module or li
     :param x_seq: the input tensor with ``shape=[batch_size, ..., T]``
     :type x_seq: torch.Tensor
     :param single_step_module: one or many single-step modules
-    :type single_step_module: torch.nn.Module or list[nn.Module] or tuple[nn.Module] or torch.nn.Sequential or Callable
+    :type single_step_module: Union[nn.Module, list[nn.Module], tuple[nn.Module], nn.Sequential, Callable]
     :return: the output tensor with ``shape=[batch_size, ..., T]``
     :rtype: torch.torch.Tensor
 
@@ -694,7 +694,7 @@ def chunk_multi_step_forward(split_size: int, x_seq: Tensor, multi_step_module: 
         y_seq.append(multi_step_module(x))
     return torch.cat(y_seq, 0)
 
-def seq_to_ann_forward(x_seq: Tensor, stateless_module: nn.Module or list or tuple or nn.Sequential or Callable):
+def seq_to_ann_forward(x_seq: Tensor, stateless_module: Union[nn.Module, list, tuple, nn.Sequential, Callable]):
     """
     * :ref:`API in English <seq_to_ann_forward-en>`
 
@@ -703,7 +703,7 @@ def seq_to_ann_forward(x_seq: Tensor, stateless_module: nn.Module or list or tup
     :param x_seq: ``shape=[T, batch_size, ...]`` 的输入tensor
     :type x_seq: Tensor
     :param stateless_module: 单个或多个无状态网络层
-    :type stateless_module: torch.nn.Module or list or tuple or torch.nn.Sequential or Callable
+    :type stateless_module: Union[nn.Module, list, tuple, nn.Sequential, Callable]
     :return: the output tensor with ``shape=[T, batch_size, ...]``
     :rtype: Tensor
 
@@ -716,7 +716,7 @@ def seq_to_ann_forward(x_seq: Tensor, stateless_module: nn.Module or list or tup
     :param x_seq: the input tensor with ``shape=[T, batch_size, ...]``
     :type x_seq: Tensor
     :param stateless_module: one or many stateless modules
-    :type stateless_module: torch.nn.Module or list or tuple or torch.nn.Sequential or Callable
+    :type stateless_module: Union[nn.Module, list, tuple, nn.Sequential, Callable]
     :return: the output tensor with ``shape=[T, batch_size, ...]``
     :rtype: Tensor
 
@@ -734,7 +734,7 @@ def seq_to_ann_forward(x_seq: Tensor, stateless_module: nn.Module or list or tup
     return y.view(y_shape)
 
 
-def t_last_seq_to_ann_forward(x_seq: Tensor, stateless_module: nn.Module or list or tuple or nn.Sequential or Callable):
+def t_last_seq_to_ann_forward(x_seq: Tensor, stateless_module: Union[nn.Module, list, tuple, nn.Sequential, Callable]):
     """
     * :ref:`API in English <t_last_seq_to_ann_forward-en>`
 
@@ -743,7 +743,7 @@ def t_last_seq_to_ann_forward(x_seq: Tensor, stateless_module: nn.Module or list
     :param x_seq: ``shape=[batch_size, ..., T]`` 的输入tensor
     :type x_seq: Tensor
     :param stateless_module: 单个或多个无状态网络层
-    :type stateless_module: torch.nn.Module or list or tuple or torch.nn.Sequential or Callable
+    :type stateless_module: Union[nn.Module, list, tuple, nn.Sequential, Callable]
     :return: the output tensor with ``shape=[batch_size, ..., T]``
     :rtype: Tensor
 
@@ -763,7 +763,7 @@ def t_last_seq_to_ann_forward(x_seq: Tensor, stateless_module: nn.Module or list
     :param x_seq: the input tensor with ``shape=[batch_size, ..., T]``
     :type x_seq: Tensor
     :param stateless_module: one or many stateless modules
-    :type stateless_module: torch.nn.Module or list or tuple or torch.nn.Sequential or Callable
+    :type stateless_module: Union[nn.Module, list, tuple, nn.Sequential, Callable]
     :return: the output tensor with ``shape=[batch_size, ..., T]``
     :rtype: Tensor
 

--- a/spikingjelly/activation_based/lava_exchange.py
+++ b/spikingjelly/activation_based/lava_exchange.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import logging
-from typing import Union, Callable
+from typing import Union, Callable, Optional
 from . import neuron, base, surrogate
 
 _hw_bits = 12
@@ -170,10 +170,10 @@ class CubaLIFNode(neuron.BaseNode):
         .. _CubaLIFNode.__init__-cn:
 
         :param current_decay: 电流衰减常数
-        :type current_decay: float | torch.Tensor
+        :type current_decay: Union[float, torch.Tensor]
 
         :param voltage_decay: 电压衰减常数
-        :type voltage_decay: float | torch.Tensor
+        :type voltage_decay: Union[float, torch.Tensor]
 
         :param v_threshold: 神经元阈值电压。默认为1。
         :type v_threshold: float
@@ -219,10 +219,10 @@ class CubaLIFNode(neuron.BaseNode):
         .. CubaLIFNode.__init__-en:
 
         :param current_decay: current decay constant
-        :type current_decay: float | torch.Tensor
+        :type current_decay: Union[float, torch.Tensor]
 
         :param voltage_decay: voltage decay constant
-        :type voltage_decay: float | torch.Tensor
+        :type voltage_decay: Union[float, torch.Tensor]
 
         :param v_threshold: threshold of the the neurons in this layer. Default to 1.
         :type v_threshold: float
@@ -462,7 +462,7 @@ try:
         return x_seq.permute(permute_args)
 
 
-    def lava_neuron_forward(lava_neuron: nn.Module, x_seq: torch.Tensor, v: torch.Tensor or float):
+    def lava_neuron_forward(lava_neuron: nn.Module, x_seq: torch.Tensor, v: Union[torch.Tensor, float]):
         # x_seq.shape = [T, N, *]
         # lave uses shape = [*, T], while SJ uses shape = [T, *]
         unsqueeze_flag = False
@@ -779,7 +779,7 @@ try:
         return slayer.block.cuba.Flatten()
 
 
-    def to_lava_blocks(net: list or tuple or nn.Sequential):
+    def to_lava_blocks(net: Union[list, tuple, nn.Sequential]):
         # https://lava-nc.org/lava-lib-dl/netx/netx.html
         '''
         Supported layer types
@@ -905,7 +905,7 @@ try:
             if isinstance(self.synapse, base.StepModule):
                 self.synapse.step_mode = value
 
-        def __init__(self, synapse: nn.Conv2d or nn.Linear or nn.AvgPool2d or nn.Flatten, neu: CubaLIFNode or None,
+        def __init__(self, synapse: Union[nn.Conv2d, nn.Linear, nn.AvgPool2d, nn.Flatten], neu: Optional[CubaLIFNode],
                      step_mode: str = 's'):
             super().__init__()
             if isinstance(synapse, nn.Flatten):

--- a/spikingjelly/activation_based/layer.py
+++ b/spikingjelly/activation_based/layer.py
@@ -1451,7 +1451,7 @@ class SynapseFilter(base.MemoryModule):
 
 class DropConnectLinear(base.MemoryModule):
     def __init__(self, in_features: int, out_features: int, bias: bool = True, p: float = 0.5, samples_num: int = 1024,
-                 invariant: bool = False, activation: None or nn.Module = nn.ReLU(), state_mode='s') -> None:
+                 invariant: bool = False, activation: Optional[nn.Module] = nn.ReLU(), state_mode='s') -> None:
         """
         * :ref:`API in English <DropConnectLinear.__init__-en>`
 
@@ -1475,7 +1475,7 @@ class DropConnectLinear(base.MemoryModule):
             默认为 ``False``
         :type invariant: bool
         :param activation: 在线性层后的激活层
-        :type activation: None or nn.Module
+        :type activation: Optional[nn.Module]
         :param step_mode: 步进模式，可以为 `'s'` (单步) 或 `'m'` (多步)
         :type step_mode: str
 
@@ -1510,7 +1510,7 @@ class DropConnectLinear(base.MemoryModule):
             for more information to understand this parameter. Default: ``False``
         :type invariant: bool
         :param activation: the activation layer after the linear layer
-        :type activation: None or nn.Module
+        :type activation: Optional[nn.Module]
         :param step_mode: the step mode, which can be `s` (single-step) or `m` (multi-step)
         :type step_mode: str
 

--- a/spikingjelly/activation_based/lynxi_exchange.py
+++ b/spikingjelly/activation_based/lynxi_exchange.py
@@ -1,6 +1,6 @@
 import copy
 import os
-from typing import Dict
+from typing import Dict, Union
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -167,7 +167,7 @@ def to_lynxi_supported_module(m_in: nn.Module, T: int):
 
     return m_out
 
-def to_lynxi_supported_modules(net: list or tuple or nn.Sequential, T: int):
+def to_lynxi_supported_modules(net: Union[list, tuple, nn.Sequential], T: int):
     output_net = []
     for i in range(net.__len__()):
         m_in = net[i]
@@ -197,7 +197,7 @@ try:
         return x
 
 
-    def lynxi_tensor_to_torch(x: lynpy.Tensor, shape: tuple or list = None, dtype: str = None):
+    def lynxi_tensor_to_torch(x: lynpy.Tensor, shape: Union[tuple, list] = None, dtype: str = None):
         if shape is not None and dtype is not None:
             x = x.view_as(shape, dtype)
         if x.devptr is not None:

--- a/spikingjelly/activation_based/monitor.py
+++ b/spikingjelly/activation_based/monitor.py
@@ -1,7 +1,7 @@
 import torch
 import numpy as np
 from torch import nn
-from typing import Callable, Any
+from typing import Callable, Any, Union
 from spikingjelly.activation_based import neuron
 import threading
 from torch.utils.tensorboard import SummaryWriter
@@ -10,7 +10,7 @@ import time
 import re
 import datetime
 
-def unpack_len1_tuple(x: tuple or torch.Tensor):
+def unpack_len1_tuple(x: Union[tuple, torch.Tensor]):
     if isinstance(x, tuple) and x.__len__() == 1:
         return x[0]
     else:

--- a/spikingjelly/activation_based/neuron.py
+++ b/spikingjelly/activation_based/neuron.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Callable
+from typing import Callable, Optional
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -22,7 +22,7 @@ except BaseException as e:
 
 
 class SimpleBaseNode(base.MemoryModule):
-    def __init__(self, v_threshold: float = 1., v_reset: float = 0.,
+    def __init__(self, v_threshold: float = 1., v_reset: Optional[float] = 0.,
                  surrogate_function: Callable = surrogate.Sigmoid(), detach_reset: bool = False,
                  step_mode='s'):
         """
@@ -82,7 +82,7 @@ class SimpleLIFNode(SimpleBaseNode):
             self.v = self.v + (self.v_reset - self.v) / self.tau + x
 
 class BaseNode(base.MemoryModule):
-    def __init__(self, v_threshold: float = 1., v_reset: float or None = 0.,
+    def __init__(self, v_threshold: float = 1., v_reset: Optional[float] = 0.,
                  surrogate_function: Callable = surrogate.Sigmoid(), detach_reset: bool = False,
                  step_mode='s', backend='torch', store_v_seq: bool = False):
         """
@@ -95,7 +95,7 @@ class BaseNode(base.MemoryModule):
 
         :param v_reset: 神经元的重置电压。如果不为 ``None``，当神经元释放脉冲后，电压会被重置为 ``v_reset``；
             如果设置为 ``None``，当神经元释放脉冲后，电压会被减去 ``v_threshold``
-        :type v_reset: float or None
+        :type v_reset: Optional[float]
 
         :param surrogate_function: 反向传播时用来计算脉冲函数梯度的替代函数
         :type surrogate_function: Callable
@@ -126,7 +126,7 @@ class BaseNode(base.MemoryModule):
 
         :param v_reset: reset voltage of this neurons layer. If not ``None``, the neuron's voltage will be set to ``v_reset``
             after firing a spike. If ``None``, the neuron's voltage will subtract ``v_threshold`` after firing a spike
-        :type v_reset: float or None
+        :type v_reset: Optional[float]
 
         :param surrogate_function: the function for calculating surrogate gradients of the heaviside step function in backward
         :type surrogate_function: Callable
@@ -325,7 +325,7 @@ class BaseNode(base.MemoryModule):
 
 
 class AdaptBaseNode(BaseNode):
-    def __init__(self, v_threshold: float = 1., v_reset: float or None = 0.,
+    def __init__(self, v_threshold: float = 1., v_reset: Optional[float] = 0.,
                  v_rest: float = 0., w_rest: float = 0., tau_w: float = 2., a: float = 0., b: float = 0.,
                  surrogate_function: Callable = surrogate.Sigmoid(), detach_reset: bool = False, step_mode='s',
                  backend='torch', store_v_seq: bool = False):
@@ -431,7 +431,7 @@ class AdaptBaseNode(BaseNode):
 
 
 class IFNode(BaseNode):
-    def __init__(self, v_threshold: float = 1., v_reset: float or None = 0.,
+    def __init__(self, v_threshold: float = 1., v_reset: Optional[float] = 0.,
                  surrogate_function: Callable = surrogate.Sigmoid(), detach_reset: bool = False, step_mode='s',
                  backend='torch', store_v_seq: bool = False):
         """
@@ -444,7 +444,7 @@ class IFNode(BaseNode):
 
         :param v_reset: 神经元的重置电压。如果不为 ``None``，当神经元释放脉冲后，电压会被重置为 ``v_reset``；
             如果设置为 ``None``，当神经元释放脉冲后，电压会被减去 ``v_threshold``
-        :type v_reset: float or None
+        :type v_reset: Optional[float]
 
         :param surrogate_function: 反向传播时用来计算脉冲函数梯度的替代函数
         :type surrogate_function: Callable
@@ -478,7 +478,7 @@ class IFNode(BaseNode):
 
         :param v_reset: reset voltage of this neurons layer. If not ``None``, the neuron's voltage will be set to ``v_reset``
             after firing a spike. If ``None``, the neuron's voltage will subtract ``v_threshold`` after firing a spike
-        :type v_reset: float or None
+        :type v_reset: Optional[float]
 
         :param surrogate_function: the function for calculating surrogate gradients of the heaviside step function in backward
         :type surrogate_function: Callable
@@ -703,7 +703,7 @@ class IFNode(BaseNode):
 
 class LIFNode(BaseNode):
     def __init__(self, tau: float = 2., decay_input: bool = True, v_threshold: float = 1.,
-                 v_reset: float or None = 0., surrogate_function: Callable = surrogate.Sigmoid(),
+                 v_reset: Optional[float] = 0., surrogate_function: Callable = surrogate.Sigmoid(),
                  detach_reset: bool = False, step_mode='s', backend='torch', store_v_seq: bool = False):
         """
         * :ref:`API in English <LIFNode.__init__-en>`
@@ -721,7 +721,7 @@ class LIFNode(BaseNode):
 
         :param v_reset: 神经元的重置电压。如果不为 ``None``，当神经元释放脉冲后，电压会被重置为 ``v_reset``；
             如果设置为 ``None``，当神经元释放脉冲后，电压会被减去 ``v_threshold``
-        :type v_reset: float or None
+        :type v_reset: Optional[float]
 
         :param surrogate_function: 反向传播时用来计算脉冲函数梯度的替代函数
         :type surrogate_function: Callable
@@ -769,7 +769,7 @@ class LIFNode(BaseNode):
 
         :param v_reset: reset voltage of this neurons layer. If not ``None``, the neuron's voltage will be set to ``v_reset``
             after firing a spike. If ``None``, the neuron's voltage will subtract ``v_threshold`` after firing a spike
-        :type v_reset: float or None
+        :type v_reset: Optional[float]
 
         :param surrogate_function: the function for calculating surrogate gradients of the heaviside step function in backward
         :type surrogate_function: Callable
@@ -1161,7 +1161,7 @@ class LIFNode(BaseNode):
 
 class ParametricLIFNode(BaseNode):
     def __init__(self, init_tau: float = 2.0, decay_input: bool = True, v_threshold: float = 1.,
-                 v_reset: float or None = 0., surrogate_function: Callable = surrogate.Sigmoid(),
+                 v_reset: Optional[float] = 0., surrogate_function: Callable = surrogate.Sigmoid(),
                  detach_reset: bool = False, step_mode='s', backend='torch', store_v_seq: bool = False):
         """
         * :ref:`API in English <ParametricLIFNode.__init__-en>`
@@ -1179,7 +1179,7 @@ class ParametricLIFNode(BaseNode):
 
         :param v_reset: 神经元的重置电压。如果不为 ``None``，当神经元释放脉冲后，电压会被重置为 ``v_reset``；
             如果设置为 ``None``，当神经元释放脉冲后，电压会被减去 ``v_threshold``
-        :type v_reset: float or None
+        :type v_reset: Optional[float]
 
         :param surrogate_function: 反向传播时用来计算脉冲函数梯度的替代函数
         :type surrogate_function: Callable
@@ -1233,7 +1233,7 @@ class ParametricLIFNode(BaseNode):
 
         :param v_reset: reset voltage of this neurons layer. If not ``None``, the neuron's voltage will be set to ``v_reset``
             after firing a spike. If ``None``, the neuron's voltage will subtract ``v_threshold`` after firing a spike
-        :type v_reset: float or None
+        :type v_reset: Optional[float]
 
         :param surrogate_function: the function for calculating surrogate gradients of the heaviside step function in backward
         :type surrogate_function: Callable
@@ -1355,7 +1355,7 @@ class ParametricLIFNode(BaseNode):
 
 class QIFNode(BaseNode):
     def __init__(self, tau: float = 2., v_c: float = 0.8, a0: float = 1., v_threshold: float = 1., v_rest: float = 0.,
-                 v_reset: float or None = -0.1,
+                 v_reset: Optional[float] = -0.1,
                  surrogate_function: Callable = surrogate.Sigmoid(), detach_reset: bool = False, step_mode='s',
                  backend='torch', store_v_seq: bool = False):
         """
@@ -1380,7 +1380,7 @@ class QIFNode(BaseNode):
 
         :param v_reset: 神经元的重置电压。如果不为 ``None``，当神经元释放脉冲后，电压会被重置为 ``v_reset``；
             如果设置为 ``None``，当神经元释放脉冲后，电压会被减去 ``v_threshold``
-        :type v_reset: float or None
+        :type v_reset: Optional[float]
 
         :param surrogate_function: 反向传播时用来计算脉冲函数梯度的替代函数
         :type surrogate_function: Callable
@@ -1424,7 +1424,7 @@ class QIFNode(BaseNode):
 
         :param v_reset: reset voltage of this neurons layer. If not ``None``, the neuron's voltage will be set to ``v_reset``
             after firing a spike. If ``None``, the neuron's voltage will subtract ``v_threshold`` after firing a spike
-        :type v_reset: float or None
+        :type v_reset: Optional[float]
 
         :param surrogate_function: the function for calculating surrogate gradients of the heaviside step function in backward
         :type surrogate_function: Callable
@@ -1505,7 +1505,7 @@ class QIFNode(BaseNode):
 
 class EIFNode(BaseNode):
     def __init__(self, tau: float = 2., delta_T: float = 1., theta_rh: float = .8, v_threshold: float = 1.,
-                 v_rest: float = 0., v_reset: float or None = -0.1,
+                 v_rest: float = 0., v_reset: Optional[float] = -0.1,
                  surrogate_function: Callable = surrogate.Sigmoid(), detach_reset: bool = False, step_mode='s',
                  backend='torch', store_v_seq: bool = False):
         """
@@ -1527,7 +1527,7 @@ class EIFNode(BaseNode):
 
         :param v_reset: 神经元的重置电压。如果不为 ``None``，当神经元释放脉冲后，电压会被重置为 ``v_reset``；
             如果设置为 ``None``，当神经元释放脉冲后，电压会被减去 ``v_threshold``
-        :type v_reset: float or None
+        :type v_reset: Optional[float]
 
         :param surrogate_function: 反向传播时用来计算脉冲函数梯度的替代函数
         :type surrogate_function: Callable
@@ -1571,7 +1571,7 @@ class EIFNode(BaseNode):
 
         :param v_reset: reset voltage of this neurons layer. If not ``None``, the neuron's voltage will be set to ``v_reset``
             after firing a spike. If ``None``, the neuron's voltage will subtract ``v_threshold`` after firing a spike
-        :type v_reset: float or None
+        :type v_reset: Optional[float]
 
         :param surrogate_function: the function for calculating surrogate gradients of the heaviside step function in backward
         :type surrogate_function: Callable
@@ -1657,7 +1657,7 @@ class EIFNode(BaseNode):
 
 class IzhikevichNode(AdaptBaseNode):
     def __init__(self, tau: float = 2., v_c: float = 0.8, a0: float = 1., v_threshold: float = 1.,
-                 v_reset: float or None = 0., v_rest: float = -0.1, w_rest: float = 0., tau_w: float = 2., a: float = 0.,
+                 v_reset: Optional[float] = 0., v_rest: float = -0.1, w_rest: float = 0., tau_w: float = 2., a: float = 0.,
                  b: float = 0.,
                  surrogate_function: Callable = surrogate.Sigmoid(), detach_reset: bool = False, step_mode='s',
                  backend='torch', store_v_seq: bool = False):
@@ -1777,7 +1777,7 @@ class LIAFNode(LIFNode):
 
 class KLIFNode(BaseNode):
     def __init__(self, scale_reset: bool = False, tau: float = 2., decay_input: bool = True, v_threshold: float = 1.,
-                 v_reset: float or None = 0., surrogate_function: Callable = surrogate.Sigmoid(),
+                 v_reset: Optional[float] = 0., surrogate_function: Callable = surrogate.Sigmoid(),
                  detach_reset: bool = False, step_mode='s', backend='torch', store_v_seq: bool = False):
         """
         * :ref:`API in English <KLIFNode.__init__-en>`
@@ -1798,7 +1798,7 @@ class KLIFNode(BaseNode):
 
         :param v_reset: 神经元的重置电压。如果不为 ``None``，当神经元释放脉冲后，电压会被重置为 ``v_reset``；
             如果设置为 ``None``，当神经元释放脉冲后，电压会被减去 ``v_threshold``
-        :type v_reset: float or None
+        :type v_reset: Optional[float]
 
         :param surrogate_function: 反向传播时用来计算脉冲函数梯度的替代函数
         :type surrogate_function: Callable
@@ -1874,7 +1874,7 @@ class KLIFNode(BaseNode):
 
         :param v_reset: reset voltage of this neurons layer. If not ``None``, the neuron's voltage will be set to ``v_reset``
             after firing a spike. If ``None``, the neuron's voltage will subtract ``v_threshold`` after firing a spike
-        :type v_reset: float or None
+        :type v_reset: Optional[float]
 
         :param surrogate_function: the function for calculating surrogate gradients of the heaviside step function in backward
         :type surrogate_function: Callable
@@ -2798,7 +2798,7 @@ class DSRLIFNode(base.MemoryModule):
 
 class OTTTLIFNode(LIFNode):
     def __init__(self, tau: float = 2., decay_input: bool = False, v_threshold: float = 1.,
-                 v_reset: float or None = None, surrogate_function: Callable = surrogate.Sigmoid(),
+                 v_reset: Optional[float] = None, surrogate_function: Callable = surrogate.Sigmoid(),
                  detach_reset: bool = True, step_mode='s', backend='torch', store_v_seq: bool = False):
         """
         * :ref:`API in English <OTTTLIFNode.__init__-en>`
@@ -2816,7 +2816,7 @@ class OTTTLIFNode(LIFNode):
 
         :param v_reset: 神经元的重置电压。如果不为 ``None``，当神经元释放脉冲后，电压会被重置为 ``v_reset``；
             如果设置为 ``None``，当神经元释放脉冲后，电压会被减去 ``v_threshold``
-        :type v_reset: float or None
+        :type v_reset: Optional[float]
 
         :param surrogate_function: 反向传播时用来计算脉冲函数梯度的替代函数
         :type surrogate_function: Callable
@@ -2855,7 +2855,7 @@ class OTTTLIFNode(LIFNode):
 
         :param v_reset: reset voltage of this neurons layer. If not ``None``, the neuron's voltage will be set to ``v_reset``
             after firing a spike. If ``None``, the neuron's voltage will subtract ``v_threshold`` after firing a spike
-        :type v_reset: float or None
+        :type v_reset: Optional[float]
 
         :param surrogate_function: the function for calculating surrogate gradients of the heaviside step function in backward
         :type surrogate_function: Callable
@@ -2987,7 +2987,7 @@ class OTTTLIFNode(LIFNode):
 
 class SLTTLIFNode(LIFNode):
     def __init__(self, tau: float = 2., decay_input: bool = True, v_threshold: float = 1.,
-                 v_reset: float or None = 0., surrogate_function: Callable = surrogate.Sigmoid(),
+                 v_reset: Optional[float] = 0., surrogate_function: Callable = surrogate.Sigmoid(),
                  detach_reset: bool = True, step_mode='s', backend='torch', store_v_seq: bool = False):
         """
         * :ref:`API in English <SLTTLIFNode.__init__-en>`
@@ -3005,7 +3005,7 @@ class SLTTLIFNode(LIFNode):
 
         :param v_reset: 神经元的重置电压。如果不为 ``None``，当神经元释放脉冲后，电压会被重置为 ``v_reset``；
             如果设置为 ``None``，当神经元释放脉冲后，电压会被减去 ``v_threshold``
-        :type v_reset: float or None
+        :type v_reset: Optional[float]
 
         :param surrogate_function: 反向传播时用来计算脉冲函数梯度的替代函数
         :type surrogate_function: Callable
@@ -3044,7 +3044,7 @@ class SLTTLIFNode(LIFNode):
 
         :param v_reset: reset voltage of this neurons layer. If not ``None``, the neuron's voltage will be set to ``v_reset``
             after firing a spike. If ``None``, the neuron's voltage will subtract ``v_threshold`` after firing a spike
-        :type v_reset: float or None
+        :type v_reset: Optional[float]
 
         :param surrogate_function: the function for calculating surrogate gradients of the heaviside step function in backward
         :type surrogate_function: Callable
@@ -3226,7 +3226,7 @@ def powerlaw_psd_gaussian(
         with gamma = 1 - beta for 0 < beta < 1.
         There may be finite-size issues for beta close to one.
 
-    shape : int or iterable
+    size : Union[int, Iterable[int]]
         The output has the given shape, and the desired power spectrum in
         the last coordinate. That is, the last dimension is taken as time,
         and all other components are independent.
@@ -3346,7 +3346,7 @@ def _get_normal_distribution(random_state: Optional[Union[int, Generator, Random
 
 class NoisyBaseNode(nn.Module, base.MultiStepModule):
     def __init__(self, num_node, is_training: bool = True, T: int = 5, sigma_init: float = 0.5, 
-                 beta: float = 0.0, v_threshold: float = 0.5, v_reset: float or None = 0.,
+                 beta: float = 0.0, v_threshold: float = 0.5, v_reset: Optional[float] = 0.,
                  surrogate_function: Callable = surrogate.Rect()):
         assert isinstance(v_reset, float) or v_reset is None
         assert isinstance(v_threshold, float)
@@ -3439,7 +3439,7 @@ class NoisyBaseNode(nn.Module, base.MultiStepModule):
 class NoisyCLIFNode(NoisyBaseNode):
     def __init__(self, num_node, c_decay: float = 0.5, v_decay: float = 0.75, is_training: bool = True, 
                  T: int = 5, sigma_init: float = 0.5, beta: float = 0.0, v_threshold: float = 0.5, 
-                 v_reset: float or None = 0., surrogate_function: Callable = surrogate.Rect()):
+                 v_reset: Optional[float] = 0., surrogate_function: Callable = surrogate.Rect()):
         super().__init__(num_node, is_training, T, sigma_init, beta, v_threshold, 
                          v_reset, surrogate_function)
 
@@ -3460,7 +3460,7 @@ class NoisyCLIFNode(NoisyBaseNode):
 ##########################################################################################################
 
 class ILCBaseNode(nn.Module, base.MultiStepModule):
-    def __init__(self, act_dim, dec_pop_dim, v_threshold: float = 1.0, v_reset: float or None = 0.,
+    def __init__(self, act_dim, dec_pop_dim, v_threshold: float = 1.0, v_reset: Optional[float] = 0.,
                  surrogate_function: Callable = surrogate.Rect()):
 
         assert isinstance(v_reset, float) or v_reset is None
@@ -3513,7 +3513,7 @@ class ILCBaseNode(nn.Module, base.MultiStepModule):
 
 class ILCCLIFNode(ILCBaseNode):
     def __init__(self, act_dim, dec_pop_dim, c_decay: float = 0.5, v_decay: float = 0.75,
-                 v_threshold: float = 0.5, v_reset: float or None = 0.,
+                 v_threshold: float = 0.5, v_reset: Optional[float] = 0.,
                  surrogate_function: Callable = surrogate.Rect()):
 
         super().__init__(act_dim, dec_pop_dim, v_threshold, v_reset, surrogate_function)
@@ -3532,7 +3532,7 @@ class ILCCLIFNode(ILCBaseNode):
 
 class ILCLIFNode(ILCBaseNode):
     def __init__(self, act_dim, dec_pop_dim, v_decay: float = 0.75,
-                 v_threshold: float = 1.0, v_reset: float or None = 0.,
+                 v_threshold: float = 1.0, v_reset: Optional[float] = 0.,
                  surrogate_function: Callable = surrogate.Rect()):
 
         super().__init__(act_dim, dec_pop_dim, v_threshold, v_reset, surrogate_function)
@@ -3544,7 +3544,7 @@ class ILCLIFNode(ILCBaseNode):
 
 
 class ILCIFNode(ILCBaseNode):
-    def __init__(self, act_dim, dec_pop_dim, v_threshold: float = 1.0, v_reset: float or None = 0.,
+    def __init__(self, act_dim, dec_pop_dim, v_threshold: float = 1.0, v_reset: Optional[float] = 0.,
                  surrogate_function: Callable = surrogate.Rect()):
 
         super().__init__(act_dim, dec_pop_dim, v_threshold, v_reset, surrogate_function)
@@ -3560,7 +3560,7 @@ class ILCIFNode(ILCBaseNode):
 class NoisyILCBaseNode(nn.Module, base.MultiStepModule):
     def __init__(self, act_dim, dec_pop_dim, is_training: bool = True, T: int = 5, 
                  sigma_init: float = 0.5, beta: float = 0.0, v_threshold: float = 1.0, 
-                 v_reset: float or None = 0., surrogate_function: Callable = surrogate.Rect()):
+                 v_reset: Optional[float] = 0., surrogate_function: Callable = surrogate.Rect()):
 
         assert isinstance(v_reset, float) or v_reset is None
         assert isinstance(v_threshold, float)
@@ -3664,7 +3664,7 @@ class NoisyILCBaseNode(nn.Module, base.MultiStepModule):
 class NoisyILCCLIFNode(NoisyILCBaseNode):
     def __init__(self, act_dim, dec_pop_dim, c_decay: float = 0.5, v_decay: float = 0.75,
                  is_training: bool = True, T: int = 5, sigma_init: float = 0.5, 
-                 beta: float = 0.0, v_threshold: float = 1.0, v_reset: float or None = 0.,
+                 beta: float = 0.0, v_threshold: float = 1.0, v_reset: Optional[float] = 0.,
                  surrogate_function: Callable = surrogate.Rect()):
         super().__init__(act_dim, dec_pop_dim, is_training, T, sigma_init, beta, v_threshold, 
                          v_reset, surrogate_function)

--- a/spikingjelly/activation_based/rnn.py
+++ b/spikingjelly/activation_based/rnn.py
@@ -382,11 +382,11 @@ class SpikingRNNBase(nn.Module):
             所有的tensor的尺寸均为 ``shape = [num_layers * num_directions, batch, hidden_size]``, 包含 ``self.states_num()``
             个初始状态
             如果RNN是双向的, ``num_directions`` 为 ``2``, 否则为 ``1``
-        :type states: torch.Tensor or tuple
+        :type states: Union[torch.Tensor, tuple]
         :return: output, output_states
             output: torch.Tensor
                 ``shape = [T, batch, num_directions * hidden_size]``，最后一层在所有时刻的输出
-            output_states: torch.Tensor or tuple
+            output_states: Union[torch.Tensor, tuple]
                 ``self.states_num()`` 为 ``1`` 时是单个tensor, 否则是一个tuple，包含 ``self.states_num()`` 个tensors。
                 所有的tensor的尺寸均为 ``shape = [num_layers * num_directions, batch, hidden_size]``, 包含 ``self.states_num()``
                 个最后时刻的状态
@@ -402,12 +402,12 @@ class SpikingRNNBase(nn.Module):
             ``shape = [num_layers * num_directions, batch, hidden_size]`` for all tensors, containing the ``self.states_num()``
             initial states for each element in the batch.
             If the RNN is bidirectional, ``num_directions`` should be ``2``, else it should be ``1``
-        :type states: torch.Tensor or tuple
+        :type states: Union[torch.Tensor, tuple]
         :return: output, output_states
             output: torch.Tensor
                 ``shape = [T, batch, num_directions * hidden_size]``, tensor containing the output features from the last
                 layer of the RNN, for each ``t``
-            output_states: torch.Tensor or tuple
+            output_states: Union[torch.Tensor, tuple]
                 a single tensor when ``self.states_num()`` is ``1``, otherwise a tuple with ``self.states_num()``
                 tensors.
                 ``shape = [num_layers * num_directions, batch, hidden_size]`` for all tensors, containing the ``self.states_num()``
@@ -549,7 +549,7 @@ class SpikingLSTMCell(SpikingRNNCellBase):
         :type surrogate_function1: spikingjelly.activation_based.surrogate.SurrogateFunctionBase
         :param surrogate_function2: 反向传播时用来计算脉冲函数梯度的替代函数, 计算 ``g`` 反向传播时使用。 若为 ``None``, 则设置成
             ``surrogate_function1``。默认为 ``None``
-        :type surrogate_function2: None or spikingjelly.activation_based.surrogate.SurrogateFunctionBase
+        :type surrogate_function2: Optional[spikingjelly.activation_based.surrogate.SurrogateFunctionBase]
 
 
         .. note::
@@ -611,7 +611,7 @@ class SpikingLSTMCell(SpikingRNNCellBase):
         :param surrogate_function2: surrogate function for replacing gradient of spiking functions during
             back-propagation, which is used for generating ``g``. If ``None``, the surrogate function for generating ``g``
             will be set as ``surrogate_function1``. Default: ``None``
-        :type surrogate_function2: None or spikingjelly.activation_based.surrogate.SurrogateFunctionBase
+        :type surrogate_function2: Optional[spikingjelly.activation_based.surrogate.SurrogateFunctionBase]
 
         .. admonition:: Note
             :class: note
@@ -666,7 +666,7 @@ class SpikingLSTMCell(SpikingRNNCellBase):
                 c_0 : torch.Tensor
                     ``shape = [batch_size, hidden_size]``，起始细胞状态
                 如果不提供(h_0, c_0)，``h_0`` 默认 ``c_0`` 默认为0
-        :type hc: tuple or None
+        :type hc: Optional[tuple]
         :return: (h_1, c_1) :
                 h_1 : torch.Tensor
                     ``shape = [batch_size, hidden_size]``，下一个时刻的隐藏状态
@@ -687,7 +687,7 @@ class SpikingLSTMCell(SpikingRNNCellBase):
                 c_0 : torch.Tensor
                     ``shape = [batch_size, hidden_size]``, tensor containing the initial cell state for each element in the batch
                 If (h_0, c_0) is not provided, both ``h_0`` and ``c_0`` default to zero
-        :type hc: tuple or None
+        :type hc: Optional[tuple]
         :return: (h_1, c_1) :
                 h_1 : torch.Tensor
                     ``shape = [batch_size, hidden_size]``, tensor containing the next hidden state for each element in the batch
@@ -777,7 +777,7 @@ class SpikingLSTM(SpikingRNNBase):
         :type surrogate_function1: spikingjelly.activation_based.surrogate.SurrogateFunctionBase
         :param surrogate_function2: 反向传播时用来计算脉冲函数梯度的替代函数, 计算 ``g`` 反向传播时使用。 若为 ``None``, 则设置成
             ``surrogate_function1``。默认为 ``None``
-        :type surrogate_function2: None or spikingjelly.activation_based.surrogate.SurrogateFunctionBase
+        :type surrogate_function2: Optional[spikingjelly.activation_based.surrogate.SurrogateFunctionBase]
 
 
         * :ref:`中文API <SpikingLSTM.__init__-cn>`
@@ -831,7 +831,7 @@ class SpikingLSTM(SpikingRNNBase):
         :param surrogate_function2: surrogate function for replacing gradient of spiking functions during
             back-propagation, which is used for generating ``g``. If ``None``, the surrogate function for generating ``g``
             will be set as ``surrogate_function1``. Default: ``None``
-        :type surrogate_function2: None or spikingjelly.activation_based.surrogate.SurrogateFunctionBase
+        :type surrogate_function2: Optional[spikingjelly.activation_based.surrogate.SurrogateFunctionBase]
         '''
         super().__init__(input_size, hidden_size, num_layers, bias, dropout_p, invariant_dropout_mask, bidirectional,
                          surrogate_function1, surrogate_function2)

--- a/spikingjelly/activation_based/surrogate.py
+++ b/spikingjelly/activation_based/surrogate.py
@@ -996,7 +996,7 @@ class Erf(SurrogateFunctionBase):
         反向传播时使用高斯误差函数(erf)的梯度的脉冲发放函数。反向传播为
 
         .. math::
-            g'(x) = \\frac{\\alpha}{\\sqrt{\pi}}e^{-\\alpha^2x^2}
+            g'(x) = \\frac{\\alpha}{\\sqrt{\\pi}}e^{-\\alpha^2x^2}
 
         对应的原函数为
 
@@ -1006,7 +1006,7 @@ class Erf(SurrogateFunctionBase):
             \\begin{split}
             g(x) &= \\frac{1}{2}(1-\\text{erf}(-\\alpha x)) \\\\
             &= \\frac{1}{2} \\text{erfc}(-\\alpha x) \\\\
-            &= \\frac{1}{\\sqrt{\\pi}}\int_{-\\infty}^{\\alpha x}e^{-t^2}dt
+            &= \\frac{1}{\\sqrt{\\pi}}\\int_{-\\infty}^{\\alpha x}e^{-t^2}dt
             \\end{split}
 
         .. image:: ../_static/API/activation_based/surrogate/Erf.*
@@ -1025,7 +1025,7 @@ class Erf(SurrogateFunctionBase):
         The Gaussian error (erf) surrogate spiking function. The gradient is defined by
 
         .. math::
-            g'(x) = \\frac{\\alpha}{\\sqrt{\pi}}e^{-\\alpha^2x^2}
+            g'(x) = \\frac{\\alpha}{\\sqrt{\\pi}}e^{-\\alpha^2x^2}
 
         The primitive function is defined by
 
@@ -1035,7 +1035,7 @@ class Erf(SurrogateFunctionBase):
             \\begin{split}
             g(x) &= \\frac{1}{2}(1-\\text{erf}(-\\alpha x)) \\\\
             &= \\frac{1}{2} \\text{erfc}(-\\alpha x) \\\\
-            &= \\frac{1}{\\sqrt{\\pi}}\int_{-\\infty}^{\\alpha x}e^{-t^2}dt
+            &= \\frac{1}{\\sqrt{\\pi}}\\int_{-\\infty}^{\\alpha x}e^{-t^2}dt
             \\end{split}
 
         .. image:: ../_static/API/activation_based/surrogate/Erf.*
@@ -1416,7 +1416,7 @@ class S2NN(MultiArgsSurrogateFunctionBase):
         .. math::
             g'(x) = \\begin{cases}
                 \\alpha * (1 - \\mathrm{sigmoid} (\\alpha x)) \\mathrm{sigmoid} (\\alpha x), x < 0 \\\\
-                \\\\frac{beta}{(x + 1)}, x \ge 0
+                \\\\frac{beta}{(x + 1)}, x \\ge 0
             \\end{cases}
 
         对应的原函数为
@@ -1424,7 +1424,7 @@ class S2NN(MultiArgsSurrogateFunctionBase):
         .. math::
             g(x) = \\begin{cases}
                 \\mathrm{sigmoid} (\\alpha x), x < 0 \\\\
-                \\beta \\mathrm{ln}(x + 1) + 1, x \ge 0
+                \\beta \\mathrm{ln}(x + 1) + 1, x \\ge 0
             \\end{cases}
 
         .. image:: ../_static/API/activation_based/surrogate/S2NN.*
@@ -1445,7 +1445,7 @@ class S2NN(MultiArgsSurrogateFunctionBase):
         .. math::
             g'(x) = \\begin{cases}
                 \\alpha * (1 - \\mathrm{sigmoid} (\\alpha x)) \\mathrm{sigmoid} (\\alpha x), x < 0 \\\\
-                \\beta (x + 1), x \ge 0
+                \\beta (x + 1), x \\ge 0
             \\end{cases}
 
         The primitive function is defined by
@@ -1453,7 +1453,7 @@ class S2NN(MultiArgsSurrogateFunctionBase):
         .. math::
             g(x) = \\begin{cases}
                 \\mathrm{sigmoid} (\\alpha x), x < 0 \\\\
-                \\beta \\mathrm{ln}(x + 1) + 1, x \ge 0
+                \\beta \\mathrm{ln}(x + 1) + 1, x \\ge 0
             \\end{cases}
 
         .. image:: ../_static/API/activation_based/surrogate/S2NN.*

--- a/spikingjelly/activation_based/tensor_cache.py
+++ b/spikingjelly/activation_based/tensor_cache.py
@@ -1,3 +1,4 @@
+from typing import Union
 import torch
 import torch.nn.functional as F
 import threading
@@ -213,7 +214,7 @@ class BoolTensorCache:
         self.cache_refcount_dict = {}
         self.lock = threading.Lock()
 
-    def store_bool(self, spike: torch.FloatTensor or torch.HalfTensor):
+    def store_bool(self, spike: Union[torch.FloatTensor, torch.HalfTensor]):
         tk = tensor_key(spike)
 
         self.lock.acquire()

--- a/spikingjelly/datasets/__init__.py
+++ b/spikingjelly/datasets/__init__.py
@@ -1,5 +1,5 @@
 from torchvision.datasets import DatasetFolder
-from typing import Callable, Dict, Optional, Tuple
+from typing import Callable, Dict, Optional, Tuple, Union
 from abc import abstractmethod
 import scipy.io
 import struct
@@ -88,10 +88,10 @@ def save_every_frame_of_an_entire_DVS_dataset(dataset: str, dataset_path: str, t
     print('complete!!!')
 
 
-def save_as_pic(x: torch.Tensor or np.ndarray, save_pic_to: str = './', pic_first_name: str = 'pic') -> None:
+def save_as_pic(x: Union[torch.Tensor, np.ndarray], save_pic_to: str = './', pic_first_name: str = 'pic') -> None:
     '''
     :param x: frames with ``shape=[T, 2, H, W]``
-    :type x: torch.Tensor or np.ndarray
+    :type x: Union[torch.Tensor, np.ndarray]
     :param save_pic_to: Where to store images.
     :type save_pic_to: str
     :param pic_first_name: Prefix for image names before _t (stored image names are: ``pic_first_name``_t.png)
@@ -115,10 +115,10 @@ def save_as_pic(x: torch.Tensor or np.ndarray, save_pic_to: str = './', pic_firs
         plt.savefig(save_pic_to + pic_first_name + '_' + str(t) + '.png', bbox_inches='tight', pad_inches=0)
 
 
-def play_frame(x: torch.Tensor or np.ndarray, save_gif_to: str = None) -> None:
+def play_frame(x: Union[torch.Tensor, np.ndarray], save_gif_to: str = None) -> None:
     '''
     :param x: frames with ``shape=[T, 2, H, W]``
-    :type x: torch.Tensor or np.ndarray
+    :type x: Union[torch.Tensor, np.ndarray]
     :param save_gif_to: If ``None``, this function will play the frames. If ``True``, this function will not play the frames
         but save frames to a gif file in the directory ``save_gif_to``
     :type save_gif_to: str
@@ -263,9 +263,9 @@ def integrate_events_segment_to_frame(x: np.ndarray, y: np.ndarray, p: np.ndarra
 
     .. math::
 
-        F(p, x, y) = \sum_{i = j_{l}}^{j_{r} - 1} \mathcal{I}_{p, x, y}(p_{i}, x_{i}, y_{i})
+        F(p, x, y) = \\sum_{i = j_{l}}^{j_{r} - 1} \\mathcal{I}_{p, x, y}(p_{i}, x_{i}, y_{i})
 
-    where :math:`\\lfloor \\cdot \\rfloor` is the floor operation, :math:`\mathcal{I}_{p, x, y}(p_{i}, x_{i}, y_{i})` is an indicator function and it equals 1 only when :math:`(p, x, y) = (p_{i}, x_{i}, y_{i})`.
+    where :math:`\\lfloor \\cdot \\rfloor` is the floor operation, :math:`\\mathcal{I}_{p, x, y}(p_{i}, x_{i}, y_{i})` is an indicator function and it equals 1 only when :math:`(p, x, y) = (p_{i}, x_{i}, y_{i})`.
     '''
     # 累计脉冲需要用bitcount而不能直接相加，原因可参考下面的示例代码，以及
     # https://stackoverflow.com/questions/15973827/handling-of-duplicate-indices-in-numpy-assignments
@@ -675,7 +675,7 @@ class NeuromorphicDatasetFolder(DatasetFolder):
         :type custom_integrate_function: Callable
         :param custom_integrated_frames_dir_name: The name of directory for saving frames integrating by ``custom_integrate_function``.
             If ``custom_integrated_frames_dir_name`` is ``None``, it will be set to ``custom_integrate_function.__name__``
-        :type custom_integrated_frames_dir_name: str or None
+        :type custom_integrated_frames_dir_name: Optional[str]
         :param transform: a function/transform that takes in
             a sample and returns a transformed version.
             E.g, ``transforms.RandomCrop`` for images.
@@ -987,16 +987,16 @@ class NeuromorphicDatasetFolder(DatasetFolder):
 
 
 
-def random_temporal_delete(x_seq: torch.Tensor or np.ndarray, T_remain: int, batch_first):
+def random_temporal_delete(x_seq: Union[torch.Tensor, np.ndarray], T_remain: int, batch_first):
     """
     :param x_seq: a sequence with `shape = [T, N, *]`, where `T` is the sequence length and `N` is the batch size
-    :type x_seq: torch.Tensor or np.ndarray
+    :type x_seq: Union[torch.Tensor, np.ndarray]
     :param T_remain: the remained length
     :type T_remain: int
     :param batch_first: if `True`, `x_seq` will be regarded as `shape = [N, T, *]`
     :type batch_first: bool
     :return: the sequence with length `T_remain`, which is obtained by randomly removing `T - T_remain` slices
-    :rtype: torch.Tensor or np.ndarray
+    :rtype: Union[torch.Tensor, np.ndarray]
     The random temporal delete data augmentation used in `Deep Residual Learning in Spiking Neural Networks <https://arxiv.org/abs/2102.04159>`_.
     Codes example:
 
@@ -1050,11 +1050,11 @@ class RandomTemporalDelete(torch.nn.Module):
         self.T_remain = T_remain
         self.batch_first = batch_first
 
-    def forward(self, x_seq: torch.Tensor or np.ndarray):
+    def forward(self, x_seq: Union[torch.Tensor, np.ndarray]):
         return random_temporal_delete(x_seq, self.T_remain, self.batch_first)
 
 
-def create_sub_dataset(source_dir: str, target_dir:str, ratio: float, use_soft_link=True, randomly=False):
+def create_sub_dataset(source_dir: str, target_dir: str, ratio: float, use_soft_link=True, randomly=False):
     """
     :param source_dir: the directory path of the origin dataset
     :type source_dir: str


### PR DESCRIPTION
#569 将类型标注中`type or None`修正为`Optional[type]`，`type1 or type2`修正为`Union[type1, type2]`
一些数学公式中缺少`\`，进行了修正