### PR TITLE
fix bug of layer.DropConnectLinear

### DIFF
--- a/spikingjelly/activation_based/layer.py
+++ b/spikingjelly/activation_based/layer.py
@@ -1451,7 +1451,7 @@ class SynapseFilter(base.MemoryModule):
 
 class DropConnectLinear(base.MemoryModule):
     def __init__(self, in_features: int, out_features: int, bias: bool = True, p: float = 0.5, samples_num: int = 1024,
-                 invariant: bool = False, activation: Optional[nn.Module] = nn.ReLU(), state_mode='s') -> None:
+                 invariant: bool = False, activation: Optional[nn.Module] = nn.ReLU(), step_mode='s') -> None:
         """
         * :ref:`API in English <DropConnectLinear.__init__-en>`
 
@@ -1528,7 +1528,7 @@ class DropConnectLinear(base.MemoryModule):
             ``activation`` as a member variable of this module.
         """
         super().__init__()
-        self.state_mode = state_mode
+        self.step_mode = step_mode
         self.in_features = in_features
         self.out_features = out_features
         self.weight = nn.Parameter(Tensor(out_features, in_features))


### PR DESCRIPTION
```python
class DropConnectLinear(base.MemoryModule):
    def __init__(self, in_features: int, out_features: int, bias: bool = True, p: float = 0.5, samples_num: int = 1024,
                 invariant: bool = False, activation: None or nn.Module = nn.ReLU(), state_mode='s') -> None:
```

`layer.DropConnectLinear`没有重载`forward`，所以初始化参数`state_mode`实际上并不能改变步进模式
同时文档没有该参数，仅有`step_mode`
以下是一个可以在`0.0.0.0.14`以及`master`分支复现bug的代码

```python
from spikingjelly.activation_based import layer
import torch

dln = layer.DropConnectLinear(5, 5, state_mode="m")

input_t = torch.rand(2, 1, 5)  # [T, batch_size, N_in]
out_ = dln(input_t)
```
运行后的报错信息为
```
Traceback (most recent call last):
  File "D:\Code\draft\draft.py", line 7, in <module>
    out_ = dln(input_t)
           ^^^^^^^^^^^^
  File "C:\Users\admin\anaconda3\Lib\site-packages\torch\nn\modules\module.py", line 1553, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\admin\anaconda3\Lib\site-packages\torch\nn\modules\module.py", line 1562, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\admin\anaconda3\Lib\site-packages\spikingjelly\activation_based\base.py", line 268, in forward
    return self.single_step_forward(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\admin\anaconda3\Lib\site-packages\spikingjelly\activation_based\layer.py", line 1538, in single_step_forward
    ret = torch.bmm(self.dropped_w, input.unsqueeze(-1)).squeeze(-1) + self.dropped_b
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: batch2 must be a 3D tensor
```
可以看到，实际调用的是`single_step_forward`