### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ numpy
 tqdm
 torchvision
 scipy
+tensorboard


### PR DESCRIPTION
添加了依赖tensorboard，用户在使用monitor时不需要手动安装
https://github.com/fangwei123456/spikingjelly/blob/c3ddca6164105110548f5ee4eb1f7d02ec82d11d/spikingjelly/activation_based/monitor.py#L7
未安装tensorboard会报错：
```python
  File "miniconda3/envs/py310/lib/python3.10/site-packages/spikingjelly/activation_based/monitor.py", line 7, in <module>
    from torch.utils.tensorboard import SummaryWriter
  File "miniconda3/envs/py310/lib/python3.10/site-packages/torch/utils/tensorboard/__init__.py", line 1, in <module>
    import tensorboard
ModuleNotFoundError: No module named 'tensorboard'
```