### PR TITLE
feat(nir): update exchange support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,10 +32,10 @@ Module: `spikingjelly.activation_based.op_counter`.
 Module: `spikingjelly.activation_based.nir_exchange`.
 
 - Added bidirectional NIR conversion for Conv1d and current-based LIF neurons.
-- Imported NIR models now return authoritative explicit neuron and graph state;
-  pass the returned state into the next call to continue execution.
+- Imported NIR models now expose neuron and graph state through the returned
+  state value.
 - The NIR optional dependency now supports `nir>=1.0.7,<2` with
-  `nirtorch>=2.6,<3`.
+  `nirtorch>=2.6,<2.7`.
 
 #### Spiking Model Families
 
@@ -84,6 +84,9 @@ Module: `spikingjelly.activation_based.nir_exchange`.
 - NIR conversion now rejects soft-reset neurons, grouped convolutions, and
   incompatible heterogeneous neuron parameters instead of silently changing
   their semantics.
+- Imported NIR models no longer advance implicit module memory. Step-by-step
+  callers must pass the returned state to continue; `state=None` restarts, and
+  `functional.reset_net` does not reset an already returned state value.
 - Recurrent NIR graphs require single-step mode.
 
 #### Model and Example Layout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ Module: `spikingjelly.activation_based.op_counter`.
 - Clarified the basic counting workflow, estimator/module coverage, and the
   boundary between ATen rules and custom `torch.*` function rules.
 
+#### NIR Exchange
+
+Module: `spikingjelly.activation_based.nir_exchange`.
+
+- Added bidirectional NIR conversion for Conv1d and current-based LIF neurons.
+- Imported NIR models now return authoritative explicit neuron and graph state;
+  pass the returned state into the next call to continue execution.
+- The NIR optional dependency now supports `nir>=1.0.7,<2` with
+  `nirtorch>=2.6,<3`.
+
 #### Spiking Model Families
 
 Module: `spikingjelly.activation_based.model`.
@@ -41,6 +51,14 @@ Module: `spikingjelly.activation_based.model`.
   `spikingjelly.activation_based.model`.
 
 ### Bug Fixes
+
+#### NIR Exchange
+
+Module: `spikingjelly.activation_based.nir_exchange`.
+
+- Restored neuron export with NIR 1.0.8 and corrected imported convolution
+  channel metadata.
+- Export shape inference now preserves the source model's neuron memories.
 
 #### Datasets
 
@@ -58,6 +76,15 @@ Module: `spikingjelly.activation_based.examples.dsqn`.
 - DSQN replay batches now build correctly with NumPy 2.x.
 
 ### Breaking Changes and Notices
+
+#### NIR Exchange
+
+Module: `spikingjelly.activation_based.nir_exchange`.
+
+- NIR conversion now rejects soft-reset neurons, grouped convolutions, and
+  incompatible heterogeneous neuron parameters instead of silently changing
+  their semantics.
+- Recurrent NIR graphs require single-step mode.
 
 #### Model and Example Layout
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Optional dependencies:
 | --- | --- |
 | CuPy backend | `pip install cupy-cuda12x` or `pip install cupy-cuda11x` |
 | Triton backend | `pip install triton==3.3.1` |
-| NIR exchange | `pip install "spikingjelly[nir]"` |
+| NIR exchange | `pip install "spikingjelly[nir]"` (PyPI) or `pip install ".[nir]"` (source checkout) |
 | Lightning integration | `pip install lightning jsonargparse[signatures]` |
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Optional dependencies:
 | --- | --- |
 | CuPy backend | `pip install cupy-cuda12x` or `pip install cupy-cuda11x` |
 | Triton backend | `pip install triton==3.3.1` |
-| NIR exchange | `pip install nir nirtorch` |
+| NIR exchange | `pip install "spikingjelly[nir]"` |
 | Lightning integration | `pip install lightning jsonargparse[signatures]` |
 
 ## Quick Start

--- a/README_cn.md
+++ b/README_cn.md
@@ -71,7 +71,7 @@ pip install .
 | --- | --- |
 | CuPy 后端 | `pip install cupy-cuda12x` 或 `pip install cupy-cuda11x` |
 | Triton 后端 | `pip install triton==3.3.1` |
-| NIR exchange | `pip install nir nirtorch` |
+| NIR exchange | `pip install "spikingjelly[nir]"` |
 | Lightning 集成 | `pip install lightning jsonargparse[signatures]` |
 
 ## 快速开始

--- a/README_cn.md
+++ b/README_cn.md
@@ -71,7 +71,7 @@ pip install .
 | --- | --- |
 | CuPy 后端 | `pip install cupy-cuda12x` 或 `pip install cupy-cuda11x` |
 | Triton 后端 | `pip install triton==3.3.1` |
-| NIR exchange | `pip install "spikingjelly[nir]"` |
+| NIR exchange | `pip install "spikingjelly[nir]"`（PyPI）或 `pip install ".[nir]"`（源码目录） |
 | Lightning 集成 | `pip install lightning jsonargparse[signatures]` |
 
 ## 快速开始

--- a/docs/source/APIs/spikingjelly.activation_based.nir_exchange.rst
+++ b/docs/source/APIs/spikingjelly.activation_based.nir_exchange.rst
@@ -20,26 +20,32 @@ Supported Modules
 **Supported SpikingJelly / PyTorch Modules:**
 
 * ``torch.nn.Linear``, :class:`layer.Linear <spikingjelly.activation_based.layer.Linear>`
+* ``torch.nn.Conv1d``, :class:`layer.Conv1d <spikingjelly.activation_based.layer.Conv1d>`
 * ``torch.nn.Conv2d``, :class:`layer.Conv2d <spikingjelly.activation_based.layer.Conv2d>`
 * ``torch.nn.AvgPool2d``, :class:`layer.AvgPool2d <spikingjelly.activation_based.layer.AvgPool2d>`
 * ``torch.nn.Flatten``, :class:`layer.Flatten <spikingjelly.activation_based.layer.Flatten>`
 * :class:`IFNode <spikingjelly.activation_based.neuron.IFNode>`
 * :class:`LIFNode <spikingjelly.activation_based.neuron.LIFNode>` and :class:`ParametricLIFNode <spikingjelly.activation_based.neuron.ParametricLIFNode>`
+* :class:`CUBALIFNode <spikingjelly.activation_based.neuron.CUBALIFNode>`
 
 **Supported NIR Nodes:**
 
 * ``nir.Linear``, ``nir.Affine``
+* ``nir.Conv1d``
 * ``nir.Conv2d``
 * ``nir.AvgPool2d``
 * ``nir.Flatten``
 * ``nir.IF``
 * ``nir.LIF``
+* ``nir.CubaLIF``
 
-.. note::
+.. warning::
 
-   我们将在后续更新中逐渐完善对其他模块的支持。
+   转换仅支持 hard reset 和非分组卷积。NIR 神经元参数必须在所有神经元上均匀，
+   并符合 SpikingJelly 使用的离散化关系。
 
-   We will add support for more modules in future updates.
+   Conversion supports only hard reset and ungrouped convolutions. NIR neuron
+   parameters must be uniform and match the discretization used by SpikingJelly.
 
 SpikingJelly to NIR
 -----------------------------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -36,6 +36,17 @@ Module: ``spikingjelly.activation_based.op_counter``.
 - Clarified the basic counting workflow, estimator/module coverage, and the
   boundary between ATen rules and custom ``torch.*`` function rules.
 
+NIR Exchange
+^^^^^^^^^^^^
+
+Module: ``spikingjelly.activation_based.nir_exchange``.
+
+- Added bidirectional NIR conversion for Conv1d and current-based LIF neurons.
+- Imported NIR models now return authoritative explicit neuron and graph state;
+  pass the returned state into the next call to continue execution.
+- The NIR optional dependency now supports ``nir>=1.0.7,<2`` with
+  ``nirtorch>=2.6,<3``.
+
 Spiking Model Families
 ^^^^^^^^^^^^^^^^^^^^^^
 
@@ -52,6 +63,15 @@ Module: ``spikingjelly.activation_based.model``.
 
 Bug Fixes
 ~~~~~~~~~
+
+NIR Exchange
+^^^^^^^^^^^^
+
+Module: ``spikingjelly.activation_based.nir_exchange``.
+
+- Restored neuron export with NIR 1.0.8 and corrected imported convolution
+  channel metadata.
+- Export shape inference now preserves the source model's neuron memories.
 
 Datasets
 ^^^^^^^^
@@ -72,6 +92,16 @@ Module: ``spikingjelly.activation_based.examples.dsqn``.
 
 Breaking Changes and Notices
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+NIR Exchange
+^^^^^^^^^^^^
+
+Module: ``spikingjelly.activation_based.nir_exchange``.
+
+- NIR conversion now rejects soft-reset neurons, grouped convolutions, and
+  incompatible heterogeneous neuron parameters instead of silently changing
+  their semantics.
+- Recurrent NIR graphs require single-step mode.
 
 Model and Example Layout
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -42,10 +42,10 @@ NIR Exchange
 Module: ``spikingjelly.activation_based.nir_exchange``.
 
 - Added bidirectional NIR conversion for Conv1d and current-based LIF neurons.
-- Imported NIR models now return authoritative explicit neuron and graph state;
-  pass the returned state into the next call to continue execution.
+- Imported NIR models now expose neuron and graph state through the returned
+  state value.
 - The NIR optional dependency now supports ``nir>=1.0.7,<2`` with
-  ``nirtorch>=2.6,<3``.
+  ``nirtorch>=2.6,<2.7``.
 
 Spiking Model Families
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -101,6 +101,9 @@ Module: ``spikingjelly.activation_based.nir_exchange``.
 - NIR conversion now rejects soft-reset neurons, grouped convolutions, and
   incompatible heterogeneous neuron parameters instead of silently changing
   their semantics.
+- Imported NIR models no longer advance implicit module memory. Step-by-step
+  callers must pass the returned state to continue; ``state=None`` restarts, and
+  ``functional.reset_net`` does not reset an already returned state value.
 - Recurrent NIR graphs require single-step mode.
 
 Model and Example Layout

--- a/docs/source/tutorials/cn/nir_exchange.rst
+++ b/docs/source/tutorials/cn/nir_exchange.rst
@@ -5,7 +5,7 @@
 
 English version: :doc:`../en/nir_exchange`
 
-`Neuromorphic intermediate representation (NIR) <https://neuroir.org/docs/index.html>`_ 是一组计算原语，以图（节点+边）的形式描述了 SNN 的模块和连接，在不同的神经形态框架和技术栈之间通用。目前，NIR `被多个模拟器和硬件平台支持 <https://neuroir.org/docs/support.html>`_ 。SpikingJelly ``0.0.0.1.0`` 引入了 ``nir_exchange`` 包，使（满足一定条件的） SpikingJelly 模型能够与 NIR 图互相转换。借助 NIR 这一中间表示，用户可以更加轻松地进行硬件部署和框架迁移。
+`Neuromorphic intermediate representation (NIR) <https://neuroir.org/docs/index.html>`_ 是一组计算原语，以图（节点+边）的形式描述了 SNN 的模块和连接，在不同的神经形态框架和技术栈之间通用。目前，NIR `被多个模拟器和硬件平台支持 <https://neuroir.org/docs/support.html>`_ 。SpikingJelly 的 ``nir_exchange`` 包支持在可转换的 SpikingJelly 模型与 NIR 图之间双向转换。
 
 .. figure:: ../../_static/tutorials/nir_exchange/nir-schema.png
     :width: 100%
@@ -21,11 +21,11 @@ SpikingJelly 的 ``nir_exchange`` 包提供了两个关键的用户接口：
 
 .. note::
 
-    ``nir_exchange`` 功能依赖于 ``nir`` 和 ``nir_exchange`` 包。可以用 ``pip`` 安装：
+    ``nir_exchange`` 依赖 ``nir>=1.0.7,<2`` 和 ``nirtorch>=2.6,<3``。可安装 SpikingJelly 的可选依赖：
 
     .. code:: shell
 
-        pip install nir nir_exchange
+        uv pip install "spikingjelly[nir]"
 
 从 SpikingJelly 到 NIR
 ==========================
@@ -33,11 +33,13 @@ SpikingJelly 的 ``nir_exchange`` 包提供了两个关键的用户接口：
 由于开发者精力有限且 NIR 本身只能表示少数几种模块，故目前 :func:`export_to_nir <spikingjelly.activation_based.nir_exchange.to_nir.export_to_nir>` 只支持以下 SpikingJelly / PyTorch 模块的转换：
 
 * ``torch.nn.Linear``, :class:`layer.Linear <spikingjelly.activation_based.layer.Linear>`
+* ``torch.nn.Conv1d``, :class:`layer.Conv1d <spikingjelly.activation_based.layer.Conv1d>`
 * ``torch.nn.Conv2d``, :class:`layer.Conv2d <spikingjelly.activation_based.layer.Conv2d>`
 * ``torch.nn.AvgPool2d``, :class:`layer.AvgPool2d <spikingjelly.activation_based.layer.AvgPool2d>`
 * ``torch.nn.Flatten``, :class:`layer.Flatten <spikingjelly.activation_based.layer.Flatten>`
 * :class:`IFNode <spikingjelly.activation_based.neuron.IFNode>`
 * :class:`LIFNode <spikingjelly.activation_based.neuron.LIFNode>` and :class:`ParametricLIFNode <spikingjelly.activation_based.neuron.ParametricLIFNode>`
+* :class:`CUBALIFNode <spikingjelly.activation_based.neuron.CUBALIFNode>`
 
 以下面的 SNN 模型为例：
 
@@ -52,7 +54,7 @@ SpikingJelly 的 ``nir_exchange`` 包提供了两个关键的用户接口：
         nn.AvgPool2d((2, 2)),
         layer.Flatten(step_mode="s"),
         nn.Linear(4096, 10),
-        neuron.ParametricLIFNode(10., decay_input=False, v_reset=None),
+        neuron.ParametricLIFNode(10., decay_input=False, v_reset=0.0),
     )
 
 为了展示兼容性，这一示例故意混用了原生 PyTorch 的无状态层 ``nn.AvgPool2d, nn.Linear`` 和 SpikingJelly 包装后的无状态层 ``layer.Conv2d, layer.Flatten``。此外，本例中还使用了 ``neuron.IFNode`` 和 ``neuron.ParametricLIFNode`` 两种神经元模型。
@@ -67,7 +69,7 @@ SpikingJelly 的 ``nir_exchange`` 包提供了两个关键的用户接口：
     graph = nir_exchange.export_to_nir(
         net,
         example_input=torch.rand(8, 3, 32, 32),
-        save_path="./example.h5",
+        save_path="./example.nir",
         dt=1e-4
     )
     print(graph)
@@ -79,7 +81,7 @@ SpikingJelly 的 ``nir_exchange`` 包提供了两个关键的用户接口：
 * ``save_path`` ：HDF5 文件路径，用于保存 NIR 图（若为 ``None`` ，则不保存）；
 * ``dt`` ：NIR 模拟时间步长。建议设置成 ``1e-4`` 以对齐其它支持 NIR 的框架。
 
-运行后，当前目录下出现文件 ``example.h5`` ，内含 NIR 图。终端打印出的结果大致为：
+运行后，当前目录下出现文件 ``example.nir``，其中包含以 HDF5 编码的 NIR 图。终端打印出的结果大致为：
 
 .. code:: text
 
@@ -124,6 +126,10 @@ SpikingJelly 的 ``nir_exchange`` 包提供了两个关键的用户接口：
 
     PyTorch / SpikingJelly 模型的子模块不含输入输出形状信息，但 NIR 图却需要这些信息。为了获取输入输出形状信息，:func:`export_to_nir <spikingjelly.activation_based.nir_exchange.to_nir.export_to_nir>` 要求用户给出 ``example_input`` 样例输入。 ``example_input`` 可以具有时间或批量维度，具体取决于 PyTorch / SpikingJelly 模型的需求。 :func:`export_to_nir <spikingjelly.activation_based.nir_exchange.to_nir.export_to_nir>` 函数内部将调用 PyTorch 的 `ShapeProp <https://github.com/pytorch/pytorch/blob/main/torch/fx/passes/shape_prop.py>`_ 功能来获取输入输出形状信息。
 
+.. warning::
+
+    NIR 无法区分 SpikingJelly 的 soft reset 与 hard reset，因此会拒绝 ``v_reset=None`` 的神经元。分组卷积以及无法被 NIR 精确表示的池化选项也会被拒绝。
+
 从 NIR 到 SpikingJelly
 ==========================
 
@@ -131,61 +137,32 @@ SpikingJelly 的 ``nir_exchange`` 包提供了两个关键的用户接口：
 
 .. code:: python
 
-    gm = nir_exchange.import_from_nir(graph="./example.h5", dt=1e-4)
+    gm = nir_exchange.import_from_nir(graph="./example.nir", dt=1e-4)
     print(gm)
     x = torch.rand(9, 3, 32, 32) # [B, C, H, W]
-    y = gm(x) # forward pass
-    print("y.shape =", y[0].shape) # y is a tuple; the 2nd element is each layer's state
+    y, state = gm(x) # state=None 表示从初始状态开始
+    print("y.shape =", y.shape)
+
+    # 将返回的状态传回模型以继续运行。
+    y, state = gm(x, state)
 
 此处，:func:`import_from_nir <spikingjelly.activation_based.nir_exchange.from_nir.import_from_nir>` 参数的含义是：
 
-* ``graph`` ：若给出字符串，则视为保存有 NIR 图的 HDF5 文件路径；函数内部将从该文件中读出 ``NIRGraph`` 。若给出 ``NIRGraph`` 对象，则直接使用该对象。
+* ``graph`` ：``NIRGraph`` 对象，或指向 HDF5 NIR 文件的字符串/``Path``。
 * ``dt`` ：NIR 图的模拟时间步长。与 :func:`export_to_nir <spikingjelly.activation_based.nir_exchange.to_nir.export_to_nir>` 的 ``dt`` 参数一致。
 
-该函数返回一个 ``torch.fx.GraphModule`` 对象，可以像 ``torch.nn.Module`` 那样直接调用以运行前向传播。前向传播返回一个二元组，第一个元素是模型的输出，第二个元素则是模型内子模块的状态字典（绝大多数情况下无需使用）。上方代码块的终端输出大致为：
-
-.. code:: text
-
-    GraphModule(
-      (_0): Conv2d(16, 3, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), step_mode=s)
-      (_1): IFNode(
-        v_threshold=1.0, v_reset=0.0, detach_reset=False, step_mode=s, backend=torch
-        (surrogate_function): Sigmoid(alpha=4.0, spiking=True)
-      )
-      (_2): AvgPool2d(kernel_size=(2, 2), stride=(2, 2), padding=0, step_mode=s)
-      (_3): Flatten(start_dim=1, end_dim=-1, step_mode=s)
-      (_4): Linear(in_features=4096, out_features=10, bias=True)
-      (_5): LIFNode(
-        v_threshold=1.0, v_reset=0.0, detach_reset=False, step_mode=s, backend=torch, tau=10.0
-        (surrogate_function): Sigmoid(alpha=4.0, spiking=True)
-      )
-    )
-
-    def forward(self, input, state : typing_Dict[str,typing_Any] = {'_0': None, '_1': None, '_2': None, '_3': None, '_4': None, '_5': None, 'input_1': None, 'output': None}):
-        ones = torch.ones(1);  ones = None
-        input_1 = input
-        _0 = self._0(input_1);  input_1 = None
-        _1 = self._1(_0);  _0 = None
-        _2 = self._2(_1);  _1 = None
-        _3 = self._3(_2);  _2 = None
-        _4 = self._4(_3);  _3 = None
-        _5 = self._5(_4);  _4 = None
-        return (_5, state)
-
-    # To see more debug info, please use `graph_module.print_readable()`
-
-    y.shape = torch.Size([9, 10])
-
-可见，NIR 图被正确地转换成了 SpikingJelly 模型。模型的无状态层均来自 ``spikingjelly.activation_based.layer`` ，可以配置步进模式（见 ``step_mode`` 属性）。
+返回的 ``torch.fx.GraphModule`` 使用显式状态。以 ``state=None`` 调用时总是从神经元和图的初始状态开始；若要继续序列，应将返回的状态传入下一次调用。循环 NIR 图只能使用单步模式，每次调用推进一个时间步。
 
 目前， :func:`import_from_nir <spikingjelly.activation_based.nir_exchange.from_nir.import_from_nir>` 仅支持以下 NIR 节点类型：
 
 * ``nir.Linear``, ``nir.Affine``
+* ``nir.Conv1d``
 * ``nir.Conv2d``
 * ``nir.AvgPool2d``
 * ``nir.Flatten``
 * ``nir.IF``
 * ``nir.LIF``
+* ``nir.CubaLIF``
 
 .. note::
 
@@ -194,9 +171,9 @@ SpikingJelly 的 ``nir_exchange`` 包提供了两个关键的用户接口：
     .. code:: python
 
         gm = nir_exchange.import_from_nir(
-            "./example.h5", dt=1e-4, step_mode="m"
+            "./example.nir", dt=1e-4, step_mode="m"
         )
         print(gm)
         x = torch.rand(7, 9, 3, 32, 32) # [T, B, C, H, W]
-        y = gm(x)
-        print("y.shape =", y[0].shape)
+        y, state = gm(x)
+        print("y.shape =", y.shape)

--- a/docs/source/tutorials/cn/nir_exchange.rst
+++ b/docs/source/tutorials/cn/nir_exchange.rst
@@ -21,11 +21,11 @@ SpikingJelly 的 ``nir_exchange`` 包提供了两个关键的用户接口：
 
 .. note::
 
-    ``nir_exchange`` 依赖 ``nir>=1.0.7,<2`` 和 ``nirtorch>=2.6,<3``。可安装 SpikingJelly 的可选依赖：
+    使用以下命令安装 NIR exchange 可选依赖：
 
     .. code:: shell
 
-        uv pip install "spikingjelly[nir]"
+        pip install "spikingjelly[nir]"
 
 从 SpikingJelly 到 NIR
 ==========================
@@ -138,7 +138,6 @@ SpikingJelly 的 ``nir_exchange`` 包提供了两个关键的用户接口：
 .. code:: python
 
     gm = nir_exchange.import_from_nir(graph="./example.nir", dt=1e-4)
-    print(gm)
     x = torch.rand(9, 3, 32, 32) # [B, C, H, W]
     y, state = gm(x) # state=None 表示从初始状态开始
     print("y.shape =", y.shape)
@@ -151,7 +150,7 @@ SpikingJelly 的 ``nir_exchange`` 包提供了两个关键的用户接口：
 * ``graph`` ：``NIRGraph`` 对象，或指向 HDF5 NIR 文件的字符串/``Path``。
 * ``dt`` ：NIR 图的模拟时间步长。与 :func:`export_to_nir <spikingjelly.activation_based.nir_exchange.to_nir.export_to_nir>` 的 ``dt`` 参数一致。
 
-返回的 ``torch.fx.GraphModule`` 使用显式状态。以 ``state=None`` 调用时总是从神经元和图的初始状态开始；若要继续序列，应将返回的状态传入下一次调用。循环 NIR 图只能使用单步模式，每次调用推进一个时间步。
+返回的 ``torch.fx.GraphModule`` 使用显式状态。以 ``state=None`` 调用时总是从神经元和图的初始状态开始。逐步循环必须将返回的状态传入下一次调用，否则每一步都会从初始状态重新运行。:func:`functional.reset_net <spikingjelly.activation_based.functional.reset_net>` 不会重置已经返回的显式状态；若要重新开始，应传入 ``state=None``。循环 NIR 图只能使用单步模式，每次调用推进一个时间步。
 
 目前， :func:`import_from_nir <spikingjelly.activation_based.nir_exchange.from_nir.import_from_nir>` 仅支持以下 NIR 节点类型：
 
@@ -173,7 +172,6 @@ SpikingJelly 的 ``nir_exchange`` 包提供了两个关键的用户接口：
         gm = nir_exchange.import_from_nir(
             "./example.nir", dt=1e-4, step_mode="m"
         )
-        print(gm)
         x = torch.rand(7, 9, 3, 32, 32) # [T, B, C, H, W]
         y, state = gm(x)
         print("y.shape =", y.shape)

--- a/docs/source/tutorials/en/nir_exchange.rst
+++ b/docs/source/tutorials/en/nir_exchange.rst
@@ -5,7 +5,7 @@ Author: `Yifan Huang (AllenYolk) <https://github.com/AllenYolk>`_
 
 中文版： :doc:`../cn/nir_exchange`
 
-`Neuromorphic intermediate representation (NIR) <https://neuroir.org/docs/index.html>`_ is a set of computational primitives that describes SNN modules and their connections in the form of graphs (nodes and edges), and is designed to be shared across different neuromorphic frameworks and technology stacks. At present, NIR `is supported by multiple simulators and hardware platforms <https://neuroir.org/docs/support.html>`_. SpikingJelly ``0.0.0.1.0`` introduces the ``nir_exchange`` package, which enables (under certain conditions) bidirectional conversion between SpikingJelly models and NIR graphs. By leveraging NIR as an intermediate representation, users can easily perform hardware deployment and framework migration.
+`Neuromorphic intermediate representation (NIR) <https://neuroir.org/docs/index.html>`_ is a set of computational primitives that describes SNN modules and their connections in the form of graphs (nodes and edges), and is designed to be shared across different neuromorphic frameworks and technology stacks. At present, NIR `is supported by multiple simulators and hardware platforms <https://neuroir.org/docs/support.html>`_. SpikingJelly's ``nir_exchange`` package enables bidirectional conversion between supported SpikingJelly models and NIR graphs.
 
 .. figure:: ../../_static/tutorials/nir_exchange/nir-schema.png
     :width: 100%
@@ -21,11 +21,11 @@ This tutorial provides a detailed introduction to these two functions.
 
 .. note::
 
-    ``nir_exchange`` package depends on ``nir`` and ``nir_exchange``. Install them using ``pip`` :
+    ``nir_exchange`` depends on ``nir>=1.0.7,<2`` and ``nirtorch>=2.6,<3``. Install the optional dependencies with:
 
     .. code:: shell
 
-        pip install nir nir_exchange
+        uv pip install "spikingjelly[nir]"
 
 From SpikingJelly to NIR
 ============================
@@ -33,11 +33,13 @@ From SpikingJelly to NIR
 Due to limited development resources and the fact that NIR itself can only represent a small number of module types, the current :func:`export_to_nir <spikingjelly.activation_based.nir_exchange.to_nir.export_to_nir>` function supports conversion only for the following SpikingJelly / PyTorch modules:
 
 * ``torch.nn.Linear``, :class:`layer.Linear <spikingjelly.activation_based.layer.Linear>`
+* ``torch.nn.Conv1d``, :class:`layer.Conv1d <spikingjelly.activation_based.layer.Conv1d>`
 * ``torch.nn.Conv2d``, :class:`layer.Conv2d <spikingjelly.activation_based.layer.Conv2d>`
 * ``torch.nn.AvgPool2d``, :class:`layer.AvgPool2d <spikingjelly.activation_based.layer.AvgPool2d>`
 * ``torch.nn.Flatten``, :class:`layer.Flatten <spikingjelly.activation_based.layer.Flatten>`
 * :class:`IFNode <spikingjelly.activation_based.neuron.IFNode>`
 * :class:`LIFNode <spikingjelly.activation_based.neuron.LIFNode>` and :class:`ParametricLIFNode <spikingjelly.activation_based.neuron.ParametricLIFNode>`
+* :class:`CUBALIFNode <spikingjelly.activation_based.neuron.CUBALIFNode>`
 
 Consider the following SNN model as an example:
 
@@ -52,7 +54,7 @@ Consider the following SNN model as an example:
         nn.AvgPool2d((2, 2)),
         layer.Flatten(step_mode="s"),
         nn.Linear(4096, 10),
-        neuron.ParametricLIFNode(10., decay_input=False, v_reset=None),
+        neuron.ParametricLIFNode(10., decay_input=False, v_reset=0.0),
     )
 
 To demonstrate compatibility, this example deliberately mixes native PyTorch stateless layers ``nn.AvgPool2d, nn.Linear`` with the SpikingJelly-wrapped stateless layers ``layer.Conv2d, layer.Flatten``. In addition, two neuron models, ``neuron.IFNode`` and ``neuron.ParametricLIFNode``, are used in this example.
@@ -67,7 +69,7 @@ By calling :func:`export_to_nir <spikingjelly.activation_based.nir_exchange.to_n
     graph = nir_exchange.export_to_nir(
         net,
         example_input=torch.rand(8, 3, 32, 32),
-        save_path="./example.h5",
+        save_path="./example.nir",
         dt=1e-4
     )
     print(graph)
@@ -79,7 +81,7 @@ The meanings of the parameters of :func:`export_to_nir <spikingjelly.activation_
 * ``save_path``: the path to the HDF5 file used to save the NIR graph (if ``None``, the graph is not saved);
 * ``dt``: the simulation time step used in NIR. It is recommended to set this value to ``1e-4`` in order to align with other frameworks that support NIR.
 
-After execution, a file named ``example.h5`` will appear in the current directory, containing the NIR graph. The output printed in the terminal is roughly as follows:
+After execution, a file named ``example.nir`` will appear in the current directory, containing the HDF5-encoded NIR graph. The output printed in the terminal is roughly as follows:
 
 .. code:: text
 
@@ -124,6 +126,10 @@ Here, only the structure of the ``NIRGraph`` is shown. As can be seen, an NIR gr
 
     Submodules in PyTorch / SpikingJelly models do not carry input-output shape information, whereas NIR graphs require it. To obtain such shape information, :func:`export_to_nir <spikingjelly.activation_based.nir_exchange.to_nir.export_to_nir>` requires the user to provide ``example_input``. ``example_input`` may include a time or batch dimension, depending on the requirements of the PyTorch / SpikingJelly model. Internally, :func:`export_to_nir <spikingjelly.activation_based.nir_exchange.to_nir.export_to_nir>` invokes PyTorch’s `ShapeProp <https://github.com/pytorch/pytorch/blob/main/torch/fx/passes/shape_prop.py>`_ utility to infer input and output shapes.
 
+.. warning::
+
+    NIR cannot distinguish SpikingJelly's soft reset from hard reset, so neurons with ``v_reset=None`` are rejected. Grouped convolutions and pooling options without an exact NIR representation are also rejected.
+
 From NIR to SpikingJelly
 ==========================
 
@@ -131,61 +137,32 @@ The function :func:`import_from_nir <spikingjelly.activation_based.nir_exchange.
 
 .. code:: python
 
-    gm = nir_exchange.import_from_nir(graph="./example.h5", dt=1e-4)
+    gm = nir_exchange.import_from_nir(graph="./example.nir", dt=1e-4)
     print(gm)
     x = torch.rand(9, 3, 32, 32) # [B, C, H, W]
-    y = gm(x) # forward pass
-    print("y.shape =", y[0].shape) # y is a tuple; the 2nd element is each layer's state
+    y, state = gm(x) # state=None starts from the initial state
+    print("y.shape =", y.shape)
+
+    # Continue from the returned state.
+    y, state = gm(x, state)
 
 Here, the arguments of :func:`import_from_nir <spikingjelly.activation_based.nir_exchange.from_nir.import_from_nir>` means:
 
-* ``graph``: If a string is provided, it is interpreted as the path to an HDF5 file that stores an NIR graph; the function will load the ``NIRGraph`` from this file. If an ``NIRGraph`` object is provided, it will be used directly.
+* ``graph``: A ``NIRGraph`` object or a string/``Path`` pointing to an HDF5 NIR file.
 * ``dt``: The simulation time step of the NIR graph. This parameter should be consistent with the ``dt`` argument of :func:`export_to_nir <spikingjelly.activation_based.nir_exchange.to_nir.export_to_nir>`.
 
-This function returns a ``torch.fx.GraphModule`` object, which can be invoked directly like a ``torch.nn.Module`` to perform forward propagation. The forward pass returns a tuple: the first element is the model output, and the second element is a dictionary of internal states of the submodules (which is unnecessary in most cases). The terminal output of the above code block is approximately
-
-.. code:: text
-
-    GraphModule(
-      (_0): Conv2d(16, 3, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), step_mode=s)
-      (_1): IFNode(
-        v_threshold=1.0, v_reset=0.0, detach_reset=False, step_mode=s, backend=torch
-        (surrogate_function): Sigmoid(alpha=4.0, spiking=True)
-      )
-      (_2): AvgPool2d(kernel_size=(2, 2), stride=(2, 2), padding=0, step_mode=s)
-      (_3): Flatten(start_dim=1, end_dim=-1, step_mode=s)
-      (_4): Linear(in_features=4096, out_features=10, bias=True)
-      (_5): LIFNode(
-        v_threshold=1.0, v_reset=0.0, detach_reset=False, step_mode=s, backend=torch, tau=10.0
-        (surrogate_function): Sigmoid(alpha=4.0, spiking=True)
-      )
-    )
-
-    def forward(self, input, state : typing_Dict[str,typing_Any] = {'_0': None, '_1': None, '_2': None, '_3': None, '_4': None, '_5': None, 'input_1': None, 'output': None}):
-        ones = torch.ones(1);  ones = None
-        input_1 = input
-        _0 = self._0(input_1);  input_1 = None
-        _1 = self._1(_0);  _0 = None
-        _2 = self._2(_1);  _1 = None
-        _3 = self._3(_2);  _2 = None
-        _4 = self._4(_3);  _3 = None
-        _5 = self._5(_4);  _4 = None
-        return (_5, state)
-
-    # To see more debug info, please use `graph_module.print_readable()`
-
-    y.shape = torch.Size([9, 10])
-
-As shown above, the NIR graph is correctly converted into a SpikingJelly model. All stateless layers in the model are instantiated from classes in ``spikingjelly.activation_based.layer`` and support configurable step modes (see the ``step_mode`` attribute).
+The returned ``torch.fx.GraphModule`` uses explicit state. Calling it with ``state=None`` always starts from the initial neuron and graph state; pass the returned state into the next call to continue a sequence. Recurrent NIR graphs must use single-step mode and advance one time step per call.
 
 Currently, :func:`import_from_nir <spikingjelly.activation_based.nir_exchange.from_nir.import_from_nir>` supports only the following NIR node types.
 
 * ``nir.Linear``, ``nir.Affine``
+* ``nir.Conv1d``
 * ``nir.Conv2d``
 * ``nir.AvgPool2d``
 * ``nir.Flatten``
 * ``nir.IF``
 * ``nir.LIF``
+* ``nir.CubaLIF``
 
 .. note::
 
@@ -194,9 +171,9 @@ Currently, :func:`import_from_nir <spikingjelly.activation_based.nir_exchange.fr
     .. code:: python
 
         gm = nir_exchange.import_from_nir(
-            "./example.h5", dt=1e-4, step_mode="m"
+            "./example.nir", dt=1e-4, step_mode="m"
         )
         print(gm)
         x = torch.rand(7, 9, 3, 32, 32) # [T, B, C, H, W]
-        y = gm(x)
-        print("y.shape =", y[0].shape)
+        y, state = gm(x)
+        print("y.shape =", y.shape)

--- a/docs/source/tutorials/en/nir_exchange.rst
+++ b/docs/source/tutorials/en/nir_exchange.rst
@@ -21,11 +21,11 @@ This tutorial provides a detailed introduction to these two functions.
 
 .. note::
 
-    ``nir_exchange`` depends on ``nir>=1.0.7,<2`` and ``nirtorch>=2.6,<3``. Install the optional dependencies with:
+    Install the NIR exchange optional dependencies with:
 
     .. code:: shell
 
-        uv pip install "spikingjelly[nir]"
+        pip install "spikingjelly[nir]"
 
 From SpikingJelly to NIR
 ============================
@@ -138,7 +138,6 @@ The function :func:`import_from_nir <spikingjelly.activation_based.nir_exchange.
 .. code:: python
 
     gm = nir_exchange.import_from_nir(graph="./example.nir", dt=1e-4)
-    print(gm)
     x = torch.rand(9, 3, 32, 32) # [B, C, H, W]
     y, state = gm(x) # state=None starts from the initial state
     print("y.shape =", y.shape)
@@ -151,7 +150,7 @@ Here, the arguments of :func:`import_from_nir <spikingjelly.activation_based.nir
 * ``graph``: A ``NIRGraph`` object or a string/``Path`` pointing to an HDF5 NIR file.
 * ``dt``: The simulation time step of the NIR graph. This parameter should be consistent with the ``dt`` argument of :func:`export_to_nir <spikingjelly.activation_based.nir_exchange.to_nir.export_to_nir>`.
 
-The returned ``torch.fx.GraphModule`` uses explicit state. Calling it with ``state=None`` always starts from the initial neuron and graph state; pass the returned state into the next call to continue a sequence. Recurrent NIR graphs must use single-step mode and advance one time step per call.
+The returned ``torch.fx.GraphModule`` uses explicit state. Calling it with ``state=None`` always starts from the initial neuron and graph state. A step-by-step loop must pass the returned state into the next call; otherwise every step restarts from the initial state. :func:`functional.reset_net <spikingjelly.activation_based.functional.reset_net>` does not reset a previously returned state; pass ``state=None`` to restart. Recurrent NIR graphs must use single-step mode and advance one time step per call.
 
 Currently, :func:`import_from_nir <spikingjelly.activation_based.nir_exchange.from_nir.import_from_nir>` supports only the following NIR node types.
 
@@ -173,7 +172,6 @@ Currently, :func:`import_from_nir <spikingjelly.activation_based.nir_exchange.fr
         gm = nir_exchange.import_from_nir(
             "./example.nir", dt=1e-4, step_mode="m"
         )
-        print(gm)
         x = torch.rand(7, 9, 3, 32, 32) # [T, B, C, H, W]
         y, state = gm(x)
         print("y.shape =", y.shape)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ license-files = ["LICENSE", "LICENSES/README.md", "LICENSES/translations/*"]
 cupy11 = ["cupy-cuda11x"]
 cupy12 = ["cupy-cuda12x"]
 triton = ["triton>=3.3.1"]
-nir = ["nir>=1.0.7,<2", "nirtorch>=2.6,<3"]
+nir = ["nir>=1.0.7,<2", "nirtorch>=2.6,<2.7"]
 lightning = ["lightning", "jsonargparse[signatures]"]
 megatron = ["megatron-core==0.18.2; python_version >= '3.12'"]
 fp8-torchao = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ license-files = ["LICENSE", "LICENSES/README.md", "LICENSES/translations/*"]
 cupy11 = ["cupy-cuda11x"]
 cupy12 = ["cupy-cuda12x"]
 triton = ["triton>=3.3.1"]
-nir = ["nir", "nirtorch"]
+nir = ["nir>=1.0.7,<2", "nirtorch>=2.6,<3"]
 lightning = ["lightning", "jsonargparse[signatures]"]
 megatron = ["megatron-core==0.18.2; python_version >= '3.12'"]
 fp8-torchao = [

--- a/spikingjelly/activation_based/nir_exchange/from_nir.py
+++ b/spikingjelly/activation_based/nir_exchange/from_nir.py
@@ -25,15 +25,24 @@ def _uniform_scalar(value: np.ndarray, name: str):
     unique = np.unique(value)
     if unique.size != 1:
         raise ValueError(f"{name} must be uniform across all neurons.")
-    return unique.item()
+    return float(unique.item())
 
 
-def _matches_discretization(value: float, expected: float) -> bool:
+def _is_close_finite(value: float, expected: float) -> bool:
     return bool(
         np.isfinite(value)
         and np.isfinite(expected)
         and np.isclose(value, expected, rtol=1e-6, atol=1e-12)
     )
+
+
+def _require_ungrouped(groups) -> int:
+    groups = _to_python_value(groups)
+    if groups != 1:
+        raise NotImplementedError(
+            "Grouped convolutions are not supported by NIR exchange."
+        )
+    return 1
 
 
 def _has_cycle(graph: nir.NIRGraph) -> bool:
@@ -93,10 +102,7 @@ class _NodeMapper:
         return module
 
     def map_conv1d(self, node: nir.Conv1d) -> layer.Conv1d:
-        if _to_python_value(node.groups) != 1:
-            raise NotImplementedError(
-                "NIR type inference does not support grouped convolutions."
-            )
+        _require_ungrouped(node.groups)
         weight = node.weight
         module = layer.Conv1d(
             in_channels=weight.shape[1],
@@ -118,11 +124,7 @@ class _NodeMapper:
         stride = _to_python_value(node.stride)
         padding = _to_python_value(node.padding)
         dilation = _to_python_value(node.dilation)
-        groups = _to_python_value(node.groups)
-        if groups != 1:
-            raise NotImplementedError(
-                "NIR type inference does not support grouped convolutions."
-            )
+        groups = _require_ungrouped(node.groups)
 
         module = layer.Conv2d(
             in_channels=weight.shape[1],
@@ -157,7 +159,7 @@ class _NodeMapper:
 
     def map_if(self, node: nir.IF) -> nn.Module:
         r = _uniform_scalar(node.r, "nir.IF.r")
-        if not _matches_discretization(r, 1.0 / self.dt):
+        if not _is_close_finite(r, 1.0 / self.dt):
             raise ValueError("nir.IF.r must equal 1 / dt.")
         return _NIRStatefulModule(
             neuron.IFNode(
@@ -171,16 +173,16 @@ class _NodeMapper:
         if not np.isfinite(tau) or tau <= 1.0:
             raise ValueError("nir.LIF.tau / dt must be finite and greater than 1.")
         r = _uniform_scalar(node.r, "nir.LIF.r")
-        if _matches_discretization(r, 1.0):
+        if _is_close_finite(r, 1.0):
             decay_input = True
-        elif _matches_discretization(r, tau):
+        elif _is_close_finite(r, tau):
             decay_input = False
         else:
             raise ValueError("nir.LIF.r must equal 1 or tau / dt.")
 
         v_reset = _uniform_scalar(node.v_reset, "nir.LIF.v_reset")
         v_leak = _uniform_scalar(node.v_leak, "nir.LIF.v_leak")
-        if not _matches_discretization(v_leak, v_reset):
+        if not _is_close_finite(v_leak, v_reset):
             raise ValueError("nir.LIF.v_leak must equal v_reset.")
 
         return _NIRStatefulModule(
@@ -200,13 +202,13 @@ class _NodeMapper:
         if tau_syn < self.dt or tau_mem < self.dt:
             raise ValueError("nir.CubaLIF time constants must be at least dt.")
         r = _uniform_scalar(node.r, "nir.CubaLIF.r")
-        if not _matches_discretization(r, tau_mem / self.dt):
+        if not _is_close_finite(r, tau_mem / self.dt):
             raise ValueError("nir.CubaLIF.r must equal tau_mem / dt.")
         w_in = _uniform_scalar(node.w_in, "nir.CubaLIF.w_in")
-        if not _matches_discretization(w_in, tau_syn / self.dt):
+        if not _is_close_finite(w_in, tau_syn / self.dt):
             raise ValueError("nir.CubaLIF.w_in must equal tau_syn / dt.")
         v_leak = _uniform_scalar(node.v_leak, "nir.CubaLIF.v_leak")
-        if not _matches_discretization(v_leak, 0.0):
+        if not _is_close_finite(v_leak, 0.0):
             raise ValueError("nir.CubaLIF.v_leak must equal 0.")
 
         return _NIRStatefulModule(
@@ -241,7 +243,9 @@ def import_from_nir(
     转换为 SpikingJelly 神经网络模型。函数会根据 NIR 节点类型自动映射为对应的
     SpikingJelly 模块（如 Linear、Conv、IF/LIF/CubaLIF 神经元等），并返回可直接运行的
     ``fx.GraphModule`` 对象。模型前向返回 ``(output, state)``；传入 ``state=None``
-    会从初始状态运行，连续运行时应将上一次返回的 ``state`` 传回模型。
+    会从初始状态运行。逐步循环必须将上一次返回的 ``state`` 传回模型，否则每一步都会
+    从初始状态重新运行。:func:`functional.reset_net <spikingjelly.activation_based.functional.reset_net>`
+    不会重置已经返回的显式状态；传入 ``state=None`` 可重新开始。
 
     :param graph: NIR 图，或存储 NIR 图的 HDF5 文件路径
     :type graph: Union[nir.NIRGraph, str, Path]
@@ -276,7 +280,10 @@ def import_from_nir(
     IF/LIF/CubaLIF neurons) and returns a runnable
     `fx.GraphModule <https://docs.pytorch.org/docs/stable/fx.html#torch.fx.GraphModule>`_.
     Its forward pass returns ``(output, state)``. Passing ``state=None`` starts
-    from the initial state; pass the previously returned ``state`` to continue.
+    from the initial state. A step-by-step loop must pass the previously returned
+    ``state`` to continue; otherwise every step restarts from the initial state.
+    :func:`functional.reset_net <spikingjelly.activation_based.functional.reset_net>`
+    does not reset a previously returned explicit state; pass ``state=None`` to restart.
 
     :param graph: NIR graph, or the path to the HDF5 file storing the NIR graph
     :type graph: Union[nir.NIRGraph, str, Path]

--- a/spikingjelly/activation_based/nir_exchange/from_nir.py
+++ b/spikingjelly/activation_based/nir_exchange/from_nir.py
@@ -274,7 +274,7 @@ def import_from_nir(
     graph to a SpikingJelly model. The function automatically maps NIR nodes to
     corresponding SpikingJelly modules (e.g., Linear, convolution, and
     IF/LIF/CubaLIF neurons) and returns a runnable
-    :class:`fx.GraphModule <https://docs.pytorch.org/docs/stable/fx.html#torch.fx.GraphModule>`.
+    `fx.GraphModule <https://docs.pytorch.org/docs/stable/fx.html#torch.fx.GraphModule>`_.
     Its forward pass returns ``(output, state)``. Passing ``state=None`` starts
     from the initial state; pass the previously returned ``state`` to continue.
 

--- a/spikingjelly/activation_based/nir_exchange/from_nir.py
+++ b/spikingjelly/activation_based/nir_exchange/from_nir.py
@@ -1,27 +1,66 @@
-from typing import Union
+from graphlib import CycleError, TopologicalSorter
+from pathlib import Path
+from typing import Optional, Union
 
-import numpy as np
-import torch
-from torch import fx
 import nir
 import nirtorch
+import numpy as np
+import torch
+import torch.nn as nn
+from torch import fx
 
-from .. import layer, functional, neuron
-from spikingjelly.logger import logger
+from .. import base, functional, layer, neuron
+from ...logger import logger
 
 
 __all__ = ["import_from_nir"]
 
 
-def _from_numpy(x):
-    if isinstance(x, (int, np.int64)):
-        return int(x)
-    if isinstance(x, (np.float32, np.float64)):
-        return float(x)
-    elif isinstance(x, np.ndarray):
-        return tuple(x.tolist())
-    else:
-        return tuple(x)
+def _to_python_value(x):
+    value = np.asarray(x)
+    return value.item() if value.ndim == 0 else tuple(value.tolist())
+
+
+def _uniform_scalar(value: np.ndarray, name: str):
+    unique = np.unique(value)
+    if unique.size != 1:
+        raise ValueError(f"{name} must be uniform across all neurons.")
+    return unique.item()
+
+
+def _matches_discretization(value: float, expected: float) -> bool:
+    return bool(
+        np.isfinite(value)
+        and np.isfinite(expected)
+        and np.isclose(value, expected, rtol=1e-6, atol=1e-12)
+    )
+
+
+def _has_cycle(graph: nir.NIRGraph) -> bool:
+    predecessors = {name: set() for name in graph.nodes}
+    for source, target in graph.edges:
+        predecessors[target].add(source)
+    try:
+        TopologicalSorter(predecessors).prepare()
+    except CycleError:
+        return True
+    return False
+
+
+class _NIRStatefulModule(nn.Module):
+    def __init__(self, module: base.MemoryModule):
+        super().__init__()
+        self.module = module
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        state: Optional[tuple[object, ...]] = None,
+    ) -> tuple[torch.Tensor, tuple[object, ...]]:
+        if state is None:
+            state = tuple(base.extract_memories(self.module))
+        outputs, updated_state = self.module.functional_forward((x,), tuple(state))
+        return outputs[0], updated_state
 
 
 class _NodeMapper:
@@ -33,12 +72,14 @@ class _NodeMapper:
         return {
             nir.Affine: self.map_affine,
             nir.Linear: self.map_linear,
+            nir.Conv1d: self.map_conv1d,
             nir.Conv2d: self.map_conv2d,
             nir.AvgPool2d: self.map_avgpool2d,
             nir.Flatten: self.map_flatten,
             nir.IF: self.map_if,
             nir.LIF: self.map_lif,
-        }  # all the functions return single-step modules
+            nir.CubaLIF: self.map_cuba_lif,
+        }
 
     def map_affine(self, node: nir.Affine) -> layer.Linear:
         module = layer.Linear(node.weight.shape[-1], node.weight.shape[-2], bias=True)
@@ -51,17 +92,41 @@ class _NodeMapper:
         module.weight.data = torch.from_numpy(node.weight)
         return module
 
+    def map_conv1d(self, node: nir.Conv1d) -> layer.Conv1d:
+        if _to_python_value(node.groups) != 1:
+            raise NotImplementedError(
+                "NIR type inference does not support grouped convolutions."
+            )
+        weight = node.weight
+        module = layer.Conv1d(
+            in_channels=weight.shape[1],
+            out_channels=weight.shape[0],
+            kernel_size=weight.shape[-1],
+            stride=_to_python_value(node.stride),
+            padding=_to_python_value(node.padding),
+            dilation=_to_python_value(node.dilation),
+            groups=1,
+            bias=True,
+        )
+        module.weight.data = torch.from_numpy(weight)
+        module.bias.data = torch.from_numpy(node.bias)
+        return module
+
     def map_conv2d(self, node: nir.Conv2d) -> layer.Conv2d:
         weight = node.weight
         bias = node.bias
-        stride = _from_numpy(node.stride)
-        padding = _from_numpy(node.padding)
-        dilation = _from_numpy(node.dilation)
-        groups = _from_numpy(node.groups)
+        stride = _to_python_value(node.stride)
+        padding = _to_python_value(node.padding)
+        dilation = _to_python_value(node.dilation)
+        groups = _to_python_value(node.groups)
+        if groups != 1:
+            raise NotImplementedError(
+                "NIR type inference does not support grouped convolutions."
+            )
 
         module = layer.Conv2d(
-            in_channels=weight.shape[-4],
-            out_channels=weight.shape[-3],
+            in_channels=weight.shape[1],
+            out_channels=weight.shape[0],
             kernel_size=weight.shape[-2:],
             stride=stride,
             padding=padding,
@@ -74,9 +139,9 @@ class _NodeMapper:
         return module
 
     def map_avgpool2d(self, node: nir.AvgPool2d) -> layer.AvgPool2d:
-        kernel_size = _from_numpy(node.kernel_size)
-        stride = _from_numpy(node.stride)
-        padding = _from_numpy(node.padding)
+        kernel_size = _to_python_value(node.kernel_size)
+        stride = _to_python_value(node.stride)
+        padding = _to_python_value(node.padding)
 
         return layer.AvgPool2d(
             kernel_size=kernel_size,
@@ -90,65 +155,74 @@ class _NodeMapper:
         end_dim = end_dim + 1 if end_dim >= 0 else end_dim
         return layer.Flatten(start_dim, end_dim)
 
-    def map_if(self, node: nir.IF) -> neuron.IFNode:
-        v_threshold = np.unique(node.v_threshold)
-        if v_threshold.size != 1:
-            raise AssertionError("`v_threshold` must be the same for all neurons!")
-        v_threshold = _from_numpy(v_threshold[0])
+    def map_if(self, node: nir.IF) -> nn.Module:
+        r = _uniform_scalar(node.r, "nir.IF.r")
+        if not _matches_discretization(r, 1.0 / self.dt):
+            raise ValueError("nir.IF.r must equal 1 / dt.")
+        return _NIRStatefulModule(
+            neuron.IFNode(
+                v_threshold=_uniform_scalar(node.v_threshold, "nir.IF.v_threshold"),
+                v_reset=_uniform_scalar(node.v_reset, "nir.IF.v_reset"),
+            )
+        )
 
-        v_reset = np.unique(node.v_reset)
-        if v_reset.size != 1:
-            raise AssertionError("`v_reset` must be the same for all neurons!")
-        v_reset = _from_numpy(v_reset[0])
+    def map_lif(self, node: nir.LIF) -> nn.Module:
+        tau = _uniform_scalar(node.tau, "nir.LIF.tau") / self.dt
+        if not np.isfinite(tau) or tau <= 1.0:
+            raise ValueError("nir.LIF.tau / dt must be finite and greater than 1.")
+        r = _uniform_scalar(node.r, "nir.LIF.r")
+        if _matches_discretization(r, 1.0):
+            decay_input = True
+        elif _matches_discretization(r, tau):
+            decay_input = False
+        else:
+            raise ValueError("nir.LIF.r must equal 1 or tau / dt.")
 
-        # r can be reconstructed directly from self.dt
-        r_value = 1.0 / self.dt
-        if not np.allclose(np.unique(node.r), r_value):
-            raise AssertionError("`nir.IF.r` mismatch 1.0/dt !")
+        v_reset = _uniform_scalar(node.v_reset, "nir.LIF.v_reset")
+        v_leak = _uniform_scalar(node.v_leak, "nir.LIF.v_leak")
+        if not _matches_discretization(v_leak, v_reset):
+            raise ValueError("nir.LIF.v_leak must equal v_reset.")
 
-        return neuron.IFNode(v_threshold=v_threshold, v_reset=v_reset)
+        return _NIRStatefulModule(
+            neuron.LIFNode(
+                tau=tau,
+                decay_input=decay_input,
+                v_reset=v_reset,
+                v_threshold=_uniform_scalar(node.v_threshold, "nir.LIF.v_threshold"),
+            )
+        )
 
-    def map_lif(self, node: nir.LIF) -> neuron.LIFNode:
-        tau_ = np.unique(node.tau)
-        if tau_.size != 1:
-            raise AssertionError("`tau` must be the same for all neurons!")
-        tau = _from_numpy(tau_[0] / self.dt)  # reverse tau_ = tau * dt
+    def map_cuba_lif(self, node: nir.CubaLIF) -> nn.Module:
+        tau_syn = _uniform_scalar(node.tau_syn, "nir.CubaLIF.tau_syn")
+        tau_mem = _uniform_scalar(node.tau_mem, "nir.CubaLIF.tau_mem")
+        if not np.isfinite(tau_syn) or not np.isfinite(tau_mem):
+            raise ValueError("nir.CubaLIF time constants must be finite.")
+        if tau_syn < self.dt or tau_mem < self.dt:
+            raise ValueError("nir.CubaLIF time constants must be at least dt.")
+        r = _uniform_scalar(node.r, "nir.CubaLIF.r")
+        if not _matches_discretization(r, tau_mem / self.dt):
+            raise ValueError("nir.CubaLIF.r must equal tau_mem / dt.")
+        w_in = _uniform_scalar(node.w_in, "nir.CubaLIF.w_in")
+        if not _matches_discretization(w_in, tau_syn / self.dt):
+            raise ValueError("nir.CubaLIF.w_in must equal tau_syn / dt.")
+        v_leak = _uniform_scalar(node.v_leak, "nir.CubaLIF.v_leak")
+        if not _matches_discretization(v_leak, 0.0):
+            raise ValueError("nir.CubaLIF.v_leak must equal 0.")
 
-        r = np.unique(node.r)
-        if r.size != 1:
-            raise AssertionError("`r` must be the same for all neurons!")
-        r = _from_numpy(r[0])
-        # note that: r = 1. if decay_input else tau
-        decay_input = False if r == tau else (True if r == 1.0 else False)
-
-        v_reset = np.unique(node.v_reset)
-        if v_reset.size != 1:
-            raise AssertionError("`v_reset` must be the same for all neurons!")
-        v_reset = _from_numpy(v_reset[0])
-
-        # Recover v_leak (usually equals v_reset in torch->NIR conversion)
-        v_leak = np.unique(node.v_leak)
-        if v_leak.size != 1:
-            raise AssertionError("`v_leak` must be the same for all neurons!")
-        v_leak = _from_numpy(v_leak[0])
-        if v_leak != v_reset:
-            raise AssertionError("`v_leak` should be equal to `v_reset`!")
-
-        v_threshold = np.unique(node.v_threshold)
-        if v_threshold.size != 1:
-            raise AssertionError("`v_threshold` must be the same for all neurons!")
-        v_threshold = _from_numpy(v_threshold[0])
-
-        return neuron.LIFNode(
-            tau=tau,
-            decay_input=decay_input,
-            v_reset=v_reset,
-            v_threshold=v_threshold,
+        return _NIRStatefulModule(
+            neuron.CUBALIFNode(
+                c_decay=1.0 - self.dt / tau_syn,
+                v_decay=1.0 - self.dt / tau_mem,
+                v_threshold=_uniform_scalar(
+                    node.v_threshold, "nir.CubaLIF.v_threshold"
+                ),
+                v_reset=_uniform_scalar(node.v_reset, "nir.CubaLIF.v_reset"),
+            )
         )
 
 
 def import_from_nir(
-    graph: Union[nir.NIRGraph, str],
+    graph: Union[nir.NIRGraph, str, Path],
     dt: float = 1e-4,
     device: str = "cpu",
     dtype: torch.dtype = torch.float32,
@@ -165,11 +239,12 @@ def import_from_nir(
 
     将 `NIR（Neuromorphic Intermediate Representation） <https://neuroir.org/docs/index.html>`_ 图
     转换为 SpikingJelly 神经网络模型。函数会根据 NIR 节点类型自动映射为对应的
-    SpikingJelly 模块（如 Linear、Conv2d、IF/LIF 神经元等），并返回可直接运行的
-    ``fx.GraphModule`` 对象。
+    SpikingJelly 模块（如 Linear、Conv、IF/LIF/CubaLIF 神经元等），并返回可直接运行的
+    ``fx.GraphModule`` 对象。模型前向返回 ``(output, state)``；传入 ``state=None``
+    会从初始状态运行，连续运行时应将上一次返回的 ``state`` 传回模型。
 
     :param graph: NIR 图，或存储 NIR 图的 HDF5 文件路径
-    :type graph: Union[nir.NIRGraph, str]
+    :type graph: Union[nir.NIRGraph, str, Path]
 
     :param dt: 网络时间步长，单位为秒，用于重构 IF/LIF 节点的时间常量等超参数。默认值为 ``1e-4``，与大多数兼容 NIR 的框架一致
     :type dt: float
@@ -181,11 +256,13 @@ def import_from_nir(
     :type dtype: torch.dtype
 
     :param step_mode: 步进模式，可选 ``'s'`` (单步) 或 ``'m'`` (多步)。NIR 图将首先转换到单步模式的 SpikingJelly 模型，
-        随后统一改变模型中所有子模块的步进模式
+        随后统一改变模型中所有子模块的步进模式。循环图仅支持 ``'s'``
     :type step_mode: str
 
     :return: 转换得到的 ``fx.GraphModule`` 对象
     :rtype: torch.fx.GraphModule
+    :raises ValueError: ``dt`` 非正、``step_mode`` 非法，或 NIR 神经元参数非均匀、不符合 SpikingJelly 离散化约束
+    :raises NotImplementedError: NIR 图包含 grouped convolution，或循环图使用多步模式
 
     ----
 
@@ -195,11 +272,14 @@ def import_from_nir(
 
     Convert a `NIR（Neuromorphic Intermediate Representation） <https://neuroir.org/docs/index.html>`_
     graph to a SpikingJelly model. The function automatically maps NIR nodes to
-    corresponding SpikingJelly modules (e.g., Linear, Conv2d, IF/LIF neurons)
-    and returns an runnable :class:`fx.GraphModule <https://docs.pytorch.org/docs/stable/fx.html#torch.fx.GraphModule>` object.
+    corresponding SpikingJelly modules (e.g., Linear, convolution, and
+    IF/LIF/CubaLIF neurons) and returns a runnable
+    :class:`fx.GraphModule <https://docs.pytorch.org/docs/stable/fx.html#torch.fx.GraphModule>`.
+    Its forward pass returns ``(output, state)``. Passing ``state=None`` starts
+    from the initial state; pass the previously returned ``state`` to continue.
 
     :param graph: NIR graph, or the path to the HDF5 file storing the NIR graph
-    :type graph: Union[nir.NIRGraph, str]
+    :type graph: Union[nir.NIRGraph, str, Path]
 
     :param dt: simulation time step in seconds, used to reconstruct time constant
         and other neuronal hyperparameters. Default is ``1e-4``, which is consistent
@@ -214,19 +294,35 @@ def import_from_nir(
 
     :param step_mode: step mode, either ``'s'`` (single-step) or ``'m'`` (multi-step).
         NIR graph will first be converted to a single-step SpikingJelly model.
-        Then, all the submodules will be set to the specified step mode.
+        Then, all the submodules will be set to the specified step mode. Recurrent
+        graphs support only ``'s'``.
     :type step_mode: str
 
     :return: the converted SpikingJelly ``fx.GraphModule`` object
     :rtype: torch.fx.GraphModule
+    :raises ValueError: If ``dt`` is not positive, ``step_mode`` is invalid, or
+        NIR neuron parameters are non-uniform or incompatible with SpikingJelly
+        discretization
+    :raises NotImplementedError: If the NIR graph contains grouped convolution,
+        or a recurrent graph uses multi-step mode
     """
+    if dt <= 0:
+        raise ValueError("dt must be positive.")
+    if step_mode not in ("s", "m"):
+        raise ValueError("step_mode must be 's' or 'm'.")
+
+    source_is_path = isinstance(graph, (str, Path))
+    if source_is_path:
+        graph = nir.read(graph)
+    if step_mode == "m" and _has_cycle(graph):
+        raise NotImplementedError("Recurrent NIR graphs require step_mode='s'.")
     mapper = _NodeMapper(dt=dt)
 
     gm = nirtorch.nir_to_torch(graph, mapper.map_dict, device=device, dtype=dtype)
     functional.set_step_mode(gm, step_mode)
     logger.info(
         "Import completed: source={} device={} dtype={} step_mode={} modules={}",
-        "path" if isinstance(graph, str) else type(graph).__name__,
+        "path" if source_is_path else type(graph).__name__,
         device,
         dtype,
         step_mode,

--- a/spikingjelly/activation_based/nir_exchange/to_nir.py
+++ b/spikingjelly/activation_based/nir_exchange/to_nir.py
@@ -1,16 +1,18 @@
-from typing import Optional, Union
+import copy
 from pathlib import Path
+from typing import Optional, Union
 
+import nir
+import nirtorch
 import numpy as np
 import torch
 import torch.nn as nn
 from torch import fx
 from torch.fx.passes.shape_prop import ShapeProp
-import nir
-import nirtorch
+from torch.utils._pytree import tree_map
 
-from .. import layer, neuron
-from spikingjelly.logger import logger
+from .. import base, layer, neuron
+from ...logger import logger
 
 
 __all__ = ["export_to_nir"]
@@ -33,10 +35,22 @@ class _ModuleMapper:
         self.set_module_io_shape(example_input)
 
     def set_module_io_shape(self, example_input: torch.Tensor):
-        tracer = nirtorch.torch_tracer.NIRTorchTracer(self.map_dict.keys())
-        graph = tracer.trace(self.net)
-        gm = fx.GraphModule(tracer.root, graph)
-        ShapeProp(gm).propagate(example_input)
+        memories = tree_map(
+            lambda value: (
+                value.detach().clone()
+                if isinstance(value, torch.Tensor)
+                else copy.deepcopy(value)
+            ),
+            base.extract_memories(self.net),
+        )
+        try:
+            tracer = nirtorch.torch_tracer.NIRTorchTracer(self.map_dict.keys())
+            graph = tracer.trace(self.net)
+            gm = fx.GraphModule(tracer.root, graph)
+            with torch.no_grad():
+                ShapeProp(gm).propagate(example_input)
+        finally:
+            base.load_memories(self.net, memories)
 
         for node in gm.graph.nodes:
             if node.op != "call_module":
@@ -45,24 +59,20 @@ class _ModuleMapper:
                 continue
 
             module = gm.get_submodule(node.target)
-            output_shape = node.meta["tensor_meta"].shape
-
             input_shapes = []
             for in_node in node.all_input_nodes:
                 if "tensor_meta" in in_node.meta:
                     input_shapes.append(in_node.meta["tensor_meta"].shape)
             input_shape = input_shapes[0]  # most modules has only one input
-
-            self.module_io_shape[module] = {
-                "input_shape": input_shape,
-                "output_shape": output_shape,
-            }
+            self.module_io_shape[module] = input_shape
 
     @property
     def map_dict(self) -> dict:
         return {
             nn.Linear: self.map_linear,
             layer.Linear: self.map_linear,
+            nn.Conv1d: self.map_conv1d,
+            layer.Conv1d: self.map_conv1d,
             nn.Conv2d: self.map_conv2d,
             layer.Conv2d: self.map_conv2d,
             nn.AvgPool2d: self.map_avgpool2d,
@@ -72,39 +82,71 @@ class _ModuleMapper:
             neuron.IFNode: self.map_if,
             neuron.LIFNode: self.map_lif,
             neuron.ParametricLIFNode: self.map_plif,
+            neuron.CUBALIFNode: self.map_cuba_lif,
         }
-
-    def map(self, module: nn.Module) -> nir.NIRNode:
-        return self.map_dict[module.__class__](module)
 
     def map_linear(self, module: nn.Linear) -> nir.NIRNode:
         if module.bias is None:
             return nir.Linear(_to_numpy(module.weight))
-        else:
-            return nir.Affine(_to_numpy(module.weight), _to_numpy(module.bias))
+        return nir.Affine(_to_numpy(module.weight), _to_numpy(module.bias))
+
+    @staticmethod
+    def _conv_bias(module: nn.Module) -> np.ndarray:
+        if module.bias is None:
+            return np.zeros(
+                module.weight.shape[0], dtype=_to_numpy(module.weight).dtype
+            )
+        return _to_numpy(module.bias)
+
+    @staticmethod
+    def _require_ungrouped(module: nn.Module) -> None:
+        if module.groups != 1:
+            raise NotImplementedError(
+                "NIR type inference does not support grouped convolutions."
+            )
+        if module.padding_mode != "zeros":
+            raise NotImplementedError("NIR supports only zero-padded convolutions.")
+
+    def map_conv1d(self, module: nn.Conv1d) -> nir.Conv1d:
+        self._require_ungrouped(module)
+        padding = (
+            module.padding if isinstance(module.padding, str) else module.padding[0]
+        )
+        return nir.Conv1d(
+            input_shape=self.module_io_shape[module][-1],
+            weight=_to_numpy(module.weight),
+            stride=module.stride[0],
+            padding=padding,
+            dilation=module.dilation[0],
+            groups=module.groups,
+            bias=self._conv_bias(module),
+        )
 
     def map_conv2d(self, module: nn.Conv2d) -> nir.Conv2d:
-        if module.bias is None:
-            bias = np.zeros((module.weight.shape[0]))
-        else:
-            bias = _to_numpy(module.bias)
-
-        H, W = self.module_io_shape[module]["input_shape"][-2:]
-
+        self._require_ungrouped(module)
+        height, width = self.module_io_shape[module][-2:]
         return nir.Conv2d(
-            input_shape=(H, W),
+            input_shape=(height, width),
             weight=_to_numpy(module.weight),
             stride=module.stride,
             padding=module.padding,
             dilation=module.dilation,
             groups=module.groups,
-            bias=bias,
+            bias=self._conv_bias(module),
         )
 
     def map_avgpool2d(self, module: nn.AvgPool2d) -> nir.NIRNode:
+        if (
+            module.ceil_mode
+            or (np.any(module.padding) and not module.count_include_pad)
+            or module.divisor_override is not None
+        ):
+            raise NotImplementedError(
+                "NIR does not represent this AvgPool2d configuration."
+            )
         return nir.AvgPool2d(
             kernel_size=module.kernel_size,
-            stride=module.stride,
+            stride=module.kernel_size if module.stride is None else module.stride,
             padding=module.padding,
         )
 
@@ -113,7 +155,7 @@ class _ModuleMapper:
         start_dim = start_dim - 1 if start_dim > 0 else start_dim
         end_dim = end_dim - 1 if end_dim > 0 else end_dim
 
-        input_shape = self.module_io_shape[module]["input_shape"]
+        input_shape = self.module_io_shape[module]
         input_type_start = 1
         if hasattr(module, "step_mode") and module.step_mode == "m":
             input_type_start = 2
@@ -124,101 +166,71 @@ class _ModuleMapper:
             end_dim=end_dim,
         )
 
-    def map_if(self, module: neuron.IFNode) -> nir.IF:
-        """
-        .. warning::
-
-            `nir.IF` does not distinguish soft reset from hard reset. If
-            `module.v_reset=None` (i.e. soft reset), it will be converted to
-            `module.v_reset=0` (i.e. hard reset with 0 reset potential).
-        """
-        v_reset = module.v_reset
-        v_threshold = module.v_threshold
-
-        r = 1 / self.dt
-        v_reset_ = 0.0 if v_reset is None else v_reset
-
-        input_shape = self.module_io_shape[module]["input_shape"]
-        output_shape = self.module_io_shape[module]["output_shape"]
+    def _neuron_shape(self, module: nn.Module) -> torch.Size:
         type_start = 1 if module.step_mode == "s" else 2
-        input_type = input_shape[type_start:]
-        output_type = output_shape[type_start:]  # remove the T and B dims
+        return self.module_io_shape[module][type_start:]
+
+    @staticmethod
+    def _hard_reset(module: neuron.BaseNode) -> float:
+        if module.v_reset is None:
+            raise NotImplementedError("NIR does not distinguish soft reset.")
+        return module.v_reset
+
+    def map_if(self, module: neuron.IFNode) -> nir.IF:
+        shape = self._neuron_shape(module)
+        v_reset = self._hard_reset(module)
 
         return nir.IF(
-            r=np.full(input_type, r),
-            v_threshold=np.full(input_type, v_threshold),
-            v_reset=np.full(input_type, v_reset_),
-            input_type=input_type,
-            output_type=output_type,
+            r=np.full(shape, 1.0 / self.dt),
+            v_threshold=np.full(shape, module.v_threshold),
+            v_reset=np.full(shape, v_reset),
         )
 
     def map_lif(self, module: neuron.LIFNode) -> nir.LIF:
-        """
-        .. warning::
-
-            `nir.LIF` does not distinguish soft reset from hard reset. If
-            `module.v_reset=None` (i.e. soft reset), it will be converted to
-            `module.v_reset=0` (i.e. hard reset with 0 reset potential).
-        """
         tau = module.tau
-        v_reset = module.v_reset
-        v_threshold = module.v_threshold
-        decay_input = module.decay_input
-
-        tau_ = tau * self.dt
-        r = 1.0 if decay_input else tau
-        v_leak = 0.0 if v_reset is None else v_reset
-        v_reset_ = 0.0 if v_reset is None else v_reset
-
-        input_shape = self.module_io_shape[module]["input_shape"]
-        output_shape = self.module_io_shape[module]["output_shape"]
-        type_start = 1 if module.step_mode == "s" else 2
-        input_type = input_shape[type_start:]
-        output_type = output_shape[type_start:]  # remove the T and B dims
+        v_reset = self._hard_reset(module)
+        shape = self._neuron_shape(module)
 
         return nir.LIF(
-            tau=np.full(input_type, tau_),
-            r=np.full(input_type, r),
-            v_leak=np.full(input_type, v_leak),
-            v_threshold=np.full(input_type, v_threshold),
-            v_reset=np.full(input_type, v_reset_),
-            input_type=input_type,
-            output_type=output_type,
+            tau=np.full(shape, tau * self.dt),
+            r=np.full(shape, 1.0 if module.decay_input else tau),
+            v_leak=np.full(shape, v_reset),
+            v_threshold=np.full(shape, module.v_threshold),
+            v_reset=np.full(shape, v_reset),
         )
 
     def map_plif(self, module: neuron.ParametricLIFNode) -> nir.LIF:
-        """
-        .. warning::
-
-            `nir.LIF` does not distinguish soft reset from hard reset. If
-            `module.v_reset=None` (i.e. soft reset), it will be converted to
-            `module.v_reset=0` (i.e. hard reset with 0 reset potential).
-        """
         with torch.no_grad():
-            tau = 1.0 / module.w.sigmoid()
-        v_reset = module.v_reset
-        v_threshold = module.v_threshold
-        decay_input = module.decay_input
-
-        tau_ = tau * self.dt
-        r = 1.0 if decay_input else tau
-        v_leak = 0.0 if v_reset is None else v_reset
-        v_reset_ = 0.0 if v_reset is None else v_reset
-
-        input_shape = self.module_io_shape[module]["input_shape"]
-        output_shape = self.module_io_shape[module]["output_shape"]
-        type_start = 1 if module.step_mode == "s" else 2
-        input_type = input_shape[type_start:]
-        output_type = output_shape[type_start:]  # remove the T and B dims
+            tau = float((1.0 / module.w.sigmoid()).detach().cpu())
+        v_reset = self._hard_reset(module)
+        shape = self._neuron_shape(module)
 
         return nir.LIF(
-            tau=np.full(input_type, tau_),
-            r=np.full(input_type, r),
-            v_leak=np.full(input_type, v_leak),
-            v_threshold=np.full(input_type, v_threshold),
-            v_reset=np.full(input_type, v_reset_),
-            input_type=input_type,
-            output_type=output_type,
+            tau=np.full(shape, tau * self.dt),
+            r=np.full(shape, 1.0 if module.decay_input else tau),
+            v_leak=np.full(shape, v_reset),
+            v_threshold=np.full(shape, module.v_threshold),
+            v_reset=np.full(shape, v_reset),
+        )
+
+    def map_cuba_lif(self, module: neuron.CUBALIFNode) -> nir.CubaLIF:
+        if not 0.0 <= module.c_decay < 1.0:
+            raise ValueError("CUBALIFNode.c_decay must be in [0, 1).")
+        if not 0.0 <= module.v_decay < 1.0:
+            raise ValueError("CUBALIFNode.v_decay must be in [0, 1).")
+
+        shape = self._neuron_shape(module)
+        v_reset = self._hard_reset(module)
+        tau_syn = self.dt / (1.0 - module.c_decay)
+        tau_mem = self.dt / (1.0 - module.v_decay)
+        return nir.CubaLIF(
+            tau_syn=np.full(shape, tau_syn),
+            tau_mem=np.full(shape, tau_mem),
+            r=np.full(shape, tau_mem / self.dt),
+            v_leak=np.zeros(shape),
+            v_threshold=np.full(shape, module.v_threshold),
+            v_reset=np.full(shape, v_reset),
+            w_in=np.full(shape, tau_syn / self.dt),
         )
 
 
@@ -227,7 +239,7 @@ def export_to_nir(
     example_input: torch.Tensor,
     save_path: Optional[Union[str, Path]] = None,
     dt: float = 1e-4,
-):
+) -> nir.NIRGraph:
     """
     **API Language** - :ref:`中文 <export_to_nir-cn>` | :ref:`English <export_to_nir-en>`
 
@@ -244,7 +256,8 @@ def export_to_nir(
     :param net: 需要转换的 SpikingJelly / PyTorch 模型
     :type net: torch.nn.Module
 
-    :param example_input: 用于推导 ``net`` 中各个子模块输入输出形状的示例输入张量
+    :param example_input: 用于推导 ``net`` 中各个子模块输入输出形状的示例输入张量。
+        其 dtype、device、批量维和可选时间维应与 ``net`` 的实际输入一致
     :type example_input: torch.Tensor
 
     :param save_path: 转换后的 NIR 图保存路径。如果不为 ``None``，函数会将 NIR 图写入指定的
@@ -257,6 +270,8 @@ def export_to_nir(
 
     :return: 转换得到的 NIRGraph 对象
     :rtype: nir.NIRGraph
+    :raises ValueError: ``dt`` 非正，或 CUBALIF 衰减参数超出可转换范围
+    :raises NotImplementedError: 模型使用 soft reset、grouped convolution 或 NIR 无法表示的层配置
 
     ----
 
@@ -274,7 +289,8 @@ def export_to_nir(
     :type net: torch.nn.Module
 
     :param example_input: an example input tensor used to infer the input and
-        output shapes of each submodule in ``net``
+        output shapes of each submodule in ``net``. Its dtype, device, batch
+        dimension, and optional time dimension must match the actual model input
     :type example_input: torch.Tensor
 
     :param save_path: the path to save the converted NIR graph. If not ``None``,
@@ -289,7 +305,14 @@ def export_to_nir(
 
     :return: the converted NIRGraph object
     :rtype: nir.NIRGraph
+    :raises ValueError: If ``dt`` is not positive or CUBALIF decay parameters
+        cannot be represented
+    :raises NotImplementedError: If the model uses soft reset, grouped convolution,
+        or another layer configuration that NIR cannot represent
     """
+    if dt <= 0:
+        raise ValueError("dt must be positive.")
+
     mapper = _ModuleMapper(net, example_input, dt=dt)
 
     graph = nirtorch.torch_to_nir(net, mapper.map_dict, type_check=True)

--- a/spikingjelly/activation_based/nir_exchange/to_nir.py
+++ b/spikingjelly/activation_based/nir_exchange/to_nir.py
@@ -35,6 +35,7 @@ class _ModuleMapper:
         self.set_module_io_shape(example_input)
 
     def set_module_io_shape(self, example_input: torch.Tensor):
+        # Memory slots can contain nested non-leaf tensors, which deepcopy rejects.
         memories = tree_map(
             lambda value: (
                 value.detach().clone()
@@ -91,48 +92,54 @@ class _ModuleMapper:
         return nir.Affine(_to_numpy(module.weight), _to_numpy(module.bias))
 
     @staticmethod
-    def _conv_bias(module: nn.Module) -> np.ndarray:
-        if module.bias is None:
-            return np.zeros(
-                module.weight.shape[0], dtype=_to_numpy(module.weight).dtype
-            )
-        return _to_numpy(module.bias)
-
-    @staticmethod
-    def _require_ungrouped(module: nn.Module) -> None:
+    def _validate_conv(module: nn.Module) -> None:
         if module.groups != 1:
             raise NotImplementedError(
-                "NIR type inference does not support grouped convolutions."
+                "Grouped convolutions are not supported by NIR exchange."
             )
         if module.padding_mode != "zeros":
-            raise NotImplementedError("NIR supports only zero-padded convolutions.")
+            raise NotImplementedError(
+                "NIR exchange supports only zero-padded convolutions."
+            )
 
     def map_conv1d(self, module: nn.Conv1d) -> nir.Conv1d:
-        self._require_ungrouped(module)
+        self._validate_conv(module)
+        weight = _to_numpy(module.weight)
+        bias = (
+            _to_numpy(module.bias)
+            if module.bias is not None
+            else np.zeros(weight.shape[0], dtype=weight.dtype)
+        )
         padding = (
             module.padding if isinstance(module.padding, str) else module.padding[0]
         )
         return nir.Conv1d(
             input_shape=self.module_io_shape[module][-1],
-            weight=_to_numpy(module.weight),
+            weight=weight,
             stride=module.stride[0],
             padding=padding,
             dilation=module.dilation[0],
             groups=module.groups,
-            bias=self._conv_bias(module),
+            bias=bias,
         )
 
     def map_conv2d(self, module: nn.Conv2d) -> nir.Conv2d:
-        self._require_ungrouped(module)
+        self._validate_conv(module)
+        weight = _to_numpy(module.weight)
+        bias = (
+            _to_numpy(module.bias)
+            if module.bias is not None
+            else np.zeros(weight.shape[0], dtype=weight.dtype)
+        )
         height, width = self.module_io_shape[module][-2:]
         return nir.Conv2d(
             input_shape=(height, width),
-            weight=_to_numpy(module.weight),
+            weight=weight,
             stride=module.stride,
             padding=module.padding,
             dilation=module.dilation,
             groups=module.groups,
-            bias=self._conv_bias(module),
+            bias=bias,
         )
 
     def map_avgpool2d(self, module: nn.AvgPool2d) -> nir.NIRNode:
@@ -146,7 +153,7 @@ class _ModuleMapper:
             )
         return nir.AvgPool2d(
             kernel_size=module.kernel_size,
-            stride=module.kernel_size if module.stride is None else module.stride,
+            stride=module.stride,
             padding=module.padding,
         )
 
@@ -200,8 +207,7 @@ class _ModuleMapper:
         )
 
     def map_plif(self, module: neuron.ParametricLIFNode) -> nir.LIF:
-        with torch.no_grad():
-            tau = float((1.0 / module.w.sigmoid()).detach().cpu())
+        tau = 1.0 / module.w.sigmoid().item()
         v_reset = self._hard_reset(module)
         shape = self._neuron_shape(module)
 

--- a/test/activation_based/test_nir_exchange.py
+++ b/test/activation_based/test_nir_exchange.py
@@ -1,0 +1,293 @@
+from pathlib import Path
+
+import pytest
+
+nir = pytest.importorskip("nir")
+pytest.importorskip("nirtorch")
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from spikingjelly.activation_based import base, functional, layer, neuron, nir_exchange
+
+
+@pytest.mark.parametrize("step_mode", ["s", "m"])
+def test_existing_nodes_round_trip(tmp_path: Path, step_mode: str):
+    torch.manual_seed(0)
+    net = nn.Sequential(
+        layer.Conv2d(2, 3, 3, padding=1),
+        neuron.IFNode(v_threshold=0.5, v_reset=0.0),
+        layer.AvgPool2d(2),
+        layer.Flatten(),
+        layer.Linear(3 * 4 * 4, 4),
+        neuron.ParametricLIFNode(init_tau=2.0, v_reset=0.0),
+    )
+    functional.set_step_mode(net, step_mode)
+    shape = (2, 2, 8, 8) if step_mode == "s" else (3, 2, 2, 8, 8)
+    x = torch.rand(shape)
+    path = tmp_path / "model.nir"
+
+    nir_exchange.export_to_nir(net, x, path)
+    restored = nir_exchange.import_from_nir(path, step_mode=step_mode)
+
+    functional.reset_net(net)
+    expected = net(x)
+    actual, _ = restored(x)
+    assert torch.equal(actual, expected)
+
+    restored_conv = next(m for m in restored.modules() if isinstance(m, layer.Conv2d))
+    assert restored_conv.in_channels == 2
+    assert restored_conv.out_channels == 3
+
+
+@pytest.mark.parametrize("step_mode", ["s", "m"])
+def test_conv1d_cuba_lif_round_trip(tmp_path: Path, step_mode: str):
+    torch.manual_seed(1)
+    net = nn.Sequential(
+        layer.Conv1d(2, 3, 3, padding=1),
+        neuron.CUBALIFNode(
+            c_decay=0.5,
+            v_decay=0.75,
+            v_threshold=0.5,
+            v_reset=0.0,
+        ),
+    )
+    functional.set_step_mode(net, step_mode)
+    shape = (2, 2, 8) if step_mode == "s" else (4, 2, 2, 8)
+    x = torch.rand(shape)
+
+    path = tmp_path / "conv1d-cuba-lif.nir"
+    nir_exchange.export_to_nir(net, x, path)
+    graph = nir.read(path)
+    restored = nir_exchange.import_from_nir(path, step_mode=step_mode)
+
+    functional.reset_net(net)
+    expected = net(x)
+    actual, _ = restored(x)
+    assert torch.equal(actual, expected)
+    assert any(isinstance(node, nir.Conv1d) for node in graph.nodes.values())
+    assert any(isinstance(node, nir.CubaLIF) for node in graph.nodes.values())
+
+
+def test_linear_without_bias_round_trip():
+    net = nn.Sequential(layer.Linear(3, 2, bias=False))
+    x = torch.rand(4, 3)
+
+    graph = nir_exchange.export_to_nir(net, x)
+    restored = nir_exchange.import_from_nir(graph)
+
+    actual, _ = restored(x)
+    assert torch.equal(actual, net(x))
+    assert any(isinstance(node, nir.Linear) for node in graph.nodes.values())
+
+
+def test_imported_state_is_explicit():
+    dt = 1e-4
+    graph = nir.NIRGraph(
+        nodes={
+            "input": nir.Input({"input": np.array([2])}),
+            "if": nir.IF(
+                r=np.full(2, 1.0 / dt),
+                v_threshold=np.ones(2),
+                v_reset=np.zeros(2),
+            ),
+            "output": nir.Output({"output": np.array([2])}),
+        },
+        edges=[("input", "if"), ("if", "if"), ("if", "output")],
+        type_check=False,
+    )
+    model = nir_exchange.import_from_nir(graph, dt=dt, dtype=torch.float64)
+    x = torch.full((1, 2), 0.6, dtype=torch.float64)
+
+    first, state = model(x)
+    continued, _ = model(x, state)
+    fresh, _ = model(x)
+
+    assert torch.count_nonzero(first) == 0
+    assert torch.count_nonzero(continued) == continued.numel()
+    assert torch.equal(fresh, first)
+    assert first.dtype == torch.float64
+    assert list(base.memories(model)) == [0.0]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
+def test_plif_cuda_round_trip():
+    net = nn.Sequential(neuron.ParametricLIFNode(v_reset=0.0)).cuda()
+    x = torch.rand(2, 3, device="cuda")
+
+    graph = nir_exchange.export_to_nir(net, x)
+    restored = nir_exchange.import_from_nir(graph, device="cuda")
+
+    functional.reset_net(net)
+    expected = net(x)
+    actual, _ = restored(x)
+    assert torch.equal(actual, expected)
+
+
+def test_export_preserves_memories():
+    net = nn.Sequential(neuron.LIFNode(tau=2.0, v_reset=0.0))
+    x = torch.full((1, 2), 0.75)
+    net(x)
+    before = [value.clone() for value in base.memories(net)]
+
+    nir_exchange.export_to_nir(net, x)
+
+    after = list(base.memories(net))
+    assert all(torch.equal(x, y) for x, y in zip(before, after))
+
+
+def test_export_restores_memories_when_tracing_fails():
+    class FailingNet(base.MemoryModule):
+        def __init__(self):
+            super().__init__()
+            self.register_memory("trace_count", torch.tensor(0))
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            self.trace_count.add_(1)
+            raise RuntimeError("trace failed")
+
+    net = FailingNet()
+    with pytest.raises(RuntimeError, match="trace failed"):
+        nir_exchange.export_to_nir(net, torch.rand(1, 2))
+    assert torch.equal(net.trace_count, torch.tensor(0))
+
+
+def test_rejects_unrepresentable_models():
+    with pytest.raises(NotImplementedError, match="soft reset"):
+        nir_exchange.export_to_nir(
+            nn.Sequential(neuron.LIFNode(v_reset=None)), torch.rand(1, 2)
+        )
+
+    with pytest.raises(NotImplementedError, match="grouped convolutions"):
+        nir_exchange.export_to_nir(
+            nn.Sequential(layer.Conv2d(2, 2, 3, groups=2)),
+            torch.rand(1, 2, 5, 5),
+        )
+
+    with pytest.raises(NotImplementedError, match="AvgPool2d"):
+        nir_exchange.export_to_nir(
+            nn.Sequential(layer.AvgPool2d(2, padding=1, count_include_pad=False)),
+            torch.rand(1, 2, 5, 5),
+        )
+
+
+def test_rejects_invalid_nir_parameters():
+    graph = nir.NIRGraph.from_list(
+        nir.IF(
+            r=np.full(2, 1e4),
+            v_threshold=np.array([1.0, 2.0]),
+            v_reset=np.zeros(2),
+        )
+    )
+    with pytest.raises(ValueError, match="uniform"):
+        nir_exchange.import_from_nir(graph)
+
+    heterogeneous_r = nir.NIRGraph.from_list(
+        nir.IF(
+            r=np.array([1e4, 1e4 + 0.01]),
+            v_threshold=np.ones(2),
+            v_reset=np.zeros(2),
+        )
+    )
+    with pytest.raises(ValueError, match="nir.IF.r must be uniform"):
+        nir_exchange.import_from_nir(heterogeneous_r)
+
+    incompatible_r = nir.NIRGraph.from_list(
+        nir.IF(
+            r=np.full(2, 1e4 + 0.05),
+            v_threshold=np.ones(2),
+            v_reset=np.zeros(2),
+        )
+    )
+    with pytest.raises(ValueError, match="nir.IF.r must equal"):
+        nir_exchange.import_from_nir(incompatible_r)
+
+    invalid_lif = nir.NIRGraph.from_list(
+        nir.LIF(
+            tau=np.full(2, 0.5e-4),
+            r=np.ones(2),
+            v_leak=np.zeros(2),
+            v_threshold=np.ones(2),
+            v_reset=np.zeros(2),
+        )
+    )
+    with pytest.raises(ValueError, match="greater than 1"):
+        nir_exchange.import_from_nir(invalid_lif)
+
+    infinite_lif = nir.NIRGraph.from_list(
+        nir.LIF(
+            tau=np.full(2, np.inf),
+            r=np.full(2, np.inf),
+            v_leak=np.zeros(2),
+            v_threshold=np.ones(2),
+            v_reset=np.zeros(2),
+        )
+    )
+    with pytest.raises(ValueError, match="finite"):
+        nir_exchange.import_from_nir(infinite_lif)
+
+    with pytest.raises(ValueError, match="positive"):
+        nir_exchange.import_from_nir(graph, dt=0.0)
+    with pytest.raises(ValueError, match="step_mode"):
+        nir_exchange.import_from_nir(graph, step_mode="invalid")
+    with pytest.raises(ValueError, match="positive"):
+        nir_exchange.export_to_nir(nn.Identity(), torch.rand(1, 2), dt=0.0)
+
+    recurrent = nir.NIRGraph(
+        nodes={"lif": graph.nodes["if"]},
+        edges=[("lif", "lif")],
+        type_check=False,
+    )
+    with pytest.raises(NotImplementedError, match="step_mode='s'"):
+        nir_exchange.import_from_nir(recurrent, step_mode="m")
+
+
+@pytest.mark.parametrize(
+    ("field", "values"),
+    [
+        ("r", np.array([4.0, 4.0 + 1e-6])),
+        ("w_in", np.array([2.0, 2.0 + 1e-6])),
+        ("v_leak", np.array([0.0, 1e-12])),
+    ],
+)
+def test_rejects_heterogeneous_cuba_lif_parameters(field: str, values: np.ndarray):
+    node = nir.CubaLIF(
+        tau_syn=np.full(2, 2e-4),
+        tau_mem=np.full(2, 4e-4),
+        r=np.full(2, 4.0),
+        v_leak=np.zeros(2),
+        v_threshold=np.ones(2),
+        v_reset=np.zeros(2),
+        w_in=np.full(2, 2.0),
+    )
+    setattr(node, field, values)
+
+    with pytest.raises(ValueError, match=rf"nir.CubaLIF.{field} must be uniform"):
+        nir_exchange.import_from_nir(nir.NIRGraph.from_list(node))
+
+
+def test_rejects_incompatible_cuba_lif_parameters():
+    incompatible = nir.CubaLIF(
+        tau_syn=np.full(2, 2e-4),
+        tau_mem=np.full(2, 4e-4),
+        r=np.full(2, 4.0 + 2e-5),
+        v_leak=np.zeros(2),
+        v_threshold=np.ones(2),
+        v_reset=np.zeros(2),
+        w_in=np.full(2, 2.0),
+    )
+    with pytest.raises(ValueError, match="nir.CubaLIF.r must equal"):
+        nir_exchange.import_from_nir(nir.NIRGraph.from_list(incompatible))
+
+    non_finite = nir.CubaLIF(
+        tau_syn=np.full(2, np.inf),
+        tau_mem=np.full(2, 4e-4),
+        r=np.full(2, 4.0),
+        v_leak=np.zeros(2),
+        v_threshold=np.ones(2),
+        v_reset=np.zeros(2),
+        w_in=np.full(2, np.inf),
+    )
+    with pytest.raises(ValueError, match="finite"):
+        nir_exchange.import_from_nir(nir.NIRGraph.from_list(non_finite))

--- a/test/activation_based/test_nir_exchange.py
+++ b/test/activation_based/test_nir_exchange.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 import pytest
@@ -134,7 +135,10 @@ def test_export_preserves_memories():
     nir_exchange.export_to_nir(net, x)
 
     after = list(base.memories(net))
-    assert all(torch.equal(x, y) for x, y in zip(before, after))
+    assert all(
+        torch.equal(expected, actual)
+        for expected, actual in zip(before, after, strict=True)
+    )
 
 
 def test_export_restores_memories_when_tracing_fails():
@@ -190,7 +194,7 @@ def test_rejects_invalid_nir_parameters():
             v_reset=np.zeros(2),
         )
     )
-    with pytest.raises(ValueError, match="nir.IF.r must be uniform"):
+    with pytest.raises(ValueError, match=re.escape("nir.IF.r must be uniform")):
         nir_exchange.import_from_nir(heterogeneous_r)
 
     incompatible_r = nir.NIRGraph.from_list(
@@ -200,7 +204,7 @@ def test_rejects_invalid_nir_parameters():
             v_reset=np.zeros(2),
         )
     )
-    with pytest.raises(ValueError, match="nir.IF.r must equal"):
+    with pytest.raises(ValueError, match=re.escape("nir.IF.r must equal")):
         nir_exchange.import_from_nir(incompatible_r)
 
     invalid_lif = nir.NIRGraph.from_list(
@@ -263,7 +267,9 @@ def test_rejects_heterogeneous_cuba_lif_parameters(field: str, values: np.ndarra
     )
     setattr(node, field, values)
 
-    with pytest.raises(ValueError, match=rf"nir.CubaLIF.{field} must be uniform"):
+    with pytest.raises(
+        ValueError, match=re.escape(f"nir.CubaLIF.{field} must be uniform")
+    ):
         nir_exchange.import_from_nir(nir.NIRGraph.from_list(node))
 
 
@@ -277,7 +283,7 @@ def test_rejects_incompatible_cuba_lif_parameters():
         v_reset=np.zeros(2),
         w_in=np.full(2, 2.0),
     )
-    with pytest.raises(ValueError, match="nir.CubaLIF.r must equal"):
+    with pytest.raises(ValueError, match=re.escape("nir.CubaLIF.r must equal")):
         nir_exchange.import_from_nir(nir.NIRGraph.from_list(incompatible))
 
     non_finite = nir.CubaLIF(

--- a/test/activation_based/test_nir_exchange.py
+++ b/test/activation_based/test_nir_exchange.py
@@ -35,7 +35,7 @@ def test_existing_nodes_round_trip(tmp_path: Path, step_mode: str):
     functional.reset_net(net)
     expected = net(x)
     actual, _ = restored(x)
-    assert torch.equal(actual, expected)
+    torch.testing.assert_close(actual, expected)
 
     restored_conv = next(m for m in restored.modules() if isinstance(m, layer.Conv2d))
     assert restored_conv.in_channels == 2
@@ -66,7 +66,7 @@ def test_conv1d_cuba_lif_round_trip(tmp_path: Path, step_mode: str):
     functional.reset_net(net)
     expected = net(x)
     actual, _ = restored(x)
-    assert torch.equal(actual, expected)
+    torch.testing.assert_close(actual, expected)
     assert any(isinstance(node, nir.Conv1d) for node in graph.nodes.values())
     assert any(isinstance(node, nir.CubaLIF) for node in graph.nodes.values())
 
@@ -79,8 +79,22 @@ def test_linear_without_bias_round_trip():
     restored = nir_exchange.import_from_nir(graph)
 
     actual, _ = restored(x)
-    assert torch.equal(actual, net(x))
+    torch.testing.assert_close(actual, net(x))
     assert any(isinstance(node, nir.Linear) for node in graph.nodes.values())
+
+
+def test_integer_if_parameters_import_as_floats():
+    graph = nir.NIRGraph.from_list(
+        nir.IF(
+            r=np.full(2, 10_000, dtype=np.int64),
+            v_threshold=np.ones(2, dtype=np.int64),
+            v_reset=np.zeros(2, dtype=np.int64),
+        )
+    )
+    model = nir_exchange.import_from_nir(graph)
+
+    output, _ = model(torch.full((1, 2), 0.6))
+    assert torch.count_nonzero(output) == 0
 
 
 def test_imported_state_is_explicit():
@@ -123,7 +137,7 @@ def test_plif_cuda_round_trip():
     functional.reset_net(net)
     expected = net(x)
     actual, _ = restored(x)
-    assert torch.equal(actual, expected)
+    torch.testing.assert_close(actual, expected)
 
 
 def test_export_preserves_memories():
@@ -163,7 +177,7 @@ def test_rejects_unrepresentable_models():
             nn.Sequential(neuron.LIFNode(v_reset=None)), torch.rand(1, 2)
         )
 
-    with pytest.raises(NotImplementedError, match="grouped convolutions"):
+    with pytest.raises(NotImplementedError, match="Grouped convolutions"):
         nir_exchange.export_to_nir(
             nn.Sequential(layer.Conv2d(2, 2, 3, groups=2)),
             torch.rand(1, 2, 5, 5),
@@ -176,7 +190,7 @@ def test_rejects_unrepresentable_models():
         )
 
 
-def test_rejects_invalid_nir_parameters():
+def test_rejects_invalid_if_parameters():
     graph = nir.NIRGraph.from_list(
         nir.IF(
             r=np.full(2, 1e4),
@@ -207,30 +221,33 @@ def test_rejects_invalid_nir_parameters():
     with pytest.raises(ValueError, match=re.escape("nir.IF.r must equal")):
         nir_exchange.import_from_nir(incompatible_r)
 
-    invalid_lif = nir.NIRGraph.from_list(
+
+@pytest.mark.parametrize(
+    ("tau", "r", "match"),
+    [(0.5e-4, 1.0, "greater than 1"), (np.inf, np.inf, "finite")],
+)
+def test_rejects_invalid_lif_time_constants(tau: float, r: float, match: str):
+    graph = nir.NIRGraph.from_list(
         nir.LIF(
-            tau=np.full(2, 0.5e-4),
-            r=np.ones(2),
+            tau=np.full(2, tau),
+            r=np.full(2, r),
             v_leak=np.zeros(2),
             v_threshold=np.ones(2),
             v_reset=np.zeros(2),
         )
     )
-    with pytest.raises(ValueError, match="greater than 1"):
-        nir_exchange.import_from_nir(invalid_lif)
+    with pytest.raises(ValueError, match=match):
+        nir_exchange.import_from_nir(graph)
 
-    infinite_lif = nir.NIRGraph.from_list(
-        nir.LIF(
-            tau=np.full(2, np.inf),
-            r=np.full(2, np.inf),
-            v_leak=np.zeros(2),
+
+def test_rejects_invalid_public_arguments():
+    graph = nir.NIRGraph.from_list(
+        nir.IF(
+            r=np.full(2, 1e4),
             v_threshold=np.ones(2),
             v_reset=np.zeros(2),
         )
     )
-    with pytest.raises(ValueError, match="finite"):
-        nir_exchange.import_from_nir(infinite_lif)
-
     with pytest.raises(ValueError, match="positive"):
         nir_exchange.import_from_nir(graph, dt=0.0)
     with pytest.raises(ValueError, match="step_mode"):
@@ -238,9 +255,16 @@ def test_rejects_invalid_nir_parameters():
     with pytest.raises(ValueError, match="positive"):
         nir_exchange.export_to_nir(nn.Identity(), torch.rand(1, 2), dt=0.0)
 
+
+def test_rejects_recurrent_multistep():
+    node = nir.IF(
+        r=np.full(2, 1e4),
+        v_threshold=np.ones(2),
+        v_reset=np.zeros(2),
+    )
     recurrent = nir.NIRGraph(
-        nodes={"lif": graph.nodes["if"]},
-        edges=[("lif", "lif")],
+        nodes={"if": node},
+        edges=[("if", "if")],
         type_check=False,
     )
     with pytest.raises(NotImplementedError, match="step_mode='s'"):


### PR DESCRIPTION
## Summary

- restore neuron export compatibility with NIR 1.0.8 while retaining NIR 1.0.7 support
- add bidirectional Conv1d and CubaLIF conversion and correct Conv2d channel metadata
- make imported neuron state explicit through NIRTorch 2.6 and preserve source memories during export tracing
- reject lossy soft reset, grouped convolution, unsupported pooling, heterogeneous parameters, and incompatible discretization
- update optional dependency bounds, bilingual docs, changelog, and focused regression coverage

## Validation

- Ruff and uv format checks passed
- NIR 1.0.8: 42 passed, 1 CUDA-only skip locally
- NIR 1.0.7: 14 passed, 1 CUDA-only skip locally
- g3 RTX 4090: 15/15 NIR tests passed for both NIR versions
- g2 A100 and g3 RTX 4090: sparse-linear 48 passed, 3 multi-GPU skips with CUDA/NVRTC 11.8
- g3 activation_based excluding FP8: 1746 passed, 10 skipped
- changelog generation check and Sphinx HTML build passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NIR import/export support for Conv1d and CUBALIF neurons.
  * Added explicit neuron-state handling for continued, restarted, and multi-step execution.
  * Added support for importing NIR graphs from file paths.

* **Bug Fixes**
  * Preserved neuron memories during export and shape inference.
  * Improved convolution metadata and neuron export compatibility.

* **Documentation**
  * Updated NIR tutorials, installation guidance, supported modules, and state-management examples.

* **Breaking Changes**
  * Unsupported soft resets, grouped convolutions, heterogeneous parameters, and multi-step recurrent graphs are now rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->