### PR TITLE
Add Complementary LIF neuron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and the archived documentation linked from the project README.
 
 ## Unreleased
 
+### Features
+
+#### Spiking Neurons
+
+Module: `spikingjelly.activation_based.neuron`.
+
+- Added the paper-faithful `ComplementaryLIFNode` with single-step and
+  multi-step PyTorch execution and optional trajectories for both neuron states.
+
 ## 2.0.0.dev2 - 2026-08-23
 
 ### Improvements

--- a/docs/source/APIs/spikingjelly.activation_based.neuron.rst
+++ b/docs/source/APIs/spikingjelly.activation_based.neuron.rst
@@ -155,6 +155,8 @@ LIF Variants
      - Gated LIF (GLIF) neuron.
    * - :class:`KLIFNode <spikingjelly.activation_based.neuron.lif_variants.KLIFNode>`
      - KLIF neuron.
+   * - :class:`ComplementaryLIFNode <spikingjelly.activation_based.neuron.lif_variants.ComplementaryLIFNode>`
+     - Complementary LIF (CLIF) neuron.
    * - :class:`CUBALIFNode <spikingjelly.activation_based.neuron.lif_variants.CUBALIFNode>`
      - CUrrent-BAsed LIF neuron.
    * - :class:`LIAFNode <spikingjelly.activation_based.neuron.lif_variants.LIAFNode>`

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -15,6 +15,17 @@ and the archived documentation linked from the project README.
 Unreleased
 ----------
 
+Features
+~~~~~~~~
+
+Spiking Neurons
+^^^^^^^^^^^^^^^
+
+Module: ``spikingjelly.activation_based.neuron``.
+
+- Added the paper-faithful ``ComplementaryLIFNode`` with single-step and
+  multi-step PyTorch execution and optional trajectories for both neuron states.
+
 2.0.0.dev2 - 2026-08-23
 -----------------------
 

--- a/spikingjelly/activation_based/neuron/lif_variants.py
+++ b/spikingjelly/activation_based/neuron/lif_variants.py
@@ -551,7 +551,8 @@ class ComplementaryLIFNode(BaseNode):
         :type backend: str
         :param store_state_seqs: 在多步模式下是否保存完整状态轨迹。若为 ``True``，
             ``state_seqs`` 按 ``[v_seq, m_seq]`` 保存两个形状为 ``[T, N, *]`` 的张量；
-            functional forward 不写入该缓存
+            functional forward 不写入该缓存。本类不使用父类的 ``store_v_seq`` 和
+            ``v_seq``，所有状态轨迹统一由 ``store_state_seqs`` 控制
         :type store_state_seqs: bool
         :raises AssertionError: ``tau`` 不是大于 ``1.0`` 的浮点数时抛出
         :raises ValueError: ``step_mode`` 不是 ``"s"`` 或 ``"m"`` 时抛出
@@ -603,7 +604,9 @@ class ComplementaryLIFNode(BaseNode):
         :param store_state_seqs: Whether to store complete state trajectories in
             multi-step mode. If ``True``, ``state_seqs`` contains two tensors in
             ``[v_seq, m_seq]`` order, each with shape ``[T, N, *]``. Functional
-            forward does not write this cache
+            forward does not write this cache. This class does not use the parent
+            ``store_v_seq`` or ``v_seq`` interface; ``store_state_seqs`` controls
+            all state trajectories
         :type store_state_seqs: bool
         :raises AssertionError: If ``tau`` is not a float greater than ``1.0``
         :raises ValueError: If ``step_mode`` is neither ``"s"`` nor ``"m"``
@@ -671,7 +674,9 @@ class ComplementaryLIFNode(BaseNode):
     ) -> tuple[object, ...]:
         states = super().materialize_states(inputs, states, step_mode)
         v, m = states
-        if isinstance(m, float) or m.shape != v.shape:
+        if not isinstance(m, torch.Tensor):
+            m = torch.full_like(v, m, requires_grad=False)
+        elif m.shape != v.shape:
             m = torch.zeros_like(v, requires_grad=False)
         elif m.dtype != v.dtype or m.device != v.device:
             m = m.to(dtype=v.dtype, device=v.device)
@@ -699,7 +704,7 @@ class ComplementaryLIFNode(BaseNode):
 
     def multi_step_forward(self, x_seq: torch.Tensor) -> torch.Tensor:
         if not self.store_state_seqs:
-            return super().multi_step_forward(x_seq)
+            return base.MemoryModule.multi_step_forward(self, x_seq)
 
         states = self.materialize_states((x_seq,), tuple(self._memories.values()), "m")
         spike_steps = []

--- a/spikingjelly/activation_based/neuron/lif_variants.py
+++ b/spikingjelly/activation_based/neuron/lif_variants.py
@@ -9,7 +9,13 @@ from .. import base, functional, surrogate
 from .base_node import BaseNode
 from .lif import LIFNode
 
-__all__ = ["GatedLIFNode", "KLIFNode", "CUBALIFNode", "LIAFNode"]
+__all__ = [
+    "GatedLIFNode",
+    "KLIFNode",
+    "ComplementaryLIFNode",
+    "CUBALIFNode",
+    "LIAFNode",
+]
 
 
 class GatedLIFNode(base.MemoryModule):
@@ -488,6 +494,229 @@ class KLIFNode(BaseNode):
             self.detach_reset,
         )
         return (spike,), (v, *states[1:])
+
+
+class ComplementaryLIFNode(BaseNode):
+    def __init__(
+        self,
+        tau: float = 2.0,
+        v_threshold: float = 1.0,
+        surrogate_function: surrogate.SurrogateFunctionBase = surrogate.Rect(alpha=1.0),
+        step_mode: str = "s",
+        backend: str = "torch",
+        store_state_seqs: bool = False,
+    ) -> None:
+        r"""
+        **API Language** - :ref:`中文 <ComplementaryLIFNode.__init__-cn>` | :ref:`English <ComplementaryLIFNode.__init__-en>`
+
+        ----
+
+        .. _ComplementaryLIFNode.__init__-cn:
+
+        * **中文**
+
+        Complementary Leaky Integrate-and-Fire（CLIF）神经元，由
+        `CLIF: Complementary Leaky Integrate-and-Fire Neuron for Spiking Neural Networks
+        <https://proceedings.mlr.press/v235/huang24n.html>`_ 提出。
+
+        CLIF 在 LIF 的膜电位 :math:`V[t]` 之外维护互补电位 :math:`M[t]`。
+        对当前输入 :math:`X[t]`，状态按照以下顺序更新：
+
+        .. math::
+            H[t] = \left(1 - \frac{1}{\tau}\right)V[t-1] + X[t]
+
+        .. math::
+            S[t] = \Theta(H[t] - V_{th})
+
+        .. math::
+            M[t] = M[t-1] \odot \sigma\left(\frac{H[t]}{\tau}\right) + S[t]
+
+        .. math::
+            V[t] = H[t] - S[t] \odot \left(V_{th} + \sigma(M[t])\right)
+
+        该实现仅包含论文定义的输入不衰减和软重置动力学，不引入 CLIF
+        专属可学习参数。``v`` 和 ``m`` 是持久状态，调用 :meth:`reset` 会将两者
+        恢复为零。默认替代函数的前向输出为二值脉冲；若显式传入非脉冲替代函数，
+        则输出遵循该替代函数的定义。
+
+        :param tau: 膜电位时间常数，必须为大于 ``1.0`` 的浮点数
+        :type tau: float
+        :param v_threshold: 放电阈值
+        :type v_threshold: float
+        :param surrogate_function: 反向传播中用于近似阶跃函数梯度的替代函数
+        :type surrogate_function: surrogate.SurrogateFunctionBase
+        :param step_mode: 步进模式，``"s"`` 表示单步，``"m"`` 表示多步
+        :type step_mode: str
+        :param backend: 计算后端，仅支持 ``"torch"``
+        :type backend: str
+        :param store_state_seqs: 在多步模式下是否保存完整状态轨迹。若为 ``True``，
+            ``state_seqs`` 按 ``[v_seq, m_seq]`` 保存两个形状为 ``[T, N, *]`` 的张量；
+            functional forward 不写入该缓存
+        :type store_state_seqs: bool
+        :raises AssertionError: ``tau`` 不是大于 ``1.0`` 的浮点数时抛出
+        :raises ValueError: ``step_mode`` 不是 ``"s"`` 或 ``"m"`` 时抛出
+        :raises NotImplementedError: ``backend`` 不是 ``"torch"`` 时抛出
+
+        ----
+
+        .. _ComplementaryLIFNode.__init__-en:
+
+        * **English**
+
+        The Complementary Leaky Integrate-and-Fire (CLIF) neuron proposed in
+        `CLIF: Complementary Leaky Integrate-and-Fire Neuron for Spiking Neural Networks
+        <https://proceedings.mlr.press/v235/huang24n.html>`_.
+
+        In addition to the LIF membrane potential :math:`V[t]`, CLIF maintains
+        the complementary potential :math:`M[t]`. For the current input
+        :math:`X[t]`, the states are updated in the following order:
+
+        .. math::
+            H[t] = \left(1 - \frac{1}{\tau}\right)V[t-1] + X[t]
+
+        .. math::
+            S[t] = \Theta(H[t] - V_{th})
+
+        .. math::
+            M[t] = M[t-1] \odot \sigma\left(\frac{H[t]}{\tau}\right) + S[t]
+
+        .. math::
+            V[t] = H[t] - S[t] \odot \left(V_{th} + \sigma(M[t])\right)
+
+        This implementation contains only the non-decayed-input and soft-reset
+        dynamics defined by the paper and adds no CLIF-specific learnable
+        parameters. ``v`` and ``m`` are persistent states; :meth:`reset`
+        restores both to zero. The default surrogate produces binary spikes in
+        forward propagation. If a non-spiking surrogate is supplied explicitly,
+        the output follows that surrogate's definition.
+
+        :param tau: Membrane time constant, which must be a float greater than ``1.0``
+        :type tau: float
+        :param v_threshold: Firing threshold
+        :type v_threshold: float
+        :param surrogate_function: Surrogate function used to approximate the gradient of the step function
+        :type surrogate_function: surrogate.SurrogateFunctionBase
+        :param step_mode: Step mode, ``"s"`` for single-step or ``"m"`` for multi-step
+        :type step_mode: str
+        :param backend: Execution backend; only ``"torch"`` is supported
+        :type backend: str
+        :param store_state_seqs: Whether to store complete state trajectories in
+            multi-step mode. If ``True``, ``state_seqs`` contains two tensors in
+            ``[v_seq, m_seq]`` order, each with shape ``[T, N, *]``. Functional
+            forward does not write this cache
+        :type store_state_seqs: bool
+        :raises AssertionError: If ``tau`` is not a float greater than ``1.0``
+        :raises ValueError: If ``step_mode`` is neither ``"s"`` nor ``"m"``
+        :raises NotImplementedError: If ``backend`` is not ``"torch"``
+        """
+        assert isinstance(tau, float) and tau > 1.0
+        super().__init__(
+            v_threshold,
+            None,
+            surrogate_function,
+            False,
+            step_mode,
+            backend,
+            False,
+        )
+        self.tau = tau
+        self.register_memory("m", 0.0)
+        self.store_state_seqs = store_state_seqs
+
+    @property
+    def supported_backends(self) -> tuple[str, ...]:
+        return ("torch",)
+
+    @property
+    def store_state_seqs(self) -> bool:
+        r"""
+        **API Language** - :ref:`中文 <ComplementaryLIFNode.store_state_seqs-cn>` | :ref:`English <ComplementaryLIFNode.store_state_seqs-en>`
+
+        ----
+
+        .. _ComplementaryLIFNode.store_state_seqs-cn:
+
+        * **中文**
+
+        :return: 是否在常规多步前向后保存 ``[v_seq, m_seq]``。修改该属性会清除
+            已保存的 ``state_seqs``
+        :rtype: bool
+
+        ----
+
+        .. _ComplementaryLIFNode.store_state_seqs-en:
+
+        * **English**
+
+        :return: Whether to store ``[v_seq, m_seq]`` after a regular multi-step
+            forward. Assigning this property clears the cached ``state_seqs``
+        :rtype: bool
+        """
+        return self._store_state_seqs
+
+    @store_state_seqs.setter
+    def store_state_seqs(self, value: bool) -> None:
+        self._store_state_seqs = value
+        self.state_seqs = None
+
+    def reset(self) -> None:
+        super().reset()
+        self.state_seqs = None
+
+    def materialize_states(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        step_mode: str,
+    ) -> tuple[object, ...]:
+        states = super().materialize_states(inputs, states, step_mode)
+        v, m = states
+        if isinstance(m, float) or m.shape != v.shape:
+            m = torch.zeros_like(v, requires_grad=False)
+        elif m.dtype != v.dtype or m.device != v.device:
+            m = m.to(dtype=v.dtype, device=v.device)
+        return v, m
+
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        x = inputs[0]
+        v, m = states
+        v = functional.lif_charge(x, v, self.tau, False, None)
+        m = m * torch.sigmoid(v / self.tau)
+        spike_function = (
+            self.surrogate_function
+            if self.training or not self.surrogate_function.spiking
+            else surrogate.heaviside
+        )
+        spike = spike_function(v - self.v_threshold)
+        m = m + spike
+        v = v - spike * (self.v_threshold + torch.sigmoid(m))
+        return (spike,), (v, m)
+
+    def multi_step_forward(self, x_seq: torch.Tensor) -> torch.Tensor:
+        if not self.store_state_seqs:
+            return super().multi_step_forward(x_seq)
+
+        states = self.materialize_states((x_seq,), tuple(self._memories.values()), "m")
+        spike_steps = []
+        v_steps = []
+        m_steps = []
+        for x in x_seq:
+            (spike,), states = self.single_step_functional_forward((x,), states)
+            spike_steps.append(spike)
+            v_steps.append(states[0])
+            m_steps.append(states[1])
+
+        self.v, self.m = states
+        self.state_seqs = [torch.stack(v_steps), torch.stack(m_steps)]
+        return torch.stack(spike_steps)
+
+    def extra_repr(self) -> str:
+        return super().extra_repr() + f", tau={self.tau}"
 
 
 class CUBALIFNode(BaseNode):

--- a/spikingjelly/activation_based/neuron/lif_variants.py
+++ b/spikingjelly/activation_based/neuron/lif_variants.py
@@ -676,6 +676,8 @@ class ComplementaryLIFNode(BaseNode):
         v, m = states
         if not isinstance(m, torch.Tensor):
             m = torch.full_like(v, m, requires_grad=False)
+        elif m.ndim == 0:
+            m = m.to(dtype=v.dtype, device=v.device).expand_as(v)
         elif m.shape != v.shape:
             m = torch.zeros_like(v, requires_grad=False)
         elif m.dtype != v.dtype or m.device != v.device:

--- a/test/activation_based/test_functional_neuron.py
+++ b/test/activation_based/test_functional_neuron.py
@@ -161,8 +161,9 @@ def test_complementary_lif_matches_paper_dynamics_and_gradient(
 
 def test_complementary_lif_single_multi_step_and_functional_state():
     scalar_state = neuron.ComplementaryLIFNode()
-    _, states = scalar_state.functional_forward((torch.zeros(2),), (0.0, 1))
-    torch.testing.assert_close(states[1], torch.full((2,), 0.5))
+    for m in (1, torch.tensor(1.0)):
+        _, states = scalar_state.functional_forward((torch.zeros(2),), (0.0, m))
+        torch.testing.assert_close(states[1], torch.full((2,), 0.5))
 
     x_seq = torch.tensor(
         [[0.3, 0.8], [0.9, 0.4], [0.7, 1.0], [0.6, 0.2]],

--- a/test/activation_based/test_functional_neuron.py
+++ b/test/activation_based/test_functional_neuron.py
@@ -160,6 +160,10 @@ def test_complementary_lif_matches_paper_dynamics_and_gradient(
 
 
 def test_complementary_lif_single_multi_step_and_functional_state():
+    scalar_state = neuron.ComplementaryLIFNode()
+    _, states = scalar_state.functional_forward((torch.zeros(2),), (0.0, 1))
+    torch.testing.assert_close(states[1], torch.full((2,), 0.5))
+
     x_seq = torch.tensor(
         [[0.3, 0.8], [0.9, 0.4], [0.7, 1.0], [0.6, 0.2]],
         dtype=torch.float64,
@@ -208,10 +212,12 @@ def test_complementary_lif_state_storage_reset_and_backend_contract():
     evaluation_output = module(x_seq)
     torch.testing.assert_close(training_output, evaluation_output)
     module.store_state_seqs = False
+    module.store_v_seq = True
     assert module.state_seqs is None
 
     x_seq = torch.randn(2, 3, dtype=torch.float64)
     module(x_seq)
+    assert module.v_seq is None
     assert module.v.shape == x_seq.shape[1:]
     assert module.m.shape == x_seq.shape[1:]
     assert module.v.dtype == x_seq.dtype

--- a/test/activation_based/test_functional_neuron.py
+++ b/test/activation_based/test_functional_neuron.py
@@ -95,6 +95,132 @@ def test_lif_step_is_composed_from_charge_and_voltage_reset(decay_input, v_reset
     _assert_close(v_next, expected_v)
 
 
+@pytest.mark.parametrize(
+    ("device", "dtype", "rtol", "atol"),
+    [
+        ("cpu", torch.float64, 1e-10, 1e-12),
+        pytest.param(
+            "cuda",
+            torch.float32,
+            1e-6,
+            1e-6,
+            marks=pytest.mark.skipif(
+                not torch.cuda.is_available(), reason="CUDA is not available"
+            ),
+        ),
+    ],
+)
+def test_complementary_lif_matches_paper_dynamics_and_gradient(
+    device, dtype, rtol, atol
+):
+    x_seq = torch.tensor(
+        [[0.8], [0.4], [0.9], [0.4], [1.0]],
+        dtype=dtype,
+        device=device,
+        requires_grad=True,
+    )
+    module = neuron.ComplementaryLIFNode(step_mode="m", store_state_seqs=True)
+
+    spike_seq = module(x_seq)
+
+    expected_spike_seq = x_seq.new_tensor([[0.0], [0.0], [1.0], [0.0], [1.0]])
+    expected_v_seq = x_seq.new_tensor(
+        [
+            [0.8],
+            [0.8],
+            [-0.43105857863000474],
+            [0.18447071068499765],
+            [-0.6988051099221311],
+        ]
+    )
+    expected_m_seq = x_seq.new_tensor(
+        [[0.0], [0.0], [1.0], [0.5230425052426416], [1.331208504044421]]
+    )
+    torch.testing.assert_close(spike_seq, expected_spike_seq, rtol=rtol, atol=atol)
+    torch.testing.assert_close(
+        module.state_seqs[0], expected_v_seq, rtol=rtol, atol=atol
+    )
+    torch.testing.assert_close(
+        module.state_seqs[1], expected_m_seq, rtol=rtol, atol=atol
+    )
+
+    weights = x_seq.new_tensor([1, 2, 3, 4, 5]).unsqueeze(1)
+    (spike_seq * weights).sum().backward()
+    expected_grad = x_seq.new_tensor(
+        [
+            [0.5587231024047484],
+            [1.3784269134271934],
+            [1.8404118601606416],
+            [2.5],
+            [5.0],
+        ]
+    )
+    torch.testing.assert_close(x_seq.grad, expected_grad, rtol=rtol, atol=atol)
+    assert list(module.parameters()) == []
+
+
+def test_complementary_lif_single_multi_step_and_functional_state():
+    x_seq = torch.tensor(
+        [[0.3, 0.8], [0.9, 0.4], [0.7, 1.0], [0.6, 0.2]],
+        dtype=torch.float64,
+    )
+    multi_step = neuron.ComplementaryLIFNode(step_mode="m", store_state_seqs=True)
+    original_states = (multi_step.v, multi_step.m)
+    functional_outputs, functional_states = multi_step.functional_forward(
+        (x_seq,), original_states
+    )
+
+    assert (multi_step.v, multi_step.m) == original_states
+    assert multi_step.state_seqs is None
+
+    multi_output = multi_step(x_seq)
+    single_step = neuron.ComplementaryLIFNode()
+    single_outputs = []
+    single_v_steps = []
+    single_m_steps = []
+    for x in x_seq:
+        single_outputs.append(single_step(x))
+        single_v_steps.append(single_step.v)
+        single_m_steps.append(single_step.m)
+
+    torch.testing.assert_close(multi_output, torch.stack(single_outputs))
+    torch.testing.assert_close(multi_output, functional_outputs[0])
+    torch.testing.assert_close(multi_step.state_seqs[0], torch.stack(single_v_steps))
+    torch.testing.assert_close(multi_step.state_seqs[1], torch.stack(single_m_steps))
+    torch.testing.assert_close(multi_step.v, functional_states[0])
+    torch.testing.assert_close(multi_step.m, functional_states[1])
+
+
+def test_complementary_lif_state_storage_reset_and_backend_contract():
+    module = neuron.ComplementaryLIFNode(step_mode="m", store_state_seqs=True)
+    x_seq = torch.randn(3, 2, 4)
+
+    training_output = module(x_seq)
+    assert len(module.state_seqs) == 2
+    assert all(state_seq.shape == x_seq.shape for state_seq in module.state_seqs)
+
+    module.reset()
+    assert module.v == 0.0
+    assert module.m == 0.0
+    assert module.state_seqs is None
+
+    module.eval()
+    evaluation_output = module(x_seq)
+    torch.testing.assert_close(training_output, evaluation_output)
+    module.store_state_seqs = False
+    assert module.state_seqs is None
+
+    x_seq = torch.randn(2, 3, dtype=torch.float64)
+    module(x_seq)
+    assert module.v.shape == x_seq.shape[1:]
+    assert module.m.shape == x_seq.shape[1:]
+    assert module.v.dtype == x_seq.dtype
+    assert module.m.dtype == x_seq.dtype
+    assert module.supported_backends == ("torch",)
+    with pytest.raises(NotImplementedError, match="not a supported backend"):
+        neuron.ComplementaryLIFNode(backend="triton")
+
+
 @pytest.mark.parametrize("threshold_related", [False, True])
 def test_liaf_step_matches_module(threshold_related):
     x = torch.randn(2, 3)


### PR DESCRIPTION
## Summary

- add a paper-faithful ComplementaryLIFNode with PyTorch single-step and multi-step execution
- preserve membrane and complementary-potential state trajectories through state_seqs
- document the public API and record the feature in the changelog

Paper: https://proceedings.mlr.press/v235/huang24n.html

## Validation

- local functional and neighboring neuron tests: 68 passed, 2 skipped
- g3 RTX 4090 CUDA validation: 69 passed, 1 unrelated skip
- Ruff and format checks passed
- changelog generation check passed
- Sphinx HTML build passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Complementary LIF (CLIF) neuron for single-step and multi-step PyTorch execution.
  * Supports persistent neuron states, optional state trajectory storage, reset handling, and state materialization.
  * Added validation for supported configuration options and data types.

* **Documentation**
  * Added API documentation and unreleased changelog entries describing the new neuron.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->