### PR TITLE
fix docs ref typo

### DIFF
--- a/spikingjelly/activation_based/lava_exchange.py
+++ b/spikingjelly/activation_based/lava_exchange.py
@@ -216,7 +216,7 @@ class CubaLIFNode(neuron.BaseNode):
 
         * :ref:`中文API <CubaLIFNode.__init__-cn>`
 
-        .. CubaLIFNode.__init__-en:
+        .. _CubaLIFNode.__init__-en:
 
         :param current_decay: current decay constant
         :type current_decay: Union[float, torch.Tensor]

--- a/spikingjelly/activation_based/surrogate.py
+++ b/spikingjelly/activation_based/surrogate.py
@@ -688,8 +688,8 @@ class SuperSpike(SurrogateFunctionBase):
             g'(x) = \\frac{\\alpha}{(1 + (|x|))^2}
 
 
-        * :ref:`中文API <ATan.__init__-cn>`
-        .. _ATan.__init__-en:
+        * :ref:`中文API <SuperSpike.__init__-cn>`
+        .. _SuperSpike.__init__-en:
 
         The SuperSpike surrogate spiking function proposed by `SuperSpike: Supervised learning in multi-layer spiking neural networks <https://arxiv.org/abs/1705.11146>`_. The gradient is defined by
 


### PR DESCRIPTION
修复了文档里部分标签失效的错误
[lava_exchange.CubaLIFNode](https://spikingjelly.readthedocs.io/zh-cn/latest/sub_module/spikingjelly.activation_based.lava_exchange.html#spikingjelly.activation_based.lava_exchange.CubaLIFNode)
[surrogate.ATan](https://spikingjelly.readthedocs.io/zh-cn/latest/sub_module/spikingjelly.activation_based.surrogate.html#spikingjelly.activation_based.surrogate.ATan)
[surrogate.SuperSpike](https://spikingjelly.readthedocs.io/zh-cn/latest/sub_module/spikingjelly.activation_based.surrogate.html#spikingjelly.activation_based.surrogate.SuperSpike)