### PR TITLE
Fix datasets.integrate_events_by_fixed_duration()

### DIFF
--- a/spikingjelly/datasets/__init__.py
+++ b/spikingjelly/datasets/__init__.py
@@ -442,6 +442,8 @@ def integrate_events_by_fixed_duration(events: Dict, duration: int, H: int, W: i
     p = events['p']
     N = t.size
 
+    t = t - t.min()
+
     frames_num = int(math.ceil(t[-1] / duration))
     frames = np.zeros([frames_num, 2, H, W])
     frame_index = t // duration

--- a/spikingjelly/datasets/__init__.py
+++ b/spikingjelly/datasets/__init__.py
@@ -443,7 +443,7 @@ def integrate_events_by_fixed_duration(events: Dict, duration: int, H: int, W: i
     N = t.size
 
     frames_num = int(math.ceil(t[-1] / duration))
-    frames = np.zeros([frames_num, W])
+    frames = np.zeros([frames_num, 2, H, W])
     frame_index = t // duration
     left = 0
 


### PR DESCRIPTION
After 01823be , `datasets.integrate_events_by_fixed_duration()` was broken due to wrong dimensions for the `frames` array initialization (`datasets.integrate_events_segment_to_frame()` always returns 2D data with 2 channels for polarity), and wrong timestamp origin (must be the earliest timestamp in the sample).