### PR TITLE
Optimize PLIF memory use and FlexSN compiler integration

### DIFF
--- a/benchmark/benchmark_snn_single_gpu.py
+++ b/benchmark/benchmark_snn_single_gpu.py
@@ -505,6 +505,7 @@ def run_case(args: argparse.Namespace) -> dict[str, Any]:
     ).resolve()
     sys.path.insert(0, str(source_root))
     import spikingjelly
+    from spikingjelly.activation_based import functional
 
     package_file = Path(spikingjelly.__file__).resolve()
     try:
@@ -541,8 +542,6 @@ def run_case(args: argparse.Namespace) -> dict[str, Any]:
     criterion = torch.nn.CrossEntropyLoss()
 
     def reset_net() -> None:
-        from spikingjelly.activation_based import functional
-
         functional.reset_net(state_model)
 
     def step() -> torch.Tensor:

--- a/benchmark/benchmark_snn_single_gpu.py
+++ b/benchmark/benchmark_snn_single_gpu.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+from contextlib import suppress
 import json
 import os
 import platform
@@ -23,24 +24,18 @@ PHASES = ("inference", "training")
 EXECUTIONS = ("eager", "compile")
 
 
-def percentile(values: list[float], q: float) -> float:
-    if not values:
-        raise ValueError("percentile requires at least one value")
-    ordered = sorted(values)
-    index = (len(ordered) - 1) * q
-    lower = int(index)
-    upper = min(lower + 1, len(ordered) - 1)
-    weight = index - lower
-    return ordered[lower] * (1.0 - weight) + ordered[upper] * weight
-
-
 def summarize_samples(samples_ms: list[float]) -> dict[str, float]:
     if not samples_ms:
         raise ValueError("samples_ms must not be empty")
+    deciles = (
+        statistics.quantiles(samples_ms, n=10, method="inclusive")
+        if len(samples_ms) > 1
+        else samples_ms * 9
+    )
     return {
         "median_ms": statistics.median(samples_ms),
-        "p10_ms": percentile(samples_ms, 0.10),
-        "p90_ms": percentile(samples_ms, 0.90),
+        "p10_ms": deciles[0],
+        "p90_ms": deciles[8],
         "stdev_ms": statistics.stdev(samples_ms) if len(samples_ms) > 1 else 0.0,
     }
 
@@ -110,25 +105,14 @@ def _stop_monitor(monitor) -> None:
     try:
         if monitor.poll() is not None:
             return
-    except ProcessLookupError:
-        return
-    try:
         monitor.terminate()
-    except ProcessLookupError:
-        pass
-    try:
         monitor.wait(timeout=10)
     except ProcessLookupError:
-        pass
+        return
     except subprocess.TimeoutExpired:
-        try:
+        with suppress(ProcessLookupError):
             monitor.kill()
-        except ProcessLookupError:
-            pass
-        try:
             monitor.wait()
-        except ProcessLookupError:
-            pass
 
 
 def aggregate_records(
@@ -844,9 +828,6 @@ def run_matrix(args: argparse.Namespace) -> dict[str, Any]:
     }
     (output_dir / "matrix.json").write_text(
         json.dumps(payload, indent=2), encoding="utf-8"
-    )
-    (output_dir / "comparison.json").write_text(
-        json.dumps(summary, indent=2), encoding="utf-8"
     )
     return payload
 

--- a/benchmark/benchmark_snn_single_gpu.py
+++ b/benchmark/benchmark_snn_single_gpu.py
@@ -1,0 +1,831 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import statistics
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import torch
+
+DEFAULT_T = 4
+DEFAULT_IMAGE_SIZE = 224
+DEFAULT_SEED = 20260808
+MODEL_NAMES = ("spiking_vgg16_bn", "sew_resnet18", "spikformer_ti")
+PHASES = ("inference", "training")
+EXECUTIONS = ("eager", "compile")
+
+
+def percentile(values: list[float], q: float) -> float:
+    if not values:
+        raise ValueError("percentile requires at least one value")
+    ordered = sorted(values)
+    index = (len(ordered) - 1) * q
+    lower = int(index)
+    upper = min(lower + 1, len(ordered) - 1)
+    weight = index - lower
+    return ordered[lower] * (1.0 - weight) + ordered[upper] * weight
+
+
+def summarize_samples(samples_ms: list[float]) -> dict[str, float]:
+    if not samples_ms:
+        raise ValueError("samples_ms must not be empty")
+    return {
+        "median_ms": statistics.median(samples_ms),
+        "p10_ms": percentile(samples_ms, 0.10),
+        "p90_ms": percentile(samples_ms, 0.90),
+        "stdev_ms": statistics.stdev(samples_ms) if len(samples_ms) > 1 else 0.0,
+    }
+
+
+def parse_source_specs(values: list[str]) -> list[tuple[str, Path]]:
+    if len(values) != 2:
+        raise ValueError("matrix requires exactly two --source LABEL=PATH values")
+
+    sources = []
+    for value in values:
+        if "=" not in value:
+            raise ValueError(f"invalid source {value!r}; expected LABEL=PATH")
+        label, raw_path = value.split("=", 1)
+        path = Path(raw_path).expanduser().resolve()
+        if not label:
+            raise ValueError("source labels must be non-empty")
+        if not (path / "spikingjelly" / "__init__.py").is_file():
+            raise ValueError(f"source root does not contain spikingjelly/: {path}")
+        sources.append((label, path))
+
+    if sources[0][0] == sources[1][0]:
+        raise ValueError(f"source labels must be unique: {sources[0][0]!r}")
+    return sources
+
+
+def case_key(record: dict[str, Any]) -> tuple[str, str, str, int, int, int]:
+    case = record["case"]
+    return (
+        case["model"],
+        case["phase"],
+        case["execution"],
+        case["T"],
+        case["batch_size"],
+        case["image_size"],
+    )
+
+
+def aggregate_records(
+    records: list[dict[str, Any]], baseline_label: str, candidate_label: str
+) -> dict[str, Any]:
+    grouped: dict[tuple[str, str, str, int, int, int], dict[str, list[dict]]] = {}
+    for record in records:
+        grouped.setdefault(case_key(record), {}).setdefault(
+            record["source_label"], []
+        ).append(record)
+
+    comparisons = []
+    for key, by_source in sorted(grouped.items()):
+        baseline = by_source.get(baseline_label, [])
+        candidate = by_source.get(candidate_label, [])
+        if not baseline or not candidate:
+            continue
+        baseline_rounds = [item["timing"]["median_ms"] for item in baseline]
+        candidate_rounds = [item["timing"]["median_ms"] for item in candidate]
+        baseline_ms = statistics.median(baseline_rounds)
+        candidate_ms = statistics.median(candidate_rounds)
+        baseline_peak = statistics.median(
+            item["memory"]["peak_allocated_bytes"] for item in baseline
+        )
+        candidate_peak = statistics.median(
+            item["memory"]["peak_allocated_bytes"] for item in candidate
+        )
+        comparisons.append(
+            {
+                "case": {
+                    "model": key[0],
+                    "phase": key[1],
+                    "execution": key[2],
+                    "T": key[3],
+                    "batch_size": key[4],
+                    "image_size": key[5],
+                },
+                "rounds": min(len(baseline), len(candidate)),
+                "baseline_round_medians_ms": baseline_rounds,
+                "candidate_round_medians_ms": candidate_rounds,
+                "baseline_median_ms": baseline_ms,
+                "candidate_median_ms": candidate_ms,
+                "latency_change_pct": (candidate_ms / baseline_ms - 1.0) * 100.0,
+                "peak_allocated_change_pct": (
+                    (candidate_peak / baseline_peak - 1.0) * 100.0
+                    if baseline_peak
+                    else None
+                ),
+                "all_candidate_rounds_faster": all(
+                    candidate_item["timing"]["median_ms"]
+                    < baseline_item["timing"]["median_ms"]
+                    for baseline_item, candidate_item in zip(
+                        sorted(baseline, key=lambda item: item["round"]),
+                        sorted(candidate, key=lambda item: item["round"]),
+                        strict=False,
+                    )
+                ),
+                "candidate_round_spread": max(candidate_rounds) / min(candidate_rounds),
+            }
+        )
+    qualifying_families = {
+        item["case"]["model"]
+        for item in comparisons
+        if item["all_candidate_rounds_faster"]
+        and (
+            item["latency_change_pct"] <= -5.0
+            or (
+                item["peak_allocated_change_pct"] is not None
+                and item["peak_allocated_change_pct"] <= -15.0
+            )
+        )
+    }
+    stable_rounds = all(
+        item["rounds"] >= 3 and item["candidate_round_spread"] <= 1.05
+        for item in comparisons
+    )
+    no_latency_regression = all(
+        item["latency_change_pct"] <= 3.0 for item in comparisons
+    )
+    return {
+        "baseline_label": baseline_label,
+        "candidate_label": candidate_label,
+        "comparisons": comparisons,
+        "acceptance": {
+            "qualifying_model_families": sorted(qualifying_families),
+            "at_least_two_model_families": len(qualifying_families) >= 2,
+            "three_stable_rounds_per_case": stable_rounds,
+            "no_case_latency_regression_over_3pct": no_latency_regression,
+            "accepted": (
+                len(qualifying_families) >= 2
+                and stable_rounds
+                and no_latency_regression
+            ),
+        },
+    }
+
+
+def _run_text(command: list[str], cwd: Path | None = None) -> str | None:
+    try:
+        return subprocess.check_output(
+            command, cwd=cwd, stderr=subprocess.DEVNULL, text=True, timeout=15
+        ).strip()
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def _git_metadata(source_root: Path) -> dict[str, Any]:
+    status = _run_text(["git", "status", "--short"], cwd=source_root)
+    return {
+        "revision": _run_text(["git", "rev-parse", "HEAD"], cwd=source_root),
+        "dirty": bool(status),
+        "status": status,
+    }
+
+
+def _physical_gpu_selector(device: torch.device) -> str:
+    logical_index = device.index or 0
+    visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if visible_devices:
+        selectors = [item.strip() for item in visible_devices.split(",")]
+        if logical_index < len(selectors) and selectors[logical_index]:
+            return selectors[logical_index]
+    return str(logical_index)
+
+
+def _nvidia_snapshot(gpu_selector: str) -> dict[str, Any] | None:
+    fields = (
+        "name,uuid,compute_cap,driver_version,memory.total,clocks.current.sm,"
+        "clocks.current.memory,power.draw,temperature.gpu,pstate,"
+        "clocks_throttle_reasons.active"
+    )
+    raw = _run_text(
+        [
+            "nvidia-smi",
+            "-i",
+            gpu_selector,
+            f"--query-gpu={fields}",
+            "--format=csv,noheader,nounits",
+        ]
+    )
+    if raw is None:
+        return None
+    processes = _run_text(
+        [
+            "nvidia-smi",
+            "-i",
+            gpu_selector,
+            "--query-compute-apps=pid,process_name,used_memory",
+            "--format=csv,noheader,nounits",
+        ]
+    )
+    return {
+        "gpu_selector": gpu_selector,
+        "query_fields": fields.split(","),
+        "gpu_rows": raw.splitlines(),
+        "processes": processes,
+    }
+
+
+def _environment_metadata(
+    source_root: Path,
+    device: torch.device,
+    package_file: Path,
+    gpu_selector: str,
+) -> dict[str, Any]:
+    try:
+        import triton
+
+        triton_version = triton.__version__
+    except ImportError:
+        triton_version = None
+    props = torch.cuda.get_device_properties(device)
+    tracked_env = {
+        key: value
+        for key, value in os.environ.items()
+        if key.startswith(("CUDA", "TORCH", "TRITON", "SJ_", "NCCL"))
+    }
+    return {
+        "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+        "argv": sys.argv,
+        "source_root": str(source_root),
+        "spikingjelly_file": str(package_file),
+        "git": _git_metadata(source_root),
+        "python": sys.version,
+        "platform": platform.platform(),
+        "torch": torch.__version__,
+        "triton": triton_version,
+        "torch_cuda": torch.version.cuda,
+        "cudnn": torch.backends.cudnn.version(),
+        "selected_device_index": device.index,
+        "physical_gpu_selector": gpu_selector,
+        "gpu": {
+            "name": props.name,
+            "compute_capability": [props.major, props.minor],
+            "total_memory_bytes": props.total_memory,
+        },
+        "environment": tracked_env,
+        "nvidia_smi_before": _nvidia_snapshot(gpu_selector),
+    }
+
+
+def _tensor_metadata(value: Any) -> Any:
+    if isinstance(value, torch.Tensor):
+        return {
+            "shape": list(value.shape),
+            "stride": list(value.stride()),
+            "storage_offset": value.storage_offset(),
+            "dtype": str(value.dtype).removeprefix("torch."),
+            "device": str(value.device),
+            "bytes": value.numel() * value.element_size(),
+            "contiguous": value.is_contiguous(),
+        }
+    if isinstance(value, (tuple, list)):
+        return [_tensor_metadata(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _tensor_metadata(item) for key, item in value.items()}
+    return type(value).__name__
+
+
+class _ProfileHooks:
+    _INTERESTING = (
+        "Node",
+        "SeqToANN",
+        "Attention",
+        "BatchNorm",
+        "Conv",
+        "Pool",
+        "Linear",
+    )
+
+    def __init__(self, model: torch.nn.Module, output: Path):
+        self.output = output
+        self.records: list[dict[str, Any]] = []
+        self.handles = []
+        for name, module in model.named_modules():
+            if name and any(
+                token in type(module).__name__ for token in self._INTERESTING
+            ):
+                self.handles.append(
+                    module.register_forward_pre_hook(self._pre_hook(name, module))
+                )
+                self.handles.append(module.register_forward_hook(self._post_hook(name)))
+
+    def _pre_hook(self, name: str, module: torch.nn.Module):
+        def hook(_module, inputs):
+            torch.cuda.nvtx.range_push(f"module:{type(module).__name__}:{name}")
+            self.records.append(
+                {
+                    "event": "input",
+                    "module": name,
+                    "type": type(module).__name__,
+                    "value": _tensor_metadata(inputs),
+                }
+            )
+
+        return hook
+
+    def _post_hook(self, name: str):
+        def hook(module, _inputs, output):
+            self.records.append(
+                {
+                    "event": "output",
+                    "module": name,
+                    "type": type(module).__name__,
+                    "value": _tensor_metadata(output),
+                }
+            )
+            torch.cuda.nvtx.range_pop()
+
+        return hook
+
+    def close(self) -> None:
+        for handle in self.handles:
+            handle.remove()
+        self.output.parent.mkdir(parents=True, exist_ok=True)
+        with self.output.open("w", encoding="utf-8") as file:
+            for record in self.records:
+                file.write(json.dumps(record) + "\n")
+
+
+def _build_model(name: str, backend: str, T: int, num_classes: int):
+    from spikingjelly.activation_based import functional, neuron
+    from spikingjelly.activation_based.model import sew_resnet, spikformer, spiking_vgg
+
+    node_kwargs = {
+        "spiking_neuron": neuron.LIFNode,
+        "tau": 2.0,
+        "detach_reset": True,
+        "step_mode": "m",
+        "backend": backend,
+    }
+    if name == "spiking_vgg16_bn":
+        model = spiking_vgg.spiking_vgg16_bn(num_classes=num_classes, **node_kwargs)
+    elif name == "sew_resnet18":
+        model = sew_resnet.sew_resnet18(
+            cnf="ADD", num_classes=num_classes, **node_kwargs
+        )
+    elif name == "spikformer_ti":
+        model = spikformer.spikformer_ti(T=T, num_classes=num_classes, backend=backend)
+    else:
+        raise ValueError(name)
+    functional.set_step_mode(model, "m")
+    return model
+
+
+def _make_batch(args: argparse.Namespace, device: torch.device):
+    shape = (args.batch_size, 3, args.image_size, args.image_size)
+    if args.model != "spikformer_ti":
+        shape = (args.T, *shape)
+    x = torch.randn(shape, device=device)
+    if args.channels_last:
+        if x.ndim == 5:
+            x = (
+                x.flatten(0, 1)
+                .contiguous(memory_format=torch.channels_last)
+                .view(shape)
+            )
+        else:
+            x = x.contiguous(memory_format=torch.channels_last)
+    target = torch.randint(args.num_classes, (args.batch_size,), device=device)
+    return x, target
+
+
+def _dynamo_counters() -> dict[str, Any]:
+    dynamo = getattr(torch, "_dynamo", None)
+    utils = getattr(dynamo, "utils", None)
+    counters = getattr(utils, "counters", {})
+    return {group: dict(values) for group, values in counters.items() if values}
+
+
+def _derived_dynamo_counts(counters: dict[str, Any]) -> dict[str, int]:
+    stats = counters.get("stats", {})
+    graph_break = counters.get("graph_break", {})
+    recompiles = counters.get("recompiles", {})
+    return {
+        "graph_count": int(stats.get("unique_graphs", 0)),
+        "graph_break_count": int(sum(graph_break.values())),
+        "recompile_count": int(sum(recompiles.values())),
+    }
+
+
+def run_case(args: argparse.Namespace) -> dict[str, Any]:
+    if not torch.cuda.is_available():
+        raise RuntimeError("benchmark cases require CUDA")
+    source_root = Path(
+        os.environ.get("SJ_BENCH_SOURCE_ROOT", Path(__file__).parents[1])
+    ).resolve()
+    sys.path.insert(0, str(source_root))
+    import spikingjelly
+
+    package_file = Path(spikingjelly.__file__).resolve()
+    try:
+        package_file.relative_to(source_root)
+    except ValueError as error:
+        raise RuntimeError(
+            f"imported spikingjelly from {package_file}, outside source root {source_root}"
+        ) from error
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+    torch.backends.cuda.matmul.allow_tf32 = False
+    torch.backends.cudnn.allow_tf32 = False
+    device = torch.device("cuda", args.device)
+    torch.cuda.set_device(device)
+    gpu_selector = _physical_gpu_selector(device)
+    if (
+        args.require_gpu_name
+        and args.require_gpu_name not in torch.cuda.get_device_name(device)
+    ):
+        raise RuntimeError(
+            f"required GPU containing {args.require_gpu_name!r}, got {torch.cuda.get_device_name(device)!r}"
+        )
+
+    metadata = _environment_metadata(source_root, device, package_file, gpu_selector)
+    model = _build_model(args.model, "triton", args.T, args.num_classes).to(device)
+    state_model = model
+    model.train(args.phase == "training")
+    x, target = _make_batch(args, device)
+    optimizer = (
+        torch.optim.SGD(model.parameters(), lr=args.lr, momentum=args.momentum)
+        if args.phase == "training"
+        else None
+    )
+    criterion = torch.nn.CrossEntropyLoss()
+
+    def reset_net() -> None:
+        from spikingjelly.activation_based import functional
+
+        functional.reset_net(state_model)
+
+    def step() -> torch.Tensor:
+        if optimizer is None:
+            with torch.inference_mode():
+                output = model(x)
+            reset_net()
+            return output
+        optimizer.zero_grad(set_to_none=True)
+        output = model(x)
+        loss = criterion(output.mean(0), target)
+        loss.backward()
+        optimizer.step()
+        reset_net()
+        return loss
+
+    dynamo = getattr(torch, "_dynamo", None)
+    if dynamo is not None:
+        dynamo.reset()
+        counters = getattr(getattr(dynamo, "utils", None), "counters", None)
+        if counters is not None:
+            counters.clear()
+    if args.execution == "compile":
+        model = torch.compile(
+            model,
+            backend="inductor",
+            options={"triton.cudagraphs": False, "triton.cudagraph_trees": False},
+        )
+
+    hooks = None
+    monitor = None
+    monitor_file = None
+    if args.monitor_log:
+        args.monitor_log.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            monitor_file = args.monitor_log.open("w", encoding="utf-8")
+            monitor = subprocess.Popen(
+                [
+                    "nvidia-smi",
+                    "dmon",
+                    "-i",
+                    gpu_selector,
+                    "-s",
+                    "pucvmet",
+                    "-d",
+                    "1",
+                    "-o",
+                    "DT",
+                ],
+                stdout=monitor_file,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+        except OSError:
+            monitor = None
+            if monitor_file is not None:
+                monitor_file.close()
+
+    try:
+        torch.cuda.synchronize(device)
+        first_started = time.perf_counter()
+        step()
+        torch.cuda.synchronize(device)
+        first_step_wall_ms = (time.perf_counter() - first_started) * 1000.0
+
+        for _ in range(args.warmup):
+            step()
+        torch.cuda.synchronize(device)
+        torch.cuda.empty_cache()
+        torch.cuda.reset_peak_memory_stats(device)
+        allocated_before = torch.cuda.memory_allocated(device)
+        reserved_before = torch.cuda.memory_reserved(device)
+        starts = [torch.cuda.Event(enable_timing=True) for _ in range(args.steps)]
+        ends = [torch.cuda.Event(enable_timing=True) for _ in range(args.steps)]
+        for index in range(args.steps):
+            starts[index].record()
+            if args.profile:
+                torch.cuda.nvtx.range_push(f"benchmark_step:{index}")
+            step()
+            if args.profile:
+                torch.cuda.nvtx.range_pop()
+            ends[index].record()
+        ends[-1].synchronize()
+        samples_ms = [
+            start.elapsed_time(end) for start, end in zip(starts, ends, strict=True)
+        ]
+        peak_allocated_bytes = torch.cuda.max_memory_allocated(device)
+        peak_reserved_bytes = torch.cuda.max_memory_reserved(device)
+
+        if args.tensor_metadata:
+            hooks = _ProfileHooks(state_model, args.tensor_metadata)
+            torch.cuda.nvtx.range_push("layout_metadata_step")
+            step()
+            torch.cuda.nvtx.range_pop()
+            torch.cuda.synchronize(device)
+            hooks.close()
+            hooks = None
+    finally:
+        if hooks is not None:
+            hooks.close()
+        if monitor is not None:
+            monitor.terminate()
+            monitor.wait(timeout=10)
+            assert monitor_file is not None
+            monitor_file.close()
+
+    raw_counters = _dynamo_counters()
+    result = {
+        "schema_version": 1,
+        "source_label": args.source_label,
+        "round": args.round,
+        "case": {
+            "model": args.model,
+            "phase": args.phase,
+            "execution": args.execution,
+            "backend": "triton",
+            "dtype": "float32",
+            "T": args.T,
+            "batch_size": args.batch_size,
+            "image_size": args.image_size,
+            "num_classes": args.num_classes,
+            "channels_last": args.channels_last,
+            "warmup": args.warmup,
+            "steps": args.steps,
+            "seed": args.seed,
+            "optimizer": (
+                {"name": "SGD", "lr": args.lr, "momentum": args.momentum}
+                if optimizer is not None
+                else None
+            ),
+            "compile": (
+                {"backend": "inductor", "mode": "default", "cudagraphs": False}
+                if args.execution == "compile"
+                else None
+            ),
+        },
+        "timing": {
+            **summarize_samples(samples_ms),
+            "samples_ms": samples_ms,
+            "first_step_wall_ms": first_step_wall_ms,
+        },
+        "memory": {
+            "allocated_before_bytes": allocated_before,
+            "reserved_before_bytes": reserved_before,
+            "peak_allocated_bytes": peak_allocated_bytes,
+            "peak_reserved_bytes": peak_reserved_bytes,
+        },
+        "dynamo": {
+            **_derived_dynamo_counts(raw_counters),
+            "raw_counters": raw_counters,
+        },
+        "metadata": {
+            **metadata,
+            "nvidia_smi_after": _nvidia_snapshot(gpu_selector),
+        },
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    print(
+        json.dumps(
+            {
+                "output": str(args.output),
+                "case": result["case"],
+                "timing": result["timing"],
+            }
+        )
+    )
+    return result
+
+
+def run_matrix(args: argparse.Namespace) -> dict[str, Any]:
+    sources = parse_source_specs(args.source)
+    output_dir = args.output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    script = Path(__file__).resolve()
+    records: list[dict[str, Any]] = []
+    for round_index in range(1, args.rounds + 1):
+        ordered_sources = sources if round_index % 2 else list(reversed(sources))
+        for model in args.models:
+            for phase in args.phases:
+                batch_size = (
+                    args.training_batch_size
+                    if phase == "training"
+                    else args.inference_batch_size
+                )
+                warmup = (
+                    args.training_warmup
+                    if phase == "training"
+                    else args.inference_warmup
+                )
+                steps = (
+                    args.training_steps if phase == "training" else args.inference_steps
+                )
+                if args.profile:
+                    steps = args.profile_steps
+                for execution in args.executions:
+                    for label, source_root in ordered_sources:
+                        stem = f"r{round_index}-{label}-{model}-{phase}-{execution}"
+                        output = output_dir / f"{stem}.json"
+                        command = [
+                            sys.executable,
+                            str(script),
+                            "case",
+                            "--model",
+                            model,
+                            "--phase",
+                            phase,
+                            "--execution",
+                            execution,
+                            "--batch-size",
+                            str(batch_size),
+                            "--warmup",
+                            str(warmup),
+                            "--steps",
+                            str(steps),
+                            "--T",
+                            str(args.T),
+                            "--image-size",
+                            str(args.image_size),
+                            "--num-classes",
+                            str(args.num_classes),
+                            "--seed",
+                            str(args.seed),
+                            "--device",
+                            str(args.device),
+                            "--source-label",
+                            label,
+                            "--round",
+                            str(round_index),
+                            "--output",
+                            str(output),
+                            "--monitor-log",
+                            str(output_dir / f"{stem}.dmon.log"),
+                        ]
+                        if args.profile:
+                            command.append("--profile")
+                            if execution == "eager":
+                                command.extend(
+                                    [
+                                        "--tensor-metadata",
+                                        str(output_dir / f"{stem}.tensors.jsonl"),
+                                    ]
+                                )
+                        if args.channels_last:
+                            command.append("--channels-last")
+                        if args.require_gpu_name:
+                            command.extend(
+                                ["--require-gpu-name", args.require_gpu_name]
+                            )
+                        env = os.environ.copy()
+                        env["SJ_BENCH_SOURCE_ROOT"] = str(source_root)
+                        env["PYTHONPATH"] = str(source_root)
+                        env["TORCHINDUCTOR_CACHE_DIR"] = str(
+                            output_dir / "cache" / stem
+                        )
+                        subprocess.run(command, check=True, env=env)
+                        records.append(json.loads(output.read_text(encoding="utf-8")))
+
+    baseline_label, candidate_label = (label for label, _ in sources)
+    summary = aggregate_records(records, baseline_label, candidate_label)
+    payload = {
+        "schema_version": 1,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "sources": [{"label": label, "path": str(path)} for label, path in sources],
+        "records": records,
+        "comparison": summary,
+    }
+    (output_dir / "matrix.json").write_text(
+        json.dumps(payload, indent=2), encoding="utf-8"
+    )
+    (output_dir / "comparison.json").write_text(
+        json.dumps(summary, indent=2), encoding="utf-8"
+    )
+    return payload
+
+
+def _add_case_parser(subparsers) -> None:
+    parser = subparsers.add_parser("case", help="run one isolated CUDA benchmark case")
+    parser.add_argument("--model", choices=MODEL_NAMES, required=True)
+    parser.add_argument("--phase", choices=PHASES, required=True)
+    parser.add_argument("--execution", choices=EXECUTIONS, required=True)
+    parser.add_argument("--batch-size", type=int, required=True)
+    parser.add_argument("--warmup", type=int, required=True)
+    parser.add_argument("--steps", type=int, required=True)
+    parser.add_argument("--T", type=int, default=DEFAULT_T)
+    parser.add_argument("--image-size", type=int, default=DEFAULT_IMAGE_SIZE)
+    parser.add_argument("--num-classes", type=int, default=1000)
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    parser.add_argument("--device", type=int, default=0)
+    parser.add_argument("--lr", type=float, default=0.1)
+    parser.add_argument("--momentum", type=float, default=0.9)
+    parser.add_argument("--channels-last", action="store_true")
+    parser.add_argument("--profile", action="store_true")
+    parser.add_argument("--require-gpu-name", default="")
+    parser.add_argument("--source-label", default="working-tree")
+    parser.add_argument("--round", type=int, default=1)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--tensor-metadata", type=Path)
+    parser.add_argument("--monitor-log", type=Path)
+    parser.set_defaults(handler=run_case)
+
+
+def _add_matrix_parser(subparsers) -> None:
+    parser = subparsers.add_parser(
+        "matrix", help="run source trees in alternating isolated processes"
+    )
+    parser.add_argument("--source", action="append", required=True, help="LABEL=PATH")
+    parser.add_argument(
+        "--models", nargs="+", choices=MODEL_NAMES, default=list(MODEL_NAMES)
+    )
+    parser.add_argument("--phases", nargs="+", choices=PHASES, default=list(PHASES))
+    parser.add_argument(
+        "--executions", nargs="+", choices=EXECUTIONS, default=list(EXECUTIONS)
+    )
+    parser.add_argument("--rounds", type=int, default=3)
+    parser.add_argument("--inference-batch-size", type=int, default=64)
+    parser.add_argument("--training-batch-size", type=int, default=32)
+    parser.add_argument("--inference-warmup", type=int, default=100)
+    parser.add_argument("--training-warmup", type=int, default=50)
+    parser.add_argument("--inference-steps", type=int, default=500)
+    parser.add_argument("--training-steps", type=int, default=100)
+    parser.add_argument("--profile", action="store_true")
+    parser.add_argument("--profile-steps", type=int, default=10)
+    parser.add_argument("--T", type=int, default=DEFAULT_T)
+    parser.add_argument("--image-size", type=int, default=DEFAULT_IMAGE_SIZE)
+    parser.add_argument("--num-classes", type=int, default=1000)
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    parser.add_argument("--device", type=int, default=0)
+    parser.add_argument("--channels-last", action="store_true")
+    parser.add_argument("--require-gpu-name", default="")
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.set_defaults(handler=run_matrix)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Single-GPU SNN benchmark runner")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    _add_case_parser(subparsers)
+    _add_matrix_parser(subparsers)
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    if min(args.T, args.image_size) <= 0:
+        raise ValueError("T and image size must be positive")
+    if args.command == "case":
+        if args.batch_size <= 0 or args.steps <= 0 or args.warmup < 0:
+            raise ValueError(
+                "batch size and steps must be positive; warmup must be non-negative"
+            )
+    else:
+        positive = (
+            args.rounds,
+            args.inference_batch_size,
+            args.training_batch_size,
+            args.inference_steps,
+            args.training_steps,
+            args.profile_steps,
+        )
+        if min(positive) <= 0 or min(args.inference_warmup, args.training_warmup) < 0:
+            raise ValueError("matrix counts must be positive and warmups non-negative")
+    args.handler(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/benchmark_snn_single_gpu.py
+++ b/benchmark/benchmark_snn_single_gpu.py
@@ -104,6 +104,33 @@ def _run_isolated_case(command: list[str], env: dict[str, str], timeout: int) ->
         )
 
 
+def _stop_monitor(monitor) -> None:
+    if monitor is None:
+        return
+    try:
+        if monitor.poll() is not None:
+            return
+    except ProcessLookupError:
+        return
+    try:
+        monitor.terminate()
+    except ProcessLookupError:
+        pass
+    try:
+        monitor.wait(timeout=10)
+    except ProcessLookupError:
+        pass
+    except subprocess.TimeoutExpired:
+        try:
+            monitor.kill()
+        except ProcessLookupError:
+            pass
+        try:
+            monitor.wait()
+        except ProcessLookupError:
+            pass
+
+
 def aggregate_records(
     records: list[dict[str, Any]], baseline_label: str, candidate_label: str
 ) -> dict[str, Any]:
@@ -133,6 +160,13 @@ def aggregate_records(
         candidate_rounds = [item["timing"]["median_ms"] for item in candidate]
         baseline_ms = statistics.median(baseline_rounds)
         candidate_ms = statistics.median(candidate_rounds)
+        candidate_min = min(candidate_rounds)
+        latency_change_pct = (
+            (candidate_ms / baseline_ms - 1.0) * 100.0 if baseline_ms else None
+        )
+        candidate_round_spread = (
+            max(candidate_rounds) / candidate_min if candidate_min else None
+        )
         baseline_peak = statistics.median(
             item["memory"]["peak_allocated_bytes"] for item in baseline
         )
@@ -154,7 +188,7 @@ def aggregate_records(
                 "candidate_round_medians_ms": candidate_rounds,
                 "baseline_median_ms": baseline_ms,
                 "candidate_median_ms": candidate_ms,
-                "latency_change_pct": (candidate_ms / baseline_ms - 1.0) * 100.0,
+                "latency_change_pct": latency_change_pct,
                 "peak_allocated_change_pct": (
                     (candidate_peak / baseline_peak - 1.0) * 100.0
                     if baseline_peak
@@ -164,12 +198,10 @@ def aggregate_records(
                     candidate_item["timing"]["median_ms"]
                     < baseline_item["timing"]["median_ms"]
                     for baseline_item, candidate_item in zip(
-                        sorted(baseline, key=lambda item: item["round"]),
-                        sorted(candidate, key=lambda item: item["round"]),
-                        strict=False,
+                        baseline, candidate, strict=False
                     )
                 ),
-                "candidate_round_spread": max(candidate_rounds) / min(candidate_rounds),
+                "candidate_round_spread": candidate_round_spread,
             }
         )
     qualifying_families = {
@@ -177,7 +209,10 @@ def aggregate_records(
         for item in comparisons
         if item["all_candidate_rounds_faster"]
         and (
-            item["latency_change_pct"] <= -5.0
+            (
+                item["latency_change_pct"] is not None
+                and item["latency_change_pct"] <= -5.0
+            )
             or (
                 item["peak_allocated_change_pct"] is not None
                 and item["peak_allocated_change_pct"] <= -15.0
@@ -185,11 +220,14 @@ def aggregate_records(
         )
     }
     stable_rounds = all(
-        item["rounds"] >= 3 and item["candidate_round_spread"] <= 1.05
+        item["rounds"] >= 3
+        and item["candidate_round_spread"] is not None
+        and item["candidate_round_spread"] <= 1.05
         for item in comparisons
     )
     no_latency_regression = all(
-        item["latency_change_pct"] <= 3.0 for item in comparisons
+        item["latency_change_pct"] is not None and item["latency_change_pct"] <= 3.0
+        for item in comparisons
     )
     return {
         "baseline_label": baseline_label,
@@ -541,27 +579,30 @@ def run_case(args: argparse.Namespace) -> dict[str, Any]:
         args.monitor_log.parent.mkdir(parents=True, exist_ok=True)
         try:
             monitor_file = args.monitor_log.open("w", encoding="utf-8")
-            monitor = subprocess.Popen(
-                [
-                    "nvidia-smi",
-                    "dmon",
-                    "-i",
-                    gpu_selector,
-                    "-s",
-                    "pucvmet",
-                    "-d",
-                    "1",
-                    "-o",
-                    "DT",
-                ],
-                stdout=monitor_file,
-                stderr=subprocess.STDOUT,
-                text=True,
-            )
+            try:
+                monitor = subprocess.Popen(
+                    [
+                        "nvidia-smi",
+                        "dmon",
+                        "-i",
+                        gpu_selector,
+                        "-s",
+                        "pucvmet",
+                        "-d",
+                        "1",
+                        "-o",
+                        "DT",
+                    ],
+                    stdout=monitor_file,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                )
+            finally:
+                if monitor is None:
+                    monitor_file.close()
+                    monitor_file = None
         except OSError:
             monitor = None
-            if monitor_file is not None:
-                monitor_file.close()
 
     try:
         torch.cuda.synchronize(device)
@@ -605,18 +646,11 @@ def run_case(args: argparse.Namespace) -> dict[str, Any]:
     finally:
         if hooks is not None:
             hooks.close()
-        if monitor is not None:
-            try:
-                if monitor.poll() is None:
-                    monitor.terminate()
-                    try:
-                        monitor.wait(timeout=10)
-                    except subprocess.TimeoutExpired:
-                        monitor.kill()
-                        monitor.wait()
-            finally:
-                if monitor_file is not None:
-                    monitor_file.close()
+        try:
+            _stop_monitor(monitor)
+        finally:
+            if monitor_file is not None:
+                monitor_file.close()
 
     raw_counters = _dynamo_counters()
     result = {

--- a/benchmark/benchmark_snn_single_gpu.py
+++ b/benchmark/benchmark_snn_single_gpu.py
@@ -238,12 +238,6 @@ def aggregate_records(
                 and not failures
             ),
         },
-        "manual_acceptance_checks": [
-            "exclusive_gpu_access",
-            "no_gpu_throttle_or_xid",
-            "no_oom",
-            "numerical_correctness",
-        ],
     }
 
 
@@ -477,21 +471,16 @@ def _make_batch(args: argparse.Namespace, device: torch.device):
     return x, target
 
 
-def _dynamo_counters() -> dict[str, Any]:
+def _dynamo_metrics() -> dict[str, Any]:
     dynamo = getattr(torch, "_dynamo", None)
     utils = getattr(dynamo, "utils", None)
     counters = getattr(utils, "counters", {})
-    return {group: dict(values) for group, values in counters.items() if values}
-
-
-def _derived_dynamo_counts(counters: dict[str, Any]) -> dict[str, int]:
-    stats = counters.get("stats", {})
-    graph_break = counters.get("graph_break", {})
-    recompiles = counters.get("recompiles", {})
+    raw = {group: dict(values) for group, values in counters.items() if values}
     return {
-        "graph_count": int(stats.get("unique_graphs", 0)),
-        "graph_break_count": int(sum(graph_break.values())),
-        "recompile_count": int(sum(recompiles.values())),
+        "graph_count": int(raw.get("stats", {}).get("unique_graphs", 0)),
+        "graph_break_count": int(sum(raw.get("graph_break", {}).values())),
+        "recompile_count": int(sum(raw.get("recompiles", {}).values())),
+        "raw_counters": raw,
     }
 
 
@@ -571,12 +560,10 @@ def run_case(args: argparse.Namespace) -> dict[str, Any]:
 
     hooks = None
     monitor = None
-    monitor_file = None
     if args.monitor_log:
         args.monitor_log.parent.mkdir(parents=True, exist_ok=True)
         try:
-            monitor_file = args.monitor_log.open("w", encoding="utf-8")
-            try:
+            with args.monitor_log.open("w", encoding="utf-8") as monitor_file:
                 monitor = subprocess.Popen(
                     [
                         "nvidia-smi",
@@ -594,12 +581,8 @@ def run_case(args: argparse.Namespace) -> dict[str, Any]:
                     stderr=subprocess.STDOUT,
                     text=True,
                 )
-            finally:
-                if monitor is None:
-                    monitor_file.close()
-                    monitor_file = None
         except OSError:
-            monitor = None
+            pass
 
     try:
         torch.cuda.synchronize(device)
@@ -643,13 +626,9 @@ def run_case(args: argparse.Namespace) -> dict[str, Any]:
     finally:
         if hooks is not None:
             hooks.close()
-        try:
-            _stop_monitor(monitor)
-        finally:
-            if monitor_file is not None:
-                monitor_file.close()
+        _stop_monitor(monitor)
 
-    raw_counters = _dynamo_counters()
+    dynamo_metrics = _dynamo_metrics()
     result = {
         "schema_version": 1,
         "source_label": args.source_label,
@@ -690,10 +669,7 @@ def run_case(args: argparse.Namespace) -> dict[str, Any]:
             "peak_allocated_bytes": peak_allocated_bytes,
             "peak_reserved_bytes": peak_reserved_bytes,
         },
-        "dynamo": {
-            **_derived_dynamo_counts(raw_counters),
-            "raw_counters": raw_counters,
-        },
+        "dynamo": dynamo_metrics,
         "metadata": {
             **metadata,
             "nvidia_smi_after": _nvidia_snapshot(gpu_selector),

--- a/benchmark/benchmark_snn_single_gpu.py
+++ b/benchmark/benchmark_snn_single_gpu.py
@@ -119,9 +119,17 @@ def aggregate_records(
     records: list[dict[str, Any]], baseline_label: str, candidate_label: str
 ) -> dict[str, Any]:
     grouped: dict[tuple[str, str, str, int, int, int], dict[str, list[dict]]] = {}
-    failures = [record for record in records if record.get("status") == "error"]
+    failures = []
     for record in records:
-        if record.get("status") == "error":
+        compile_metrics = record.get("dynamo", {})
+        compile_metrics_invalid = record.get("case", {}).get(
+            "execution"
+        ) == "compile" and (
+            compile_metrics.get("graph_break_count") != 0
+            or compile_metrics.get("recompile_count") != 0
+        )
+        if record.get("status") == "error" or compile_metrics_invalid:
+            failures.append(record)
             continue
         grouped.setdefault(case_key(record), {}).setdefault(
             record["source_label"], []
@@ -218,18 +226,24 @@ def aggregate_records(
         "candidate_label": candidate_label,
         "comparisons": comparisons,
         "failures": failures,
-        "acceptance": {
+        "performance_gates": {
             "qualifying_model_families": sorted(qualifying_families),
             "at_least_two_model_families": len(qualifying_families) >= 2,
             "three_stable_rounds_per_case": stable_rounds,
             "no_case_latency_regression_over_3pct": no_latency_regression,
-            "accepted": (
+            "met": (
                 len(qualifying_families) >= 2
                 and stable_rounds
                 and no_latency_regression
                 and not failures
             ),
         },
+        "manual_acceptance_checks": [
+            "exclusive_gpu_access",
+            "no_gpu_throttle_or_xid",
+            "no_oom",
+            "numerical_correctness",
+        ],
     }
 
 

--- a/benchmark/benchmark_snn_single_gpu.py
+++ b/benchmark/benchmark_snn_single_gpu.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import os
 import platform
+import signal
 import statistics
 import subprocess
 import sys
@@ -77,11 +78,40 @@ def case_key(record: dict[str, Any]) -> tuple[str, str, str, int, int, int]:
     )
 
 
+def _run_isolated_case(command: list[str], env: dict[str, str], timeout: int) -> None:
+    process = subprocess.Popen(
+        command,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        stdout, stderr = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired as error:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        stdout, stderr = process.communicate()
+        raise subprocess.TimeoutExpired(
+            command, timeout, output=stdout, stderr=stderr
+        ) from error
+    if process.returncode:
+        raise subprocess.CalledProcessError(
+            process.returncode, command, output=stdout, stderr=stderr
+        )
+
+
 def aggregate_records(
     records: list[dict[str, Any]], baseline_label: str, candidate_label: str
 ) -> dict[str, Any]:
     grouped: dict[tuple[str, str, str, int, int, int], dict[str, list[dict]]] = {}
+    failures = [record for record in records if record.get("status") == "error"]
     for record in records:
+        if record.get("status") == "error":
+            continue
         grouped.setdefault(case_key(record), {}).setdefault(
             record["source_label"], []
         ).append(record)
@@ -91,6 +121,13 @@ def aggregate_records(
         baseline = by_source.get(baseline_label, [])
         candidate = by_source.get(candidate_label, [])
         if not baseline or not candidate:
+            continue
+        baseline_by_round = {item["round"]: item for item in baseline}
+        candidate_by_round = {item["round"]: item for item in candidate}
+        paired_rounds = sorted(baseline_by_round.keys() & candidate_by_round.keys())
+        baseline = [baseline_by_round[round_index] for round_index in paired_rounds]
+        candidate = [candidate_by_round[round_index] for round_index in paired_rounds]
+        if not baseline:
             continue
         baseline_rounds = [item["timing"]["median_ms"] for item in baseline]
         candidate_rounds = [item["timing"]["median_ms"] for item in candidate]
@@ -158,6 +195,7 @@ def aggregate_records(
         "baseline_label": baseline_label,
         "candidate_label": candidate_label,
         "comparisons": comparisons,
+        "failures": failures,
         "acceptance": {
             "qualifying_model_families": sorted(qualifying_families),
             "at_least_two_model_families": len(qualifying_families) >= 2,
@@ -167,6 +205,7 @@ def aggregate_records(
                 len(qualifying_families) >= 2
                 and stable_rounds
                 and no_latency_regression
+                and not failures
             ),
         },
     }
@@ -251,6 +290,10 @@ def _environment_metadata(
         key: value
         for key, value in os.environ.items()
         if key.startswith(("CUDA", "TORCH", "TRITON", "SJ_", "NCCL"))
+        and not any(
+            marker in key.upper()
+            for marker in ("TOKEN", "SECRET", "KEY", "PASSWORD", "CREDENTIAL")
+        )
     }
     return {
         "timestamp_utc": datetime.now(timezone.utc).isoformat(),
@@ -563,10 +606,17 @@ def run_case(args: argparse.Namespace) -> dict[str, Any]:
         if hooks is not None:
             hooks.close()
         if monitor is not None:
-            monitor.terminate()
-            monitor.wait(timeout=10)
-            assert monitor_file is not None
-            monitor_file.close()
+            try:
+                if monitor.poll() is None:
+                    monitor.terminate()
+                    try:
+                        monitor.wait(timeout=10)
+                    except subprocess.TimeoutExpired:
+                        monitor.kill()
+                        monitor.wait()
+            finally:
+                if monitor_file is not None:
+                    monitor_file.close()
 
     raw_counters = _dynamo_counters()
     result = {
@@ -717,8 +767,38 @@ def run_matrix(args: argparse.Namespace) -> dict[str, Any]:
                         env["TORCHINDUCTOR_CACHE_DIR"] = str(
                             output_dir / "cache" / stem
                         )
-                        subprocess.run(command, check=True, env=env)
-                        records.append(json.loads(output.read_text(encoding="utf-8")))
+                        try:
+                            _run_isolated_case(command, env, args.timeout)
+                            record = json.loads(output.read_text(encoding="utf-8"))
+                        except (
+                            subprocess.CalledProcessError,
+                            subprocess.TimeoutExpired,
+                            OSError,
+                        ) as error:
+                            record = {
+                                "source_label": label,
+                                "round": round_index,
+                                "status": "error",
+                                "case": {
+                                    "model": model,
+                                    "phase": phase,
+                                    "execution": execution,
+                                    "T": args.T,
+                                    "batch_size": batch_size,
+                                    "image_size": args.image_size,
+                                },
+                                "error": {
+                                    "type": type(error).__name__,
+                                    "message": str(error),
+                                    "stdout": str(getattr(error, "stdout", "") or "")[
+                                        -4000:
+                                    ],
+                                    "stderr": str(getattr(error, "stderr", "") or "")[
+                                        -4000:
+                                    ],
+                                },
+                            }
+                        records.append(record)
 
     baseline_label, candidate_label = (label for label, _ in sources)
     summary = aggregate_records(records, baseline_label, candidate_label)
@@ -777,6 +857,7 @@ def _add_matrix_parser(subparsers) -> None:
         "--executions", nargs="+", choices=EXECUTIONS, default=list(EXECUTIONS)
     )
     parser.add_argument("--rounds", type=int, default=3)
+    parser.add_argument("--timeout", type=int, default=1800)
     parser.add_argument("--inference-batch-size", type=int, default=64)
     parser.add_argument("--training-batch-size", type=int, default=32)
     parser.add_argument("--inference-warmup", type=int, default=100)
@@ -821,6 +902,7 @@ def main() -> None:
             args.inference_steps,
             args.training_steps,
             args.profile_steps,
+            args.timeout,
         )
         if min(positive) <= 0 or min(args.inference_warmup, args.training_warmup) < 0:
             raise ValueError("matrix counts must be positive and warmups non-negative")

--- a/benchmark/probe_snn_compile_boundary.py
+++ b/benchmark/probe_snn_compile_boundary.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import os
+import re
 import subprocess
 import sys
-import importlib.util
 from pathlib import Path
-from uuid import uuid4
 from typing import Any
+from uuid import uuid4
 
 import torch
 
@@ -188,7 +189,20 @@ def _generated_code(cache_dir: Path) -> tuple[list[str], int, int]:
         allocation_count += text.count("empty_strided_") + text.count(
             "alloc_from_pool("
         )
-        launch_count += text.count(".run(") + text.count("extern_kernels.")
+        launch_count += len(
+            re.findall(
+                r"^\s*(?:\w+\s*=\s*)?(?:(?:triton_|cpp_)\w+|\w*kernel\w*)\.run\(",
+                text,
+                re.MULTILINE,
+            )
+        )
+        launch_count += len(
+            re.findall(
+                r"^\s*(?:\w+\s*=\s*)?extern_kernels\.\w+\(",
+                text,
+                re.MULTILINE,
+            )
+        )
     return [str(path) for path in paths], allocation_count, launch_count
 
 

--- a/benchmark/probe_snn_compile_boundary.py
+++ b/benchmark/probe_snn_compile_boundary.py
@@ -501,7 +501,6 @@ def main() -> None:
     if args.child:
         if args.case is None or args.phase is None:
             raise ValueError("--child requires --case and --phase")
-        os.environ.update(_registration_env(args.case))
         result = run_child(args)
         print("JSON_RESULT=" + json.dumps(result), flush=True)
     else:

--- a/benchmark/probe_snn_compile_boundary.py
+++ b/benchmark/probe_snn_compile_boundary.py
@@ -182,14 +182,10 @@ def _build_model(case: str, phase: str, device: torch.device) -> torch.nn.Module
     return PointwiseNode(node).to(device)
 
 
-def _reset(model: torch.nn.Module) -> None:
+def _run_once(model: torch.nn.Module, x: torch.Tensor, phase: str):
     from spikingjelly.activation_based import functional
 
     functional.reset_net(model)
-
-
-def _run_once(model: torch.nn.Module, x: torch.Tensor, phase: str):
-    _reset(model)
     if phase == "inference":
         with torch.inference_mode():
             return model(x), None

--- a/benchmark/probe_snn_compile_boundary.py
+++ b/benchmark/probe_snn_compile_boundary.py
@@ -73,7 +73,16 @@ def _unsupported(
 
 
 def _prerequisite_failure(case: str, phase: str) -> dict[str, Any] | None:
-    if not hasattr(torch, "compile") or not hasattr(torch, "_dynamo"):
+    if not hasattr(torch, "compile"):
+        return _unsupported(
+            case,
+            phase,
+            "torch_compile_unavailable",
+            "torch.compile and torch._dynamo are required",
+        )
+    try:
+        importlib.import_module("torch._dynamo")
+    except ImportError:
         return _unsupported(
             case,
             phase,
@@ -94,14 +103,24 @@ def _prerequisite_failure(case: str, phase: str) -> dict[str, Any] | None:
             return _unsupported(
                 case, phase, "triton_required", "the Triton package is not importable"
             )
-    if case == "triton_lif" and not (
-        hasattr(torch.library, "triton_op") and hasattr(torch.library, "wrap_triton")
+    registration_env = _registration_env(case)
+    if registration_env["SJ_USE_TRITON_OP"] == "1" and not hasattr(
+        torch.library, "triton_op"
     ):
         return _unsupported(
             case,
             phase,
             "triton_op_unavailable",
-            "torch.library.triton_op and wrap_triton are required",
+            "torch.library.triton_op is required",
+        )
+    if registration_env["SJ_USE_WRAP_TRITON"] == "1" and not hasattr(
+        torch.library, "wrap_triton"
+    ):
+        return _unsupported(
+            case,
+            phase,
+            "wrap_triton_unavailable",
+            "torch.library.wrap_triton is required",
         )
     return None
 
@@ -181,6 +200,7 @@ def _run_once(model: torch.nn.Module, x: torch.Tensor, phase: str):
 
 
 def _generated_code(cache_dir: Path) -> tuple[list[str], int, int]:
+    """Count same-line Inductor launcher calls; profiler counts are authoritative."""
     paths = sorted(cache_dir.rglob("output_code.py"))
     allocation_count = 0
     launch_count = 0
@@ -433,14 +453,23 @@ def run_parent(args: argparse.Namespace) -> dict[str, Any]:
                 results.append(result)
                 print(json.dumps(result), flush=True)
                 continue
+            stderr_log = None
+            if completed.stderr:
+                stderr_log = work_dir / f"{case}-{phase}.stderr"
+                stderr_log.write_text(
+                    completed.stderr, encoding="utf-8", errors="replace"
+                )
             if child_output.exists():
                 result = json.loads(child_output.read_text(encoding="utf-8"))
             else:
-                result = _unsupported(
-                    case, phase, "child_process_failed", completed.stderr[-4000:]
-                )
+                reason = completed.stderr[-4000:]
+                if stderr_log is not None:
+                    reason = f"{reason}\nfull stderr: {stderr_log}"
+                result = _unsupported(case, phase, "child_process_failed", reason)
                 result["status"] = "error"
                 result["returncode"] = completed.returncode
+            if stderr_log is not None:
+                result["stderr_path"] = str(stderr_log)
             result.setdefault("registration_environment", _registration_env(case))
             results.append(result)
             print(json.dumps(result), flush=True)

--- a/benchmark/probe_snn_compile_boundary.py
+++ b/benchmark/probe_snn_compile_boundary.py
@@ -23,6 +23,15 @@ CASES = (
 PHASES = ("inference", "training")
 
 
+def _registration_env(case: str) -> dict[str, str]:
+    return {
+        "SJ_USE_TRITON_OP": ("1" if case in {"triton_lif", "triton_flexsn"} else "0"),
+        "SJ_USE_WRAP_TRITON": (
+            "1" if case in {"custom_lif", "triton_lif", "triton_flexsn"} else "0"
+        ),
+    }
+
+
 def _graph_break_count(explain_output: Any) -> int:
     if hasattr(explain_output, "graph_break_count"):
         return int(explain_output.graph_break_count)
@@ -102,7 +111,7 @@ def _lif_core(x: torch.Tensor, v: torch.Tensor):
     return output, h - output
 
 
-def _build_model(case: str, device: torch.device) -> torch.nn.Module:
+def _build_model(case: str, phase: str, device: torch.device) -> torch.nn.Module:
     from spikingjelly.activation_based import neuron, surrogate
 
     if case.endswith("lif") and "flexsn" not in case:
@@ -133,8 +142,14 @@ def _build_model(case: str, device: torch.device) -> torch.nn.Module:
             step_mode="m",
             backend=backend,
         )
-        if backend == "triton" and not node._inductor_training_available:
-            raise RuntimeError("FlexSN Triton training kernel construction failed")
+        if backend == "triton":
+            if phase == "inference" and not (
+                node._inductor_inference_final_state_available
+                or node._inductor_inference_available
+            ):
+                raise RuntimeError("FlexSN Triton inference kernel construction failed")
+            if phase == "training" and not node._inductor_training_available:
+                raise RuntimeError("FlexSN Triton training kernel construction failed")
 
     class PointwiseNode(torch.nn.Module):
         def __init__(self, inner: torch.nn.Module):
@@ -249,7 +264,9 @@ def run_child(args: argparse.Namespace) -> dict[str, Any]:
         torch.cuda.manual_seed_all(args.seed)
     x_template = torch.randn(4, 2, 16, device=device)
 
-    explain_model = _build_model(args.case, device).train(args.phase == "training")
+    explain_model = _build_model(args.case, args.phase, device).train(
+        args.phase == "training"
+    )
     explain_input = x_template.clone().requires_grad_(args.phase == "training")
     _clear_dynamo_state()
     try:
@@ -268,8 +285,12 @@ def run_child(args: argparse.Namespace) -> dict[str, Any]:
         args.output.write_text(json.dumps(result, indent=2), encoding="utf-8")
         return result
 
-    eager_model = _build_model(args.case, device).train(args.phase == "training")
-    compiled_source = _build_model(args.case, device).train(args.phase == "training")
+    eager_model = _build_model(args.case, args.phase, device).train(
+        args.phase == "training"
+    )
+    compiled_source = _build_model(args.case, args.phase, device).train(
+        args.phase == "training"
+    )
     compiled_source.load_state_dict(eager_model.state_dict(), strict=True)
     eager_x = x_template.clone().requires_grad_(args.phase == "training")
     compiled_x = x_template.clone().requires_grad_(args.phase == "training")
@@ -304,6 +325,9 @@ def run_child(args: argparse.Namespace) -> dict[str, Any]:
             "reason": None,
             "device": str(device),
             "spikingjelly_file": str(package_file),
+            "registration_environment": {
+                key: os.environ.get(key) for key in _registration_env(args.case)
+            },
             "graph_count": compile_counts["graph_count"],
             "graph_break_count": compile_counts["graph_break_count"],
             "recompile_count": compile_counts["recompile_count"],
@@ -359,12 +383,7 @@ def run_parent(args: argparse.Namespace) -> dict[str, Any]:
             child_output = work_dir / f"{case}-{phase}.json"
             cache_dir = work_dir / "cache" / f"{case}-{phase}"
             env = os.environ.copy()
-            env["SJ_USE_TRITON_OP"] = (
-                "1" if case in {"triton_lif", "triton_flexsn"} else "0"
-            )
-            env["SJ_USE_WRAP_TRITON"] = (
-                "1" if case in {"custom_lif", "triton_lif", "triton_flexsn"} else "0"
-            )
+            env.update(_registration_env(case))
             env["TORCHINDUCTOR_CACHE_DIR"] = str(cache_dir)
             env["TORCH_COMPILE_DEBUG"] = "1"
             command = [
@@ -380,9 +399,26 @@ def run_parent(args: argparse.Namespace) -> dict[str, Any]:
                 "--output",
                 str(child_output),
             ]
-            completed = subprocess.run(
-                command, env=env, capture_output=True, text=True, timeout=args.timeout
-            )
+            try:
+                completed = subprocess.run(
+                    command,
+                    env=env,
+                    capture_output=True,
+                    text=True,
+                    timeout=args.timeout,
+                )
+            except subprocess.TimeoutExpired:
+                result = _unsupported(
+                    case,
+                    phase,
+                    "child_process_timeout",
+                    f"child exceeded timeout of {args.timeout} seconds",
+                )
+                result["status"] = "error"
+                result["registration_environment"] = _registration_env(case)
+                results.append(result)
+                print(json.dumps(result), flush=True)
+                continue
             if child_output.exists():
                 result = json.loads(child_output.read_text(encoding="utf-8"))
             else:
@@ -391,6 +427,7 @@ def run_parent(args: argparse.Namespace) -> dict[str, Any]:
                 )
                 result["status"] = "error"
                 result["returncode"] = completed.returncode
+            result.setdefault("registration_environment", _registration_env(case))
             results.append(result)
             print(json.dumps(result), flush=True)
 
@@ -425,6 +462,7 @@ def main() -> None:
     if args.child:
         if args.case is None or args.phase is None:
             raise ValueError("--child requires --case and --phase")
+        os.environ.update(_registration_env(args.case))
         result = run_child(args)
         print("JSON_RESULT=" + json.dumps(result), flush=True)
     else:

--- a/benchmark/probe_snn_compile_boundary.py
+++ b/benchmark/probe_snn_compile_boundary.py
@@ -1,0 +1,435 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import importlib.util
+from pathlib import Path
+from uuid import uuid4
+from typing import Any
+
+import torch
+
+CASES = (
+    "torch_lif",
+    "custom_lif",
+    "triton_lif",
+    "torch_flexsn",
+    "triton_flexsn",
+    "opaque_flexsn",
+)
+PHASES = ("inference", "training")
+
+
+def _graph_break_count(explain_output: Any) -> int:
+    if hasattr(explain_output, "graph_break_count"):
+        return int(explain_output.graph_break_count)
+    if hasattr(explain_output, "break_reasons"):
+        return len(explain_output.break_reasons)
+    raise TypeError(f"unsupported explain output: {type(explain_output).__name__}")
+
+
+def _graph_count(explain_output: Any) -> int:
+    if hasattr(explain_output, "graph_count"):
+        return int(explain_output.graph_count)
+    graphs = getattr(explain_output, "graphs", None)
+    if graphs is not None:
+        return len(graphs)
+    raise TypeError(f"unsupported explain output: {type(explain_output).__name__}")
+
+
+def _unsupported(
+    case: str, phase: str, reason_code: str, reason: str
+) -> dict[str, Any]:
+    return {
+        "case": case,
+        "phase": phase,
+        "status": "unsupported",
+        "reason_code": reason_code,
+        "reason": reason,
+        "device": "cuda" if torch.cuda.is_available() else "cpu",
+        "graph_count": None,
+        "graph_break_count": None,
+        "recompile_count": None,
+        "generated_code_paths": [],
+        "allocation_count": None,
+        "kernel_launch_count": None,
+        "physical_metrics_source": None,
+        "output_close": None,
+        "gradient_close": None,
+    }
+
+
+def _prerequisite_failure(case: str, phase: str) -> dict[str, Any] | None:
+    if not hasattr(torch, "compile") or not hasattr(torch, "_dynamo"):
+        return _unsupported(
+            case,
+            phase,
+            "torch_compile_unavailable",
+            "torch.compile and torch._dynamo are required",
+        )
+    if case in {
+        "custom_lif",
+        "triton_lif",
+        "triton_flexsn",
+        "opaque_flexsn",
+    }:
+        if not torch.cuda.is_available():
+            return _unsupported(
+                case, phase, "cuda_required", "the Triton-backed boundary requires CUDA"
+            )
+        if importlib.util.find_spec("triton") is None:
+            return _unsupported(
+                case, phase, "triton_required", "the Triton package is not importable"
+            )
+    if case == "triton_lif" and not (
+        hasattr(torch.library, "triton_op") and hasattr(torch.library, "wrap_triton")
+    ):
+        return _unsupported(
+            case,
+            phase,
+            "triton_op_unavailable",
+            "torch.library.triton_op and wrap_triton are required",
+        )
+    return None
+
+
+def _lif_core(x: torch.Tensor, v: torch.Tensor):
+    h = v + (x - v) / 2.0
+    output = torch.tanh(h)
+    return output, h - output
+
+
+def _build_model(case: str, device: torch.device) -> torch.nn.Module:
+    from spikingjelly.activation_based import neuron, surrogate
+
+    if case.endswith("lif") and "flexsn" not in case:
+        backend = "torch" if case == "torch_lif" else "triton"
+        node = neuron.LIFNode(
+            tau=2.0,
+            decay_input=True,
+            v_threshold=1.0,
+            v_reset=0.0,
+            surrogate_function=surrogate.Sigmoid(alpha=4.0),
+            detach_reset=False,
+            step_mode="m",
+            backend=backend,
+        )
+    else:
+        from spikingjelly.activation_based.neuron.flexsn import FlexSN
+
+        backend = "torch" if case == "torch_flexsn" else "triton"
+        example = torch.zeros(2, 16, device=device)
+        node = FlexSN(
+            core=_lif_core,
+            num_inputs=1,
+            num_states=1,
+            num_outputs=1,
+            example_inputs=(example, example),
+            example_outputs=(example,),
+            requires_grad=(True, True),
+            step_mode="m",
+            backend=backend,
+        )
+        if backend == "triton" and not node._inductor_training_available:
+            raise RuntimeError("FlexSN Triton training kernel construction failed")
+
+    class PointwiseNode(torch.nn.Module):
+        def __init__(self, inner: torch.nn.Module):
+            super().__init__()
+            self.inner = inner
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return (self.inner(x * 1.1) + 0.2) * 0.9
+
+    return PointwiseNode(node).to(device)
+
+
+def _reset(model: torch.nn.Module) -> None:
+    from spikingjelly.activation_based import functional
+
+    functional.reset_net(model)
+
+
+def _run_once(model: torch.nn.Module, x: torch.Tensor, phase: str):
+    _reset(model)
+    if phase == "inference":
+        with torch.inference_mode():
+            return model(x), None
+    x.grad = None
+    output = model(x)
+    output.sum().backward()
+    return output.detach(), x.grad.detach().clone()
+
+
+def _generated_code(cache_dir: Path) -> tuple[list[str], int, int]:
+    paths = sorted(cache_dir.rglob("output_code.py"))
+    allocation_count = 0
+    launch_count = 0
+    for path in paths:
+        text = path.read_text(encoding="utf-8", errors="replace")
+        allocation_count += text.count("empty_strided_") + text.count(
+            "alloc_from_pool("
+        )
+        launch_count += text.count(".run(") + text.count("extern_kernels.")
+    return [str(path) for path in paths], allocation_count, launch_count
+
+
+def _profile_physical_step(model, x, phase: str) -> tuple[int | None, int | None]:
+    if x.device.type != "cuda":
+        return None, None
+    activities = [
+        torch.profiler.ProfilerActivity.CPU,
+        torch.profiler.ProfilerActivity.CUDA,
+    ]
+    with torch.profiler.profile(activities=activities, profile_memory=True) as profile:
+        _run_once(model, x, phase)
+    kernel_events = [
+        event
+        for event in profile.events()
+        if event.device_type == torch.autograd.DeviceType.CUDA
+        and not event.name.startswith(("Memcpy", "Memset"))
+        and event.name != "[memory]"
+    ]
+    allocations = [
+        event
+        for event in profile.events()
+        if event.name == "[memory]"
+        and getattr(
+            event,
+            "device_memory_usage",
+            getattr(event, "cuda_memory_usage", 0),
+        )
+        > 0
+    ]
+    return len(allocations), len(kernel_events)
+
+
+def _clear_dynamo_state() -> None:
+    torch._dynamo.reset()
+    counters = getattr(getattr(torch._dynamo, "utils", None), "counters", None)
+    if counters is not None:
+        counters.clear()
+
+
+def _dynamo_counts() -> dict[str, int]:
+    counters = getattr(getattr(torch._dynamo, "utils", None), "counters", {})
+    return {
+        "graph_count": int(counters.get("stats", {}).get("unique_graphs", 0)),
+        "graph_break_count": int(sum(counters.get("graph_break", {}).values())),
+        "recompile_count": int(sum(counters.get("recompiles", {}).values())),
+    }
+
+
+def run_child(args: argparse.Namespace) -> dict[str, Any]:
+    prerequisite = _prerequisite_failure(args.case, args.phase)
+    if prerequisite is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(prerequisite, indent=2), encoding="utf-8")
+        return prerequisite
+
+    source_root = Path(
+        os.environ.get("SJ_BENCH_SOURCE_ROOT", Path(__file__).parents[1])
+    ).resolve()
+    sys.path.insert(0, str(source_root))
+    import spikingjelly
+
+    package_file = Path(spikingjelly.__file__).resolve()
+    try:
+        package_file.relative_to(source_root)
+    except ValueError as error:
+        raise RuntimeError(
+            f"imported spikingjelly from {package_file}, outside source root {source_root}"
+        ) from error
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    torch.manual_seed(args.seed)
+    if device.type == "cuda":
+        torch.cuda.manual_seed_all(args.seed)
+    x_template = torch.randn(4, 2, 16, device=device)
+
+    explain_model = _build_model(args.case, device).train(args.phase == "training")
+    explain_input = x_template.clone().requires_grad_(args.phase == "training")
+    _clear_dynamo_state()
+    try:
+        explain_output = torch._dynamo.explain(explain_model)(explain_input)
+        graph_count = _graph_count(explain_output)
+        graph_break_count = _graph_break_count(explain_output)
+    except Exception as error:
+        result = _unsupported(
+            args.case,
+            args.phase,
+            "dynamo_explain_failed",
+            f"{type(error).__name__}: {error}",
+        )
+        result["status"] = "error"
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(result, indent=2), encoding="utf-8")
+        return result
+
+    eager_model = _build_model(args.case, device).train(args.phase == "training")
+    compiled_source = _build_model(args.case, device).train(args.phase == "training")
+    compiled_source.load_state_dict(eager_model.state_dict(), strict=True)
+    eager_x = x_template.clone().requires_grad_(args.phase == "training")
+    compiled_x = x_template.clone().requires_grad_(args.phase == "training")
+    eager_output, eager_grad = _run_once(eager_model, eager_x, args.phase)
+
+    _clear_dynamo_state()
+    compiled_model = torch.compile(
+        compiled_source,
+        backend="inductor",
+        fullgraph=True,
+        options={"triton.cudagraphs": False, "triton.cudagraph_trees": False},
+    )
+    try:
+        compiled_output, compiled_grad = _run_once(
+            compiled_model, compiled_x, args.phase
+        )
+        compiled_output_2, _ = _run_once(compiled_model, compiled_x, args.phase)
+        if device.type == "cuda":
+            torch.cuda.synchronize(device)
+        allocation_count, kernel_launch_count = _profile_physical_step(
+            compiled_model, compiled_x, args.phase
+        )
+        generated_paths, generated_allocations, generated_launches = _generated_code(
+            Path(os.environ["TORCHINDUCTOR_CACHE_DIR"])
+        )
+        compile_counts = _dynamo_counts()
+        result = {
+            "case": args.case,
+            "phase": args.phase,
+            "status": "ok",
+            "reason_code": None,
+            "reason": None,
+            "device": str(device),
+            "spikingjelly_file": str(package_file),
+            "graph_count": compile_counts["graph_count"],
+            "graph_break_count": compile_counts["graph_break_count"],
+            "recompile_count": compile_counts["recompile_count"],
+            "explain_graph_count": graph_count,
+            "explain_graph_break_count": graph_break_count,
+            "generated_code_paths": generated_paths,
+            "generated_allocation_count": generated_allocations,
+            "generated_launch_count": generated_launches,
+            "allocation_count": allocation_count,
+            "kernel_launch_count": kernel_launch_count,
+            "physical_metrics_source": "torch.profiler"
+            if device.type == "cuda"
+            else None,
+            "output_close": torch.allclose(
+                eager_output, compiled_output, rtol=1e-4, atol=1e-5
+            ),
+            "second_output_close": torch.allclose(
+                eager_output, compiled_output_2, rtol=1e-4, atol=1e-5
+            ),
+            "gradient_close": (
+                torch.allclose(eager_grad, compiled_grad, rtol=1e-3, atol=1e-4)
+                if eager_grad is not None and compiled_grad is not None
+                else None
+            ),
+        }
+    except Exception as error:
+        result = _unsupported(
+            args.case,
+            args.phase,
+            "fullgraph_compile_failed",
+            f"{type(error).__name__}: {error}",
+        )
+        result.update(
+            {
+                "status": "error",
+                "explain_graph_count": graph_count,
+                "explain_graph_break_count": graph_break_count,
+            }
+        )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    return result
+
+
+def run_parent(args: argparse.Namespace) -> dict[str, Any]:
+    output = args.output.resolve()
+    work_dir = output.parent / f"{output.stem}-artifacts-{uuid4().hex[:8]}"
+    work_dir.mkdir(parents=True, exist_ok=True)
+    results = []
+    for case in args.cases:
+        for phase in args.phases:
+            child_output = work_dir / f"{case}-{phase}.json"
+            cache_dir = work_dir / "cache" / f"{case}-{phase}"
+            env = os.environ.copy()
+            env["SJ_USE_TRITON_OP"] = (
+                "1" if case in {"triton_lif", "triton_flexsn"} else "0"
+            )
+            env["SJ_USE_WRAP_TRITON"] = (
+                "1" if case in {"custom_lif", "triton_lif", "triton_flexsn"} else "0"
+            )
+            env["TORCHINDUCTOR_CACHE_DIR"] = str(cache_dir)
+            env["TORCH_COMPILE_DEBUG"] = "1"
+            command = [
+                sys.executable,
+                str(Path(__file__).resolve()),
+                "--child",
+                "--case",
+                case,
+                "--phase",
+                phase,
+                "--seed",
+                str(args.seed),
+                "--output",
+                str(child_output),
+            ]
+            completed = subprocess.run(
+                command, env=env, capture_output=True, text=True, timeout=args.timeout
+            )
+            if child_output.exists():
+                result = json.loads(child_output.read_text(encoding="utf-8"))
+            else:
+                result = _unsupported(
+                    case, phase, "child_process_failed", completed.stderr[-4000:]
+                )
+                result["status"] = "error"
+                result["returncode"] = completed.returncode
+            results.append(result)
+            print(json.dumps(result), flush=True)
+
+    payload = {
+        "schema_version": 1,
+        "torch": torch.__version__,
+        "cuda": torch.version.cuda,
+        "results": results,
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return payload
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Probe SNN torch.compile operator boundaries"
+    )
+    parser.add_argument("--child", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--case", choices=CASES)
+    parser.add_argument("--phase", choices=PHASES)
+    parser.add_argument("--cases", nargs="+", choices=CASES, default=list(CASES))
+    parser.add_argument("--phases", nargs="+", choices=PHASES, default=list(PHASES))
+    parser.add_argument("--seed", type=int, default=20260808)
+    parser.add_argument("--timeout", type=int, default=600)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    if args.child:
+        if args.case is None or args.phase is None:
+            raise ValueError("--child requires --case and --phase")
+        result = run_child(args)
+        print("JSON_RESULT=" + json.dumps(result), flush=True)
+    else:
+        run_parent(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/test/test_snn_single_gpu_benchmark.py
+++ b/benchmark/test/test_snn_single_gpu_benchmark.py
@@ -134,22 +134,13 @@ def test_isolated_case_timeout_kills_process_group(monkeypatch):
 
 def test_stop_monitor_tolerates_exit_race():
     class ExitedMonitor:
-        def __init__(self):
-            self.wait_calls = []
-
         def poll(self):
             return None
 
         def terminate(self):
             raise ProcessLookupError
 
-        def wait(self, timeout=None):
-            self.wait_calls.append(timeout)
-
-    monitor = ExitedMonitor()
-    benchmark._stop_monitor(monitor)
-
-    assert monitor.wait_calls == [10]
+    benchmark._stop_monitor(ExitedMonitor())
 
 
 def test_physical_gpu_selector_uses_cuda_visible_devices(monkeypatch):

--- a/benchmark/test/test_snn_single_gpu_benchmark.py
+++ b/benchmark/test/test_snn_single_gpu_benchmark.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -62,6 +63,75 @@ def test_source_parser_requires_one_baseline_and_one_candidate(tmp_path: Path):
         benchmark.parse_source_specs([f"baseline={tmp_path}", f"baseline={tmp_path}"])
 
 
+def test_matrix_records_child_timeouts(monkeypatch, tmp_path: Path):
+    sources = []
+    for label in ("baseline", "candidate"):
+        root = tmp_path / label
+        package = root / "spikingjelly"
+        package.mkdir(parents=True)
+        (package / "__init__.py").write_text("", encoding="utf-8")
+        sources.extend(["--source", f"{label}={root}"])
+    args = benchmark.build_parser().parse_args(
+        [
+            "matrix",
+            *sources,
+            "--models",
+            "sew_resnet18",
+            "--phases",
+            "inference",
+            "--executions",
+            "eager",
+            "--rounds",
+            "1",
+            "--timeout",
+            "1",
+            "--output-dir",
+            str(tmp_path / "output"),
+        ]
+    )
+
+    def timeout(command, _env, seconds):
+        raise benchmark.subprocess.TimeoutExpired(command, seconds)
+
+    monkeypatch.setattr(benchmark, "_run_isolated_case", timeout)
+    payload = benchmark.run_matrix(args)
+
+    assert len(payload["records"]) == 2
+    assert len(payload["comparison"]["failures"]) == 2
+    assert payload["comparison"]["acceptance"]["accepted"] is False
+
+
+def test_isolated_case_timeout_kills_process_group(monkeypatch):
+    class HungProcess:
+        pid = 123
+        returncode = None
+
+        def __init__(self):
+            self.calls = 0
+
+        def communicate(self, timeout=None):
+            self.calls += 1
+            if self.calls == 1:
+                raise benchmark.subprocess.TimeoutExpired(["case"], timeout)
+            return "partial stdout", "partial stderr"
+
+    process = HungProcess()
+    killed = []
+    monkeypatch.setattr(
+        benchmark.subprocess, "Popen", lambda *_args, **_kwargs: process
+    )
+    monkeypatch.setattr(
+        benchmark.os, "killpg", lambda pid, sig: killed.append((pid, sig))
+    )
+
+    with pytest.raises(benchmark.subprocess.TimeoutExpired) as raised:
+        benchmark._run_isolated_case(["case"], {}, 1)
+
+    assert killed == [(123, benchmark.signal.SIGKILL)]
+    assert raised.value.stdout == "partial stdout"
+    assert raised.value.stderr == "partial stderr"
+
+
 def test_physical_gpu_selector_uses_cuda_visible_devices(monkeypatch):
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3,GPU-example")
 
@@ -70,6 +140,30 @@ def test_physical_gpu_selector_uses_cuda_visible_devices(monkeypatch):
         benchmark._physical_gpu_selector(benchmark.torch.device("cuda", 1))
         == "GPU-example"
     )
+
+
+def test_environment_metadata_filters_secrets(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("SJ_MODE", "benchmark")
+    monkeypatch.setenv("SJ_API_TOKEN", "secret")
+    monkeypatch.setattr(
+        benchmark.torch.cuda,
+        "get_device_properties",
+        lambda _device: SimpleNamespace(
+            name="test-gpu", major=8, minor=0, total_memory=1024
+        ),
+    )
+    monkeypatch.setattr(benchmark, "_git_metadata", lambda _root: {})
+    monkeypatch.setattr(benchmark, "_nvidia_snapshot", lambda _selector: None)
+
+    metadata = benchmark._environment_metadata(
+        tmp_path,
+        benchmark.torch.device("cuda", 0),
+        tmp_path / "spikingjelly" / "__init__.py",
+        "0",
+    )
+
+    assert metadata["environment"]["SJ_MODE"] == "benchmark"
+    assert "SJ_API_TOKEN" not in metadata["environment"]
 
 
 def test_aggregate_records_reports_paired_latency_and_memory_changes():
@@ -98,6 +192,24 @@ def test_aggregate_records_reports_paired_latency_and_memory_changes():
     assert acceptance["accepted"] is False
 
 
+def test_aggregate_records_compares_only_matching_successful_rounds():
+    records = [
+        _record("baseline", 1, 10.0, 1000),
+        _record("baseline", 2, 11.0, 1000),
+        _record("candidate", 2, 9.0, 800),
+        _record("candidate", 3, 8.0, 800),
+        {"source_label": "candidate", "round": 1, "status": "error"},
+    ]
+
+    result = benchmark.aggregate_records(records, "baseline", "candidate")[
+        "comparisons"
+    ][0]
+
+    assert result["rounds"] == 1
+    assert result["baseline_round_medians_ms"] == [11.0]
+    assert result["candidate_round_medians_ms"] == [9.0]
+
+
 def test_probe_marks_unmeasured_physical_metrics_as_null():
     result = probe._unsupported(
         "triton_lif", "training", "cuda_required", "CUDA required"
@@ -107,6 +219,58 @@ def test_probe_marks_unmeasured_physical_metrics_as_null():
     assert result["kernel_launch_count"] is None
     assert result["allocation_count"] is None
     assert result["graph_break_count"] is None
+
+
+def test_probe_records_child_timeouts(monkeypatch, tmp_path: Path):
+    args = probe.build_parser().parse_args(
+        [
+            "--cases",
+            "torch_lif",
+            "--phases",
+            "inference",
+            "--timeout",
+            "1",
+            "--output",
+            str(tmp_path / "probe.json"),
+        ]
+    )
+
+    def timeout(command, **kwargs):
+        raise probe.subprocess.TimeoutExpired(command, kwargs["timeout"])
+
+    monkeypatch.setattr(probe.subprocess, "run", timeout)
+    result = probe.run_parent(args)["results"][0]
+
+    assert result["status"] == "error"
+    assert result["reason_code"] == "child_process_timeout"
+    assert result["registration_environment"] == {
+        "SJ_USE_TRITON_OP": "0",
+        "SJ_USE_WRAP_TRITON": "0",
+    }
+
+
+@pytest.mark.parametrize(
+    ("phase", "message"),
+    [
+        ("inference", "inference kernel construction failed"),
+        ("training", "training kernel construction failed"),
+    ],
+)
+def test_flexsn_probe_rejects_unavailable_phase_kernel(monkeypatch, phase, message):
+    from spikingjelly.activation_based.neuron import flexsn
+
+    class UnavailableFlexSN(probe.torch.nn.Module):
+        _inductor_inference_available = False
+        _inductor_inference_final_state_available = False
+        _inductor_training_available = False
+
+        def __init__(self, *_args, **_kwargs):
+            super().__init__()
+
+    monkeypatch.setattr(flexsn, "FlexSN", UnavailableFlexSN)
+
+    with pytest.raises(RuntimeError, match=message):
+        probe._build_model("triton_flexsn", phase, probe.torch.device("cpu"))
 
 
 def test_flexsn_probe_core_is_differentiable():

--- a/benchmark/test/test_snn_single_gpu_benchmark.py
+++ b/benchmark/test/test_snn_single_gpu_benchmark.py
@@ -251,17 +251,6 @@ def test_aggregate_records_rejects_invalid_compile_metrics(metric):
     assert comparison["performance_gates"]["met"] is False
 
 
-def test_probe_marks_unmeasured_physical_metrics_as_null():
-    result = probe._unsupported(
-        "triton_lif", "training", "cuda_required", "CUDA required"
-    )
-
-    assert result["status"] == "unsupported"
-    assert result["kernel_launch_count"] is None
-    assert result["allocation_count"] is None
-    assert result["graph_break_count"] is None
-
-
 @pytest.mark.parametrize(
     ("case", "missing_api", "reason_code"),
     [
@@ -327,6 +316,9 @@ def test_probe_records_child_timeouts(monkeypatch, tmp_path: Path):
 
     assert result["status"] == "error"
     assert result["reason_code"] == "child_process_timeout"
+    assert result["kernel_launch_count"] is None
+    assert result["allocation_count"] is None
+    assert result["graph_break_count"] is None
     assert result["registration_environment"] == {
         "SJ_USE_TRITON_OP": "0",
         "SJ_USE_WRAP_TRITON": "0",

--- a/benchmark/test/test_snn_single_gpu_benchmark.py
+++ b/benchmark/test/test_snn_single_gpu_benchmark.py
@@ -255,6 +255,25 @@ def test_probe_marks_unmeasured_physical_metrics_as_null():
     assert result["graph_break_count"] is None
 
 
+@pytest.mark.parametrize(
+    ("case", "missing_api", "reason_code"),
+    [
+        ("triton_flexsn", "triton_op", "triton_op_unavailable"),
+        ("custom_lif", "wrap_triton", "wrap_triton_unavailable"),
+    ],
+)
+def test_probe_checks_registration_prerequisites(
+    monkeypatch, case, missing_api, reason_code
+):
+    monkeypatch.setattr(probe.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(probe.importlib.util, "find_spec", lambda _name: object())
+    monkeypatch.delattr(probe.torch.library, missing_api, raising=False)
+
+    result = probe._prerequisite_failure(case, "inference")
+
+    assert result["reason_code"] == reason_code
+
+
 def test_generated_code_counts_only_kernel_call_sites(tmp_path: Path):
     generated = tmp_path / "output_code.py"
     generated.write_text(
@@ -300,6 +319,27 @@ def test_probe_records_child_timeouts(monkeypatch, tmp_path: Path):
         "SJ_USE_TRITON_OP": "0",
         "SJ_USE_WRAP_TRITON": "0",
     }
+
+
+def test_probe_preserves_failed_child_stderr(monkeypatch, tmp_path: Path):
+    args = probe.build_parser().parse_args(
+        [
+            "--cases",
+            "torch_lif",
+            "--phases",
+            "inference",
+            "--output",
+            str(tmp_path / "probe.json"),
+        ]
+    )
+    stderr = "root cause\n" + "x" * 5000
+    completed = SimpleNamespace(stderr=stderr, returncode=1)
+    monkeypatch.setattr(probe.subprocess, "run", lambda *_args, **_kwargs: completed)
+
+    result = probe.run_parent(args)["results"][0]
+
+    assert Path(result["stderr_path"]).read_text(encoding="utf-8") == stderr
+    assert result["stderr_path"] in result["reason"]
 
 
 @pytest.mark.parametrize(

--- a/benchmark/test/test_snn_single_gpu_benchmark.py
+++ b/benchmark/test/test_snn_single_gpu_benchmark.py
@@ -132,6 +132,26 @@ def test_isolated_case_timeout_kills_process_group(monkeypatch):
     assert raised.value.stderr == "partial stderr"
 
 
+def test_stop_monitor_tolerates_exit_race():
+    class ExitedMonitor:
+        def __init__(self):
+            self.wait_calls = []
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            raise ProcessLookupError
+
+        def wait(self, timeout=None):
+            self.wait_calls.append(timeout)
+
+    monitor = ExitedMonitor()
+    benchmark._stop_monitor(monitor)
+
+    assert monitor.wait_calls == [10]
+
+
 def test_physical_gpu_selector_uses_cuda_visible_devices(monkeypatch):
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3,GPU-example")
 
@@ -192,6 +212,20 @@ def test_aggregate_records_reports_paired_latency_and_memory_changes():
     assert acceptance["accepted"] is False
 
 
+def test_aggregate_records_rejects_zero_latency_measurements():
+    records = [
+        _record("baseline", 1, 0.0, 1000),
+        _record("candidate", 1, 0.0, 800),
+    ]
+
+    comparison = benchmark.aggregate_records(records, "baseline", "candidate")
+    result = comparison["comparisons"][0]
+
+    assert result["latency_change_pct"] is None
+    assert result["candidate_round_spread"] is None
+    assert comparison["acceptance"]["accepted"] is False
+
+
 def test_aggregate_records_compares_only_matching_successful_rounds():
     records = [
         _record("baseline", 1, 10.0, 1000),
@@ -219,6 +253,25 @@ def test_probe_marks_unmeasured_physical_metrics_as_null():
     assert result["kernel_launch_count"] is None
     assert result["allocation_count"] is None
     assert result["graph_break_count"] is None
+
+
+def test_generated_code_counts_only_kernel_call_sites(tmp_path: Path):
+    generated = tmp_path / "output_code.py"
+    generated.write_text(
+        """
+triton_poi_fused_0.run(arg0, arg1)
+flexsn_forward_kernel_0.run(arg0, arg1)
+buf0 = extern_kernels.mm(arg0, arg1)
+wrapper.run(arg0)
+benchmark.run(arg0)
+""",
+        encoding="utf-8",
+    )
+
+    paths, _allocations, launches = probe._generated_code(tmp_path)
+
+    assert paths == [str(generated)]
+    assert launches == 3
 
 
 def test_probe_records_child_timeouts(monkeypatch, tmp_path: Path):

--- a/benchmark/test/test_snn_single_gpu_benchmark.py
+++ b/benchmark/test/test_snn_single_gpu_benchmark.py
@@ -21,6 +21,7 @@ def _record(label: str, round_index: int, latency_ms: float, peak_bytes: int):
         },
         "timing": {"median_ms": latency_ms},
         "memory": {"peak_allocated_bytes": peak_bytes},
+        "dynamo": {"graph_break_count": 0, "recompile_count": 0},
     }
 
 
@@ -98,7 +99,7 @@ def test_matrix_records_child_timeouts(monkeypatch, tmp_path: Path):
 
     assert len(payload["records"]) == 2
     assert len(payload["comparison"]["failures"]) == 2
-    assert payload["comparison"]["acceptance"]["accepted"] is False
+    assert payload["comparison"]["performance_gates"]["met"] is False
 
 
 def test_isolated_case_timeout_kills_process_group(monkeypatch):
@@ -195,12 +196,12 @@ def test_aggregate_records_reports_paired_latency_and_memory_changes():
     assert result["peak_allocated_change_pct"] == pytest.approx(-20.0)
     assert result["all_candidate_rounds_faster"] is True
     assert result["candidate_round_spread"] == pytest.approx(9.0 / 8.0)
-    acceptance = comparison["acceptance"]
-    assert acceptance["qualifying_model_families"] == ["sew_resnet18"]
-    assert acceptance["at_least_two_model_families"] is False
-    assert acceptance["three_stable_rounds_per_case"] is False
-    assert acceptance["no_case_latency_regression_over_3pct"] is True
-    assert acceptance["accepted"] is False
+    gates = comparison["performance_gates"]
+    assert gates["qualifying_model_families"] == ["sew_resnet18"]
+    assert gates["at_least_two_model_families"] is False
+    assert gates["three_stable_rounds_per_case"] is False
+    assert gates["no_case_latency_regression_over_3pct"] is True
+    assert gates["met"] is False
 
 
 def test_aggregate_records_rejects_zero_latency_measurements():
@@ -214,7 +215,7 @@ def test_aggregate_records_rejects_zero_latency_measurements():
 
     assert result["latency_change_pct"] is None
     assert result["candidate_round_spread"] is None
-    assert comparison["acceptance"]["accepted"] is False
+    assert comparison["performance_gates"]["met"] is False
 
 
 def test_aggregate_records_compares_only_matching_successful_rounds():
@@ -233,6 +234,21 @@ def test_aggregate_records_compares_only_matching_successful_rounds():
     assert result["rounds"] == 1
     assert result["baseline_round_medians_ms"] == [11.0]
     assert result["candidate_round_medians_ms"] == [9.0]
+
+
+@pytest.mark.parametrize("metric", ["graph_break_count", "recompile_count"])
+def test_aggregate_records_rejects_invalid_compile_metrics(metric):
+    baseline = _record("baseline", 1, 10.0, 1000)
+    candidate = _record("candidate", 1, 9.0, 800)
+    candidate["dynamo"][metric] = 1
+
+    comparison = benchmark.aggregate_records(
+        [baseline, candidate], "baseline", "candidate"
+    )
+
+    assert comparison["failures"] == [candidate]
+    assert comparison["comparisons"] == []
+    assert comparison["performance_gates"]["met"] is False
 
 
 def test_probe_marks_unmeasured_physical_metrics_as_null():
@@ -257,7 +273,12 @@ def test_probe_checks_registration_prerequisites(
     monkeypatch, case, missing_api, reason_code
 ):
     monkeypatch.setattr(probe.torch.cuda, "is_available", lambda: True)
-    monkeypatch.setattr(probe.importlib.util, "find_spec", lambda _name: object())
+    find_spec = probe.importlib.util.find_spec
+    monkeypatch.setattr(
+        probe.importlib.util,
+        "find_spec",
+        lambda name: object() if name == "triton" else find_spec(name),
+    )
     monkeypatch.delattr(probe.torch.library, missing_api, raising=False)
 
     result = probe._prerequisite_failure(case, "inference")

--- a/benchmark/test/test_snn_single_gpu_benchmark.py
+++ b/benchmark/test/test_snn_single_gpu_benchmark.py
@@ -1,0 +1,128 @@
+from pathlib import Path
+
+import pytest
+
+import benchmark.benchmark_snn_single_gpu as benchmark
+import benchmark.probe_snn_compile_boundary as probe
+
+
+def _record(label: str, round_index: int, latency_ms: float, peak_bytes: int):
+    return {
+        "source_label": label,
+        "round": round_index,
+        "case": {
+            "model": "sew_resnet18",
+            "phase": "training",
+            "execution": "compile",
+            "T": 4,
+            "batch_size": 32,
+            "image_size": 224,
+        },
+        "timing": {"median_ms": latency_ms},
+        "memory": {"peak_allocated_bytes": peak_bytes},
+    }
+
+
+def test_case_parser_keeps_required_reproduction_fields(tmp_path: Path):
+    args = benchmark.build_parser().parse_args(
+        [
+            "case",
+            "--model",
+            "spikformer_ti",
+            "--phase",
+            "inference",
+            "--execution",
+            "compile",
+            "--batch-size",
+            "64",
+            "--warmup",
+            "100",
+            "--steps",
+            "500",
+            "--output",
+            str(tmp_path / "result.json"),
+        ]
+    )
+
+    assert (args.T, args.image_size, args.seed) == (4, 224, 20260808)
+    assert (args.model, args.phase, args.execution) == (
+        "spikformer_ti",
+        "inference",
+        "compile",
+    )
+
+
+def test_source_parser_requires_one_baseline_and_one_candidate(tmp_path: Path):
+    package = tmp_path / "spikingjelly"
+    package.mkdir()
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    with pytest.raises(ValueError, match="exactly two"):
+        benchmark.parse_source_specs([f"baseline={tmp_path}"])
+    with pytest.raises(ValueError, match="unique"):
+        benchmark.parse_source_specs([f"baseline={tmp_path}", f"baseline={tmp_path}"])
+
+
+def test_physical_gpu_selector_uses_cuda_visible_devices(monkeypatch):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3,GPU-example")
+
+    assert benchmark._physical_gpu_selector(benchmark.torch.device("cuda", 0)) == "3"
+    assert (
+        benchmark._physical_gpu_selector(benchmark.torch.device("cuda", 1))
+        == "GPU-example"
+    )
+
+
+def test_aggregate_records_reports_paired_latency_and_memory_changes():
+    records = [
+        _record("baseline", 1, 10.0, 1000),
+        _record("candidate", 1, 9.0, 800),
+        _record("candidate", 2, 8.0, 800),
+        _record("baseline", 2, 10.0, 1000),
+        _record("baseline", 3, 11.0, 1000),
+        _record("candidate", 3, 9.0, 800),
+    ]
+
+    comparison = benchmark.aggregate_records(records, "baseline", "candidate")
+    result = comparison["comparisons"][0]
+
+    assert result["rounds"] == 3
+    assert result["latency_change_pct"] == pytest.approx(-10.0)
+    assert result["peak_allocated_change_pct"] == pytest.approx(-20.0)
+    assert result["all_candidate_rounds_faster"] is True
+    assert result["candidate_round_spread"] == pytest.approx(9.0 / 8.0)
+    acceptance = comparison["acceptance"]
+    assert acceptance["qualifying_model_families"] == ["sew_resnet18"]
+    assert acceptance["at_least_two_model_families"] is False
+    assert acceptance["three_stable_rounds_per_case"] is False
+    assert acceptance["no_case_latency_regression_over_3pct"] is True
+    assert acceptance["accepted"] is False
+
+
+def test_probe_marks_unmeasured_physical_metrics_as_null():
+    result = probe._unsupported(
+        "triton_lif", "training", "cuda_required", "CUDA required"
+    )
+
+    assert result["status"] == "unsupported"
+    assert result["kernel_launch_count"] is None
+    assert result["allocation_count"] is None
+    assert result["graph_break_count"] is None
+
+
+def test_flexsn_probe_core_is_differentiable():
+    x = probe.torch.randn(2, 3, requires_grad=True)
+    state = probe.torch.zeros_like(x)
+
+    output, next_state = probe._lif_core(x, state)
+    (output + next_state).sum().backward()
+
+    assert x.grad is not None
+
+
+def test_probe_clears_dynamo_counters():
+    counters = probe.torch._dynamo.utils.counters
+    counters["stats"]["unique_graphs"] = 7
+
+    probe._clear_dynamo_state()
+
+    assert not counters

--- a/spikingjelly/activation_based/neuron/flexsn.py
+++ b/spikingjelly/activation_based/neuron/flexsn.py
@@ -522,7 +522,7 @@ class FlexSNKernel:
         * **中文**
 
         ``FlexSNKernel`` 可以根据自定义的 PyTorch 单步函数 ``core`` 生成 Triton 多步脉冲神经元核。
-        不同于 :class:`FlexSN` ， ``FlexSNKernel`` 是对底层 custom op 调度的轻量 ``Callable`` 封装。
+        不同于 :class:`FlexSN` ， ``FlexSNKernel`` 是对底层 ``torch.library`` registered op 调度的轻量 ``Callable`` 封装。
 
         实例化后， ``FlexSNKernel`` 对象接受的输入参数为 ``[*input_seqs, *states]`` ，其中 ``input_seqs`` 是
         ``num_inputs`` 个输入序列，``states`` 是 ``num_states`` 个初始状态；返回值为 ``[*output_seqs, *state_seqs]`` ，
@@ -561,7 +561,7 @@ class FlexSNKernel:
         from a customized PyTorch single-step function ``core`` via FlexSN's
         triton / inductor backend.
         It is a lightweight ``Callable`` wrapper over the underlying FlexSN
-        custom-op dispatch path.
+        ``torch.library`` registered-op dispatch path.
 
         The input arguments of a ``FlexSNKernel`` object is ``[*input_seqs, *states]`` , where ``input_seqs`` is
         a list of input sequences, ``states`` is a list of initial states; the return value is

--- a/spikingjelly/activation_based/triton_kernel/flexsn/custom_ops.py
+++ b/spikingjelly/activation_based/triton_kernel/flexsn/custom_ops.py
@@ -7,15 +7,17 @@
 
 * **中文**
 
-``custom_ops`` 模块为 FlexSN 的共享 Triton 路径提供底层 opaque custom op。
+``custom_ops`` 模块为 FlexSN 的共享 Triton 路径提供底层 registered op。
 它负责在 Python 侧保存 Triton kernel 与元数据，并通过轻量级整数 ``handle``
-把这些 kernel 暴露给 ``torch.compile`` / AOTAutograd。
+把这些 kernel 暴露给 ``torch.compile`` / AOTAutograd。默认注册使用与其他 Triton
+神经元一致的 ``torch.library.triton_op`` + ``wrap_triton``；设置
+``SJ_USE_TRITON_OP=0`` 后使用 opaque ``custom_op`` fallback。
 
 该模块的主要职责包括：
 
 * 在 Python 注册表中维护 FlexSN kernel handle；
-* 将前向 / 反向封装为 ``torch.library`` custom op，避免编译器追踪 Python
-  kernel 对象与 Triton launcher 细节；
+* 将前向 / 反向封装为 ``torch.library`` registered op，避免编译器追踪 Python
+  kernel 对象与 launcher 细节，同时让默认路径看到包装后的 Triton launch；
 * 为 fake tensor、autograd setup/backward、final-state fast path 提供辅助实现。
 
 通常用户不需要直接调用这些函数；它们主要由
@@ -28,16 +30,19 @@
 
 * **English**
 
-The ``custom_ops`` module provides the low-level opaque custom ops used by
+The ``custom_ops`` module provides the low-level registered ops used by
 FlexSN's shared Triton execution path. It stores Triton kernels and metadata in
 a Python-side registry and exposes them to ``torch.compile`` / AOTAutograd
-through lightweight integer ``handle`` values.
+through lightweight integer ``handle`` values. By default, registration uses
+the same ``torch.library.triton_op`` + ``wrap_triton`` path as the other Triton
+neurons; ``SJ_USE_TRITON_OP=0`` selects the opaque ``custom_op`` fallback.
 
 Its main responsibilities are:
 
 * maintaining the Python-side FlexSN kernel-handle registry;
-* wrapping forward and backward as ``torch.library`` custom ops so the
-  compiler does not trace Python kernel objects or Triton launcher internals;
+* wrapping forward and backward as ``torch.library`` registered ops so the
+  compiler can see wrapped Triton launches without tracing Python kernel objects
+  or launcher internals;
 * providing helpers for fake tensors, autograd setup/backward, and final-state
   fast paths.
 
@@ -61,6 +66,7 @@ import torch
 from spikingjelly.logger import logger
 
 from .info import FlexSNInfo
+from ..triton_utils import register_op, wrap_triton
 from .wrapper import (
     flexsn_backward,
     flexsn_forward,
@@ -487,7 +493,7 @@ def _materialize_zero_state_args(
     if len(flat_args) == info.num_inputs:
         # In the common reset-before-forward path, FlexSN initial states are
         # zero tensors matching the per-step input shape. Materialize them
-        # inside the opaque custom op so compile graphs do not need explicit
+        # inside the registered op so compile graphs do not need explicit
         # ``zeros_like`` nodes in front of every neuron layer.
         if info.num_inputs == 0:
             raise ValueError("FlexSN custom ops require at least one input sequence.")
@@ -505,7 +511,7 @@ def _flexsn_inductor_inference_impl(
     with _device_guard(args):
         return list(
             flexsn_inference(
-                bundle.inference_kernel,
+                wrap_triton(bundle.inference_kernel),
                 bundle.inference_info,
                 *args,
             )
@@ -520,7 +526,7 @@ def _flexsn_inductor_inference_final_state_impl(
     with _device_guard(args):
         return list(
             flexsn_inference_final_state(
-                bundle.inference_final_state_kernel,
+                wrap_triton(bundle.inference_final_state_kernel),
                 bundle.inference_final_state_info,
                 *args,
             )
@@ -535,7 +541,7 @@ def _flexsn_inductor_training_impl(
     with _device_guard(args):
         return list(
             flexsn_forward(
-                bundle.forward_kernel,
+                wrap_triton(bundle.forward_kernel),
                 bundle.training_info,
                 *args,
             )
@@ -580,7 +586,7 @@ def _flexsn_inductor_backward_impl(
     with _device_guard([*grads, *saved, *templates]):
         return list(
             flexsn_backward(
-                bundle.backward_kernel,
+                wrap_triton(bundle.backward_kernel),
                 info,
                 *grads,
                 *saved,
@@ -590,7 +596,7 @@ def _flexsn_inductor_backward_impl(
         )
 
 
-@torch.library.custom_op("sj::flexsn_inductor_inference", mutates_args=())
+@register_op("sj::flexsn_inductor_inference", mutates_args=())
 def flexsn_inductor_inference(
     handle: int, flat_args: List[torch.Tensor]
 ) -> List[torch.Tensor]:
@@ -635,7 +641,7 @@ def flexsn_inductor_inference(
     return _flexsn_inductor_inference_impl(bundle, flat_args)
 
 
-@torch.library.custom_op("sj::flexsn_inductor_inference_final_state", mutates_args=())
+@register_op("sj::flexsn_inductor_inference_final_state", mutates_args=())
 def flexsn_inductor_inference_final_state(
     handle: int, flat_args: List[torch.Tensor]
 ) -> List[torch.Tensor]:
@@ -719,7 +725,7 @@ def _flexsn_inductor_inference_final_state_fake(
     return [*seq_outputs, *final_states]
 
 
-@torch.library.custom_op("sj::flexsn_inductor_training", mutates_args=())
+@register_op("sj::flexsn_inductor_training", mutates_args=())
 def flexsn_inductor_training(
     handle: int, flat_args: List[torch.Tensor]
 ) -> List[torch.Tensor]:
@@ -768,7 +774,7 @@ def flexsn_inductor_training(
     return _flexsn_inductor_training_impl(bundle, flat_args)
 
 
-@torch.library.custom_op("sj::flexsn_inductor_training_final_state", mutates_args=())
+@register_op("sj::flexsn_inductor_training_final_state", mutates_args=())
 def flexsn_inductor_training_final_state(
     handle: int, flat_args: List[torch.Tensor]
 ) -> List[torch.Tensor]:
@@ -852,7 +858,7 @@ def _flexsn_inductor_training_final_state_fake(
     return [*seq_outputs, *final_states, *extra_saved_tensors]
 
 
-@torch.library.custom_op("sj::flexsn_inductor_backward", mutates_args=())
+@register_op("sj::flexsn_inductor_backward", mutates_args=())
 def flexsn_inductor_backward(
     handle: int,
     grad_outputs: List[torch.Tensor],
@@ -1101,7 +1107,7 @@ torch.library.register_autograd(
 )
 
 logger.info(
-    "FlexSN custom operators registered: operators=%s fake_kernels=%s autograd_kernels=%s",
+    "FlexSN operators registered: operators=%s fake_kernels=%s autograd_kernels=%s",
     5,
     5,
     2,

--- a/spikingjelly/activation_based/triton_kernel/neuron_kernel/plif.py
+++ b/spikingjelly/activation_based/triton_kernel/neuron_kernel/plif.py
@@ -248,7 +248,8 @@ def _multistep_plif_backward_kernel_static(
     grad_s_seq_ptr,
     grad_v_seq_ptr,
     h_seq_ptr,
-    v_init_v_seq_ptr,
+    v_init_ptr,
+    v_seq_ptr,
     grad_x_seq_ptr,
     grad_v_init_ptr,
     grad_r_tau_ptr,
@@ -273,6 +274,18 @@ def _multistep_plif_backward_kernel_static(
     r_tau = tl.full([1], r_tau, dtype=compute_dtype)
     grad_v_acc = tl.zeros([1, BLOCK_NCL], dtype=compute_dtype)
     grad_r_tau_acc = tl.zeros([1, BLOCK_NCL], dtype=compute_dtype)
+
+    v_init_ptrs = tl.make_block_ptr(
+        v_init_ptr,
+        shape=(1, NCL),
+        strides=(NCL, 1),
+        offsets=(0, ncl_offset),
+        block_shape=(1, BLOCK_NCL),
+        order=(1, 0),
+    )
+    v_initial = tl.load(v_init_ptrs, boundary_check=(1,), padding_option="zero").to(
+        compute_dtype
+    )
 
     for t in tl.static_range(T - 1, -1, -1):
         grad_s_ptrs = tl.make_block_ptr(
@@ -308,17 +321,18 @@ def _multistep_plif_backward_kernel_static(
         h = tl.load(h_ptrs, boundary_check=(1,), padding_option="zero").to(
             compute_dtype
         )
-        v_last_ptrs = tl.make_block_ptr(
-            v_init_v_seq_ptr,
-            shape=(T + 1, NCL),
+        v_seq_ptrs = tl.make_block_ptr(
+            v_seq_ptr,
+            shape=(T, NCL),
             strides=(NCL, 1),
-            offsets=(t, ncl_offset),
+            offsets=(t - 1, ncl_offset),
             block_shape=(1, BLOCK_NCL),
             order=(1, 0),
         )
-        v_last = tl.load(v_last_ptrs, boundary_check=(0, 1), padding_option="zero").to(
-            compute_dtype
-        )
+        v_previous = tl.load(
+            v_seq_ptrs, boundary_check=(0, 1), padding_option="zero"
+        ).to(compute_dtype)
+        v_last = tl.where(t == 0, v_initial, v_previous)
 
         sg = sg_triton(h - v_threshold, alpha, sg_triton_id)
         grad_v_acc = grad_v + grad_v_acc
@@ -392,7 +406,8 @@ def _multistep_plif_backward_kernel_dynamic(
     grad_s_seq_ptr,
     grad_v_seq_ptr,
     h_seq_ptr,
-    v_init_v_seq_ptr,
+    v_init_ptr,
+    v_seq_ptr,
     grad_x_seq_ptr,
     grad_v_init_ptr,
     grad_r_tau_ptr,
@@ -417,6 +432,18 @@ def _multistep_plif_backward_kernel_dynamic(
     r_tau = tl.full([1], r_tau, dtype=compute_dtype)
     grad_v_acc = tl.zeros([1, BLOCK_NCL], dtype=compute_dtype)
     grad_r_tau_acc = tl.zeros([1, BLOCK_NCL], dtype=compute_dtype)
+
+    v_init_ptrs = tl.make_block_ptr(
+        v_init_ptr,
+        shape=(1, NCL),
+        strides=(NCL, 1),
+        offsets=(0, ncl_offset),
+        block_shape=(1, BLOCK_NCL),
+        order=(1, 0),
+    )
+    v_initial = tl.load(v_init_ptrs, boundary_check=(1,), padding_option="zero").to(
+        compute_dtype
+    )
 
     for t in tl.range(T - 1, -1, -1):
         grad_s_ptrs = tl.make_block_ptr(
@@ -452,17 +479,18 @@ def _multistep_plif_backward_kernel_dynamic(
         h = tl.load(h_ptrs, boundary_check=(1,), padding_option="zero").to(
             compute_dtype
         )
-        v_last_ptrs = tl.make_block_ptr(
-            v_init_v_seq_ptr,
-            shape=(T + 1, NCL),
+        v_seq_ptrs = tl.make_block_ptr(
+            v_seq_ptr,
+            shape=(T, NCL),
             strides=(NCL, 1),
-            offsets=(t, ncl_offset),
+            offsets=(t - 1, ncl_offset),
             block_shape=(1, BLOCK_NCL),
             order=(1, 0),
         )
-        v_last = tl.load(v_last_ptrs, boundary_check=(0, 1), padding_option="zero").to(
-            compute_dtype
-        )
+        v_previous = tl.load(
+            v_seq_ptrs, boundary_check=(0, 1), padding_option="zero"
+        ).to(compute_dtype)
+        v_last = tl.where(t == 0, v_initial, v_previous)
 
         sg = sg_triton(h - v_threshold, alpha, sg_triton_id)
         grad_v_acc = grad_v + grad_v_acc
@@ -592,7 +620,8 @@ def _launch_plif_backward_kernel(
     grad_s_seq: torch.Tensor,
     grad_v_seq: torch.Tensor,
     h_seq: torch.Tensor,
-    v_init_v_seq: torch.Tensor,
+    v_init: torch.Tensor,
+    v_seq: torch.Tensor,
     grad_x_seq: torch.Tensor,
     grad_v_init: torch.Tensor,
     grad_r_tau: torch.Tensor,
@@ -623,7 +652,8 @@ def _launch_plif_backward_kernel(
             grad_s_seq,
             grad_v_seq,
             h_seq,
-            v_init_v_seq,
+            v_init,
+            v_seq,
             grad_x_seq,
             grad_v_init,
             grad_r_tau,
@@ -1053,8 +1083,7 @@ def _setup_mp_plif_context(ctx, inputs, output):
     _, v_seq, h_seq = output
     storage_dtype = triton_neuron_dtype_id_to_torch_dtype(storage_dtype_id)
     v_storage = v_init.detach().to(dtype=storage_dtype).contiguous()
-    v_init_v_seq = torch.cat([v_storage.unsqueeze(0), v_seq.detach()], dim=0)
-    ctx.save_for_backward(h_seq, v_init_v_seq, r_tau)
+    ctx.save_for_backward(h_seq, v_storage, v_seq.detach(), r_tau)
     ctx.x_dtype = x_seq.dtype
     ctx.v_init_dtype = v_init.dtype
     ctx.r_tau_dtype = r_tau.dtype
@@ -1071,7 +1100,7 @@ def _setup_mp_plif_context(ctx, inputs, output):
 
 
 def _multistep_plif_mp_backward(ctx, grad_s_seq, grad_v_seq, grad_h_seq):
-    h_seq, v_init_v_seq, r_tau = ctx.saved_tensors
+    h_seq, v_init, v_seq, r_tau = ctx.saved_tensors
     del grad_h_seq
     storage_dtype = triton_neuron_dtype_id_to_torch_dtype(ctx.storage_dtype_id)
     spike_dtype = triton_neuron_dtype_id_to_torch_dtype(ctx.spike_dtype_id)
@@ -1082,7 +1111,8 @@ def _multistep_plif_mp_backward(ctx, grad_s_seq, grad_v_seq, grad_h_seq):
     grad_s_seq = grad_s_seq.contiguous()
     grad_v_seq = grad_v_seq.contiguous()
     h_seq = h_seq.contiguous()
-    v_init_v_seq = v_init_v_seq.contiguous()
+    v_init = v_init.contiguous()
+    v_seq = v_seq.contiguous()
     grad_x_seq = torch.empty(h_seq.shape, dtype=ctx.x_dtype, device=h_seq.device)
     grad_v_init = torch.empty(
         h_seq[0].shape, dtype=ctx.v_init_dtype, device=h_seq.device
@@ -1098,7 +1128,8 @@ def _multistep_plif_mp_backward(ctx, grad_s_seq, grad_v_seq, grad_h_seq):
         grad_s_seq,
         grad_v_seq,
         h_seq,
-        v_init_v_seq,
+        v_init,
+        v_seq,
         grad_x_seq,
         grad_v_init,
         grad_r_tau_seq,
@@ -1154,8 +1185,7 @@ def _setup_context(ctx, inputs, output):
         sg_alpha,
     ) = inputs[1:]
     _, v_seq, h_seq = output
-    v_init_v_seq = torch.cat([v_init.unsqueeze(0), v_seq], dim=0)
-    ctx.save_for_backward(h_seq, v_init_v_seq, r_tau)
+    ctx.save_for_backward(h_seq, v_init, v_seq, r_tau)
     ctx.decay_input = decay_input
     ctx.v_threshold = v_threshold
     ctx.v_reset = v_reset
@@ -1166,11 +1196,12 @@ def _setup_context(ctx, inputs, output):
 
 
 def _multistep_plif_backward(ctx, grad_s_seq, grad_v_seq, grad_h_seq):
-    h_seq, v_init_v_seq, r_tau = ctx.saved_tensors
+    h_seq, v_init, v_seq, r_tau = ctx.saved_tensors
     grad_s_seq = grad_s_seq.contiguous()
     grad_v_seq = grad_v_seq.contiguous()
     h_seq = h_seq.contiguous()
-    v_init_v_seq = v_init_v_seq.contiguous()
+    v_init = v_init.contiguous()
+    v_seq = v_seq.contiguous()
     grad_x_seq = torch.empty(
         grad_s_seq.shape, dtype=grad_s_seq.dtype, device=grad_s_seq.device
     )
@@ -1185,7 +1216,8 @@ def _multistep_plif_backward(ctx, grad_s_seq, grad_v_seq, grad_h_seq):
         grad_s_seq,
         grad_v_seq,
         h_seq,
-        v_init_v_seq,
+        v_init,
+        v_seq,
         grad_x_seq,
         grad_v_init,
         grad_r_tau,

--- a/spikingjelly/activation_based/triton_kernel/neuron_kernel/plif.py
+++ b/spikingjelly/activation_based/triton_kernel/neuron_kernel/plif.py
@@ -321,11 +321,12 @@ def _multistep_plif_backward_kernel_static(
         h = tl.load(h_ptrs, boundary_check=(1,), padding_option="zero").to(
             compute_dtype
         )
+        previous_t = tl.maximum(t - 1, 0)
         v_seq_ptrs = tl.make_block_ptr(
             v_seq_ptr,
             shape=(T, NCL),
             strides=(NCL, 1),
-            offsets=(t - 1, ncl_offset),
+            offsets=(previous_t, ncl_offset),
             block_shape=(1, BLOCK_NCL),
             order=(1, 0),
         )
@@ -479,11 +480,12 @@ def _multistep_plif_backward_kernel_dynamic(
         h = tl.load(h_ptrs, boundary_check=(1,), padding_option="zero").to(
             compute_dtype
         )
+        previous_t = tl.maximum(t - 1, 0)
         v_seq_ptrs = tl.make_block_ptr(
             v_seq_ptr,
             shape=(T, NCL),
             strides=(NCL, 1),
-            offsets=(t - 1, ncl_offset),
+            offsets=(previous_t, ncl_offset),
             block_shape=(1, BLOCK_NCL),
             order=(1, 0),
         )

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -908,7 +908,6 @@ def test_inductor_backward_impl_passes_state_templates_to_wrapper(monkeypatch):
     )
     seen = {}
     wrapped_kernel = object()
-    wrap_calls = []
 
     def fake_backward(
         kernel,
@@ -923,7 +922,7 @@ def test_inductor_backward_impl_passes_state_templates_to_wrapper(monkeypatch):
         return [torch.zeros_like(input_template), torch.zeros_like(state_template)]
 
     def fake_wrap_triton(kernel):
-        wrap_calls.append(kernel)
+        assert kernel is bundle.backward_kernel
         return wrapped_kernel
 
     monkeypatch.setattr(custom_ops, "flexsn_backward", fake_backward)
@@ -937,7 +936,6 @@ def test_inductor_backward_impl_passes_state_templates_to_wrapper(monkeypatch):
     )
 
     assert len(seen["input_templates"]) == 1
-    assert wrap_calls == [bundle.backward_kernel]
     assert seen["kernel"] is wrapped_kernel
     assert len(seen["state_templates"]) == 1
     assert seen["input_templates"][0].shape == input_template.shape

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -2029,7 +2029,6 @@ def test_flexsn_registered_operators_pass_opcheck(op_name):
         raise_exception=False,
     )
 
-    assert result
     assert set(result.values()) == {"SUCCESS"}
 
 

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -915,11 +915,13 @@ def test_inductor_backward_impl_passes_state_templates_to_wrapper(monkeypatch):
         input_templates=None,
         state_templates=None,
     ):
+        seen["kernel"] = kernel
         seen["input_templates"] = input_templates
         seen["state_templates"] = state_templates
         return [torch.zeros_like(input_template), torch.zeros_like(state_template)]
 
     monkeypatch.setattr(custom_ops, "flexsn_backward", fake_backward)
+    monkeypatch.setattr(custom_ops, "wrap_triton", lambda kernel: ("wrapped", kernel))
 
     grads = custom_ops._flexsn_inductor_backward_impl(
         bundle,
@@ -929,6 +931,7 @@ def test_inductor_backward_impl_passes_state_templates_to_wrapper(monkeypatch):
     )
 
     assert len(seen["input_templates"]) == 1
+    assert seen["kernel"] == ("wrapped", bundle.backward_kernel)
     assert len(seen["state_templates"]) == 1
     assert seen["input_templates"][0].shape == input_template.shape
     assert seen["state_templates"][0].shape == state_template.shape
@@ -1970,6 +1973,64 @@ def test_flexsnkernel_matches_inductor_backend(rng):
     torch.testing.assert_close(v_seq_kernel, v_seq_inductor)
     torch.testing.assert_close(x_kernel.grad, x_inductor.grad)
     torch.testing.assert_close(v0_kernel.grad, v0_inductor.grad)
+
+
+def test_flexsn_registered_operator_schemas_are_stable():
+    expected = {
+        "flexsn_inductor_inference": (
+            "sj::flexsn_inductor_inference(SymInt handle, Tensor[] flat_args) -> Tensor[]"
+        ),
+        "flexsn_inductor_inference_final_state": (
+            "sj::flexsn_inductor_inference_final_state(SymInt handle, Tensor[] flat_args) -> Tensor[]"
+        ),
+        "flexsn_inductor_training": (
+            "sj::flexsn_inductor_training(SymInt handle, Tensor[] flat_args) -> Tensor[]"
+        ),
+        "flexsn_inductor_training_final_state": (
+            "sj::flexsn_inductor_training_final_state(SymInt handle, Tensor[] flat_args) -> Tensor[]"
+        ),
+        "flexsn_inductor_backward": (
+            "sj::flexsn_inductor_backward(SymInt handle, Tensor[] grad_outputs, "
+            "Tensor[] saved_tensors, Tensor[] input_templates) -> Tensor[]"
+        ),
+    }
+
+    assert {
+        name: str(getattr(torch.ops.sj, name).default._schema) for name in expected
+    } == expected
+
+
+@pytest.mark.parametrize(
+    "op_name",
+    ["flexsn_inductor_inference", "flexsn_inductor_training"],
+)
+def test_flexsn_registered_operators_pass_opcheck(op_name):
+    if not torch.cuda.is_available():
+        pytest.skip("FlexSN operator contracts are exercised on CUDA")
+    if base_module.triton is None:
+        pytest.skip("Triton is required for FlexSN operator contracts")
+
+    example = torch.zeros(2, 16, device="cuda")
+    kernel = FlexSNKernel(
+        core=_differentiable_lif_core,
+        num_inputs=1,
+        num_states=1,
+        num_outputs=1,
+        example_inputs=(example, example),
+        requires_grad=(True, True),
+    )
+    needs_grad = op_name.endswith("training")
+    x = torch.randn(4, 2, 16, device="cuda", requires_grad=needs_grad)
+    state = torch.randn(2, 16, device="cuda", requires_grad=needs_grad)
+
+    result = torch.library.opcheck(
+        getattr(torch.ops.sj, op_name).default,
+        (kernel._handle, [x, state]),
+        raise_exception=False,
+    )
+
+    assert result
+    assert set(result.values()) == {"SUCCESS"}
 
 
 def test_flexsnkernel_deepcopy_preserves_handle_lifetime(rng):

--- a/test/activation_based/test_flex_sn_inductor.py
+++ b/test/activation_based/test_flex_sn_inductor.py
@@ -907,6 +907,8 @@ def test_inductor_backward_impl_passes_state_templates_to_wrapper(monkeypatch):
         training_info=SimpleNamespace(num_inputs=1, num_outputs=0, num_states=1),
     )
     seen = {}
+    wrapped_kernel = object()
+    wrap_calls = []
 
     def fake_backward(
         kernel,
@@ -920,8 +922,12 @@ def test_inductor_backward_impl_passes_state_templates_to_wrapper(monkeypatch):
         seen["state_templates"] = state_templates
         return [torch.zeros_like(input_template), torch.zeros_like(state_template)]
 
+    def fake_wrap_triton(kernel):
+        wrap_calls.append(kernel)
+        return wrapped_kernel
+
     monkeypatch.setattr(custom_ops, "flexsn_backward", fake_backward)
-    monkeypatch.setattr(custom_ops, "wrap_triton", lambda kernel: ("wrapped", kernel))
+    monkeypatch.setattr(custom_ops, "wrap_triton", fake_wrap_triton)
 
     grads = custom_ops._flexsn_inductor_backward_impl(
         bundle,
@@ -931,7 +937,8 @@ def test_inductor_backward_impl_passes_state_templates_to_wrapper(monkeypatch):
     )
 
     assert len(seen["input_templates"]) == 1
-    assert seen["kernel"] == ("wrapped", bundle.backward_kernel)
+    assert wrap_calls == [bundle.backward_kernel]
+    assert seen["kernel"] is wrapped_kernel
     assert len(seen["state_templates"]) == 1
     assert seen["input_templates"][0].shape == input_template.shape
     assert seen["state_templates"][0].shape == state_template.shape

--- a/test/activation_based/test_triton_neuron.py
+++ b/test/activation_based/test_triton_neuron.py
@@ -1540,7 +1540,7 @@ def test_plif_triton_matches_torch_training(
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_plif_training_avoids_voltage_history_materialization():
-    for T in (4, 32):
+    for T in (1, 4, 32):
         torch_node = neuron.ParametricLIFNode(
             init_tau=2.0, step_mode="m", backend="torch"
         ).to("cuda")

--- a/test/activation_based/test_triton_neuron.py
+++ b/test/activation_based/test_triton_neuron.py
@@ -1539,6 +1539,84 @@ def test_plif_triton_matches_torch_training(
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_plif_training_avoids_voltage_history_materialization():
+    for T in (4, 32):
+        torch_node = neuron.ParametricLIFNode(
+            init_tau=2.0, step_mode="m", backend="torch"
+        ).to("cuda")
+        triton_node = neuron.ParametricLIFNode(
+            init_tau=2.0,
+            step_mode="m",
+            backend="triton",
+            store_v_seq=True,
+        ).to("cuda")
+        triton_node.load_state_dict(torch_node.state_dict())
+        x = torch.randn(T, 3, 8, device="cuda")
+        x_torch = x.clone().requires_grad_()
+        x_triton = x.clone().requires_grad_()
+        v = torch.randn_like(x[0]) * 0.1
+        v_torch = v.clone().requires_grad_()
+        v_triton = v.clone().requires_grad_()
+        torch_node.v = v_torch
+        triton_node.v = v_triton
+
+        output_torch = torch_node(x_torch)
+        with torch.profiler.profile(
+            activities=[torch.profiler.ProfilerActivity.CPU]
+        ) as profile:
+            output_triton = triton_node(x_triton)
+
+        assert "aten::cat" not in {event.key for event in profile.key_averages()}
+        assert triton_node.v_seq.is_contiguous()
+        assert triton_node.v_seq.storage_offset() == 0
+        _assert_close(output_torch, output_triton, torch.float32)
+        output_torch.sum().backward()
+        output_triton.sum().backward()
+        _assert_close(x_torch.grad, x_triton.grad, torch.float32)
+        _assert_close(v_torch.grad, v_triton.grad, torch.float32)
+        _assert_close(torch_node.w.grad, triton_node.w.grad, torch.float32)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_plif_mixed_precision_dynamic_backward_uses_nonzero_initial_state():
+    T = 32
+    torch_node = neuron.ParametricLIFNode(
+        init_tau=2.0, step_mode="m", backend="torch"
+    ).to("cuda")
+    x = torch.randn(T, 3, 8, device="cuda")
+    x_torch = x.clone().requires_grad_()
+    x_mixed = x.clone().requires_grad_()
+    v = torch.randn_like(x[0]) * 0.1
+    v_torch = v.clone().requires_grad_()
+    v_mixed = v.clone().requires_grad_()
+    torch_node.v = v_torch
+    r_tau = torch_node.w.sigmoid().detach().clone().requires_grad_()
+
+    output_torch = torch_node(x_torch)
+    with torch.profiler.profile(
+        activities=[torch.profiler.ProfilerActivity.CPU]
+    ) as profile:
+        output_mixed, _, _ = _call_mixed_precision_forward(
+            "plif",
+            x_mixed,
+            v_mixed,
+            storage_dtype=torch.float32,
+            compute_dtype="fp32",
+            backward_compute_dtype="fp32",
+            r_tau=r_tau,
+        )
+
+    assert "aten::cat" not in {event.key for event in profile.key_averages()}
+    _assert_close(output_torch, output_mixed, torch.float32)
+    output_torch.sum().backward()
+    output_mixed.sum().backward()
+    _assert_close(x_torch.grad, x_mixed.grad, torch.float32)
+    _assert_close(v_torch.grad, v_mixed.grad, torch.float32)
+    expected_w_grad = r_tau.grad * r_tau.detach() * (1.0 - r_tau.detach())
+    _assert_close(torch_node.w.grad, expected_w_grad, torch.float32)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 @pytest.mark.parametrize(
     ("kernel_module", "runner"),
     [

--- a/test/activation_based/test_triton_neuron.py
+++ b/test/activation_based/test_triton_neuron.py
@@ -1539,7 +1539,7 @@ def test_plif_triton_matches_torch_training(
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-def test_plif_training_avoids_voltage_history_materialization():
+def test_plif_training_avoids_voltage_history_cat():
     for T in (1, 4, 32):
         torch_node = neuron.ParametricLIFNode(
             init_tau=2.0, step_mode="m", backend="torch"
@@ -1578,7 +1578,7 @@ def test_plif_training_avoids_voltage_history_materialization():
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-def test_plif_mixed_precision_dynamic_backward_uses_nonzero_initial_state():
+def test_plif_mp_helper_dynamic_backward_uses_nonzero_initial_state():
     T = 32
     torch_node = neuron.ParametricLIFNode(
         init_tau=2.0, step_mode="m", backend="torch"


### PR DESCRIPTION
## Summary

- add a reproducible single-GPU SNN benchmark runner and compile-boundary probe for SpikingVGG, SEW-ResNet, Spikformer, LIF, and FlexSN
- remove PLIF backward's redundant `[v_init; v_seq]` materialization by passing the initial voltage and voltage sequence separately to the Triton kernels
- align the five FlexSN operators with the existing `torch.library.triton_op` + `wrap_triton` path while preserving the opaque `custom_op` fallback
- preserve public operator schemas, state/reset behavior, output layout, and registered-autograd contracts

## Measured evidence

Experiments used an NVIDIA A100-SXM4-80GB, PyTorch 2.7.1+cu118, CUDA 11.8, and Triton 3.3.1.

### PLIF

- `aten::cat` calls: 8 -> 0
- peak allocated memory: approximately 10.42% lower across the three tested shapes
- median kernel latency: 5.31% to 9.40% lower across the three tested shapes
- one small-shape round regressed slightly, so this is presented as a memory-materialization optimization rather than a significant latency or end-to-end speedup

### FlexSN

The corrected training probe uses `requires_grad=(True, True)` and rejects unavailable Triton training kernels instead of silently measuring the eager fallback.

| Path | Inference median | Training median |
| --- | ---: | ---: |
| Torch compile | 0.096256 ms | 0.495616 ms |
| registered Triton FlexSN | 0.098304 ms | 0.473088 ms |
| opaque FlexSN | 0.193536 ms | 1.032192 ms |

Registered Triton is approximately 1.97x faster than opaque inference and 2.18x faster than opaque training in this probe. Generated training code directly launches the FlexSN forward/backward Triton kernels and contains no runtime `torch.ops.sj` FlexSN call. All compared paths use one Dynamo graph with zero graph breaks and recompiles.

Kernel activity count is retained only as structural evidence, not as the optimization target. Inference has the same four physical activities for registered and opaque FlexSN despite the latency difference.

## Validation

- `python -m pytest -q test/activation_based`: 1448 passed, 341 skipped
- `python -m pytest -q benchmark/test/test_snn_single_gpu_benchmark.py`: 7 passed
- g2 CUDA FlexSN/benchmark suite: 135 passed
- corrected A100 compile probe: six inference/training rows passed with matching outputs and gradients
- `ruff format --check`, `ruff check`, `py_compile`, and `git diff --check` passed

## Scope

This change does not add model-name routing, a new runtime backend, a feature flag, or a `torch.autograd.Function`. It does not modify multi-GPU, data/optimizer, AMP policy, CUDA Graph, sparse compute, or Inductor/cuDNN lowering. PyTorch version evidence currently covers 2.7.1; the supported version matrix should be rechecked in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable single-GPU benchmarking for inference and training, with latency, memory, profiling, GPU monitoring, and JSON reports.
  - Added benchmark comparison workflows across source versions, including paired results and failure handling.
  - Added compile-boundary probing across supported model cases with structured success, unsupported, and diagnostic results.

- **Bug Fixes**
  - Improved PLIF training and mixed-precision backward handling, including initial-state gradient propagation.
  - Improved FlexSN operator registration and compatibility.

- **Tests**
  - Expanded CUDA coverage for FlexSN and PLIF correctness and compatibility.

- **Documentation**
  - Updated FlexSN documentation to reflect registered operator integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->