### PR TITLE
fix for many ReLU per depth level

### DIFF
--- a/spikingjelly/activation_based/ann2snn/converter.py
+++ b/spikingjelly/activation_based/ann2snn/converter.py
@@ -269,13 +269,16 @@ class Converter(nn.Module):
                 prefix = str(node.args[0])
                 prefix = prefix.split('_')
 
+                # if we have a prefix, it means we are at a submodule
                 if len(prefix) > 1:
                     prefix = ".".join(prefix[:-1])
                     counter = hook_counts_per_prefix.get(prefix, 1)
                     hook_counts_per_prefix[prefix] = counter + 1
                     target = f"{prefix}.voltage_hook_{counter}"  # voltage_hook
+
+                # if we don't have a prefix, it means we are at the first level of the module
                 else:
-                    prefix = "FLAT_MODEL_FIRST_LEVEL"
+                    prefix = "__FIRST_LEVEL_OF_MODULE__"
                     counter = hook_counts_per_prefix.get(prefix, 1)
                     hook_counts_per_prefix[prefix] = counter + 1
                     target = f"voltage_hook_{counter}"  # voltage_hook

--- a/spikingjelly/activation_based/ann2snn/converter.py
+++ b/spikingjelly/activation_based/ann2snn/converter.py
@@ -272,14 +272,14 @@ class Converter(nn.Module):
                 # if we have a prefix, it means we are at a submodule
                 if len(prefix) > 1:
                     prefix = ".".join(prefix[:-1])
-                    counter = hook_counts_per_prefix.get(prefix, 1)
+                    counter = hook_counts_per_prefix.get(prefix, 0)
                     hook_counts_per_prefix[prefix] = counter + 1
                     target = f"{prefix}.voltage_hook_{counter}"  # voltage_hook
 
                 # if we don't have a prefix, it means we are at the first level of the module
                 else:
                     prefix = "__FIRST_LEVEL_OF_MODULE__"
-                    counter = hook_counts_per_prefix.get(prefix, 1)
+                    counter = hook_counts_per_prefix.get(prefix, 0)
                     hook_counts_per_prefix[prefix] = counter + 1
                     target = f"voltage_hook_{counter}"  # voltage_hook
 

--- a/spikingjelly/activation_based/ann2snn/converter.py
+++ b/spikingjelly/activation_based/ann2snn/converter.py
@@ -331,6 +331,8 @@ class Converter(nn.Module):
 
                     # get the voltage hook prefix
                     prefix = node.name.replace("voltage_hook_", "")
+                    prefix = prefix.split('_')
+                    prefix = ".".join(prefix)
 
                     s = fx_model.get_submodule(node.target).scale.item()
                     # this allows for easier import/export of the model
@@ -341,6 +343,7 @@ class Converter(nn.Module):
                     m0 = VoltageScaler(1.0 / s)
                     m1 = neuron.IFNode(v_threshold=1., v_reset=None)
                     m2 = VoltageScaler(s)
+
                     node0 = Converter._add_module_and_node(fx_model, target0, hook_node, m0, relu_node.args)
                     node1 = Converter._add_module_and_node(fx_model, target1, node0, m1, (node0,))
                     node2 = Converter._add_module_and_node(fx_model, target2, node1, m2, args=(node1,))


### PR DESCRIPTION
Hi, 

On pull request #618 I made big mistake, I assumed there would only be submodules. For example:
```
model = Sequential([Conv, ReLU])
```
would not have any indication of ReLU being the second module in the model. Even worse, I assumed everyone would be as crazy as me and would put a single ReLU per "component". That is, something like: 
```
model = Sequential([Conv, ReLU, Conv, ReLU]) 
```
Would not be parsed correctly as the first ReLU substitution would be "obscured" by the second one. The way I fixed is using the technique you used before, i.e. using counters for ReLUs, but I do a counter per each "prefix".

Sorry about the bug introduction 😞 I think this should fix it.