### PR TITLE
Fix monitor lifecycles and GPU sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,19 @@ Module: `spikingjelly.activation_based.op_counter`.
   NeuroMC forward-energy estimators using pinned author code or published
   equations, with scale-free ranking metrics and explicit unvalidated scopes.
 
+### Improvements
+
+#### Monitoring
+
+Module: `spikingjelly.activation_based.monitor`.
+
+- Added deterministic hook cleanup through `BaseMonitor.close()` and context
+  managers, and changed `InputMonitor` transformations to run before module
+  forward execution.
+- STDP learners now clear consumed monitor records without invalidating
+  per-layer indexes, reject mismatched input/output record counts, and treat
+  empty record buffers as a no-op.
+
 ### Breaking Changes and Notices
 
 #### FlexSN Migration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ Module: `spikingjelly.activation_based.monitor`.
 - STDP learners now clear consumed monitor records without invalidating
   per-layer indexes, reject mismatched input/output record counts, and treat
   empty record buffers as a no-op.
+- `GPUMonitor` now stops promptly between samples, invokes `nvidia-smi`
+  without a shell, reports command failures, and closes its TensorBoard writer.
 
 ### Breaking Changes and Notices
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -63,6 +63,8 @@ Module: ``spikingjelly.activation_based.monitor``.
 - STDP learners now clear consumed monitor records without invalidating
   per-layer indexes, reject mismatched input/output record counts, and treat
   empty record buffers as a no-op.
+- ``GPUMonitor`` now stops promptly between samples, invokes ``nvidia-smi``
+  without a shell, reports command failures, and closes its TensorBoard writer.
 
 Breaking Changes and Notices
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -49,6 +49,21 @@ Module: ``spikingjelly.activation_based.op_counter``.
   NeuroMC forward-energy estimators using pinned author code or published
   equations, with scale-free ranking metrics and explicit unvalidated scopes.
 
+Improvements
+~~~~~~~~~~~~
+
+Monitoring
+^^^^^^^^^^
+
+Module: ``spikingjelly.activation_based.monitor``.
+
+- Added deterministic hook cleanup through ``BaseMonitor.close()`` and context
+  managers, and changed ``InputMonitor`` transformations to run before module
+  forward execution.
+- STDP learners now clear consumed monitor records without invalidating
+  per-layer indexes, reject mismatched input/output record counts, and treat
+  empty record buffers as a no-op.
+
 Breaking Changes and Notices
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/tutorials/cn/monitor.rst
+++ b/docs/source/tutorials/cn/monitor.rst
@@ -358,6 +358,8 @@ English version: :doc:`../en/monitor`
 
         input_grad_monitor.clear_recorded_data()
 
+    input_grad_monitor.close()
+
 
 输出为：
 

--- a/docs/source/tutorials/cn/monitor.rst
+++ b/docs/source/tutorials/cn/monitor.rst
@@ -39,13 +39,13 @@ English version: :doc:`../en/monitor`
 
 .. code-block:: python
 
-    spike_seq_monitor = monitor.OutputMonitor(net, neuron.IFNode)
     T = 4
     N = 1
     x_seq = torch.rand([T, N, 8])
 
-    with torch.no_grad():
-        net(x_seq)
+    with monitor.OutputMonitor(net, neuron.IFNode) as spike_seq_monitor:
+        with torch.no_grad():
+            net(x_seq)
 
 要记录的数据，会根据生成顺序，保存在 ``.records`` 的 ``list`` 中：
 
@@ -149,18 +149,16 @@ English version: :doc:`../en/monitor`
     spike_seq_monitor.records=[]
     spike_seq_monitor['1']=[]
 
-所有的 ``monitor`` 在析构时都会自动删除已经注册的钩子，但python的内存回收机制并不保证在手动调用 ``del`` 时一定会进行析构。因此删除一个监视器，并不能保证钩子也立刻被删除：
+退出上述上下文后，钩子已经被移除，但 ``records`` 仍可读取。没有使用 ``with``
+创建监视器时，应在不再需要监视器后显式调用 ``close()``：
 
 .. code-block:: python
 
-    del spike_seq_monitor
-    # 钩子可能仍然在起作用
+    spike_seq_monitor.close()
 
-若想立刻删除钩子，应该通过以下方式：
-
-.. code-block:: python
-
-    spike_seq_monitor.remove_hooks()
+``disable()`` 仅暂停记录并保留钩子，以便通过 ``enable()`` 恢复；``close()`` 会
+永久移除钩子。删除监视器变量不能替代 ``close()``，因为仍存活模块上的钩子可能
+继续引用监视器。
 
 
 :class:`OutputMonitor <spikingjelly.activation_based.monitor.OutputMonitor>` 还支持在记录数据时就对数据进行简单的处理，只需要\
@@ -194,7 +192,7 @@ English version: :doc:`../en/monitor`
         net(x_seq)
         print(f'after call fr_monitor.enable(), fr_monitor.records=\n{fr_monitor.records}')
         functional.reset_net(net)
-        del fr_monitor
+        fr_monitor.close()
 
 输出为：
 
@@ -228,7 +226,7 @@ English version: :doc:`../en/monitor`
         net(x_seq)
         print(f'v_seq_monitor.records=\n{v_seq_monitor.records}')
         functional.reset_net(net)
-        del v_seq_monitor
+        v_seq_monitor.close()
 
 输出为：
 
@@ -253,6 +251,10 @@ English version: :doc:`../en/monitor`
 -------------------------------------------
 设置输入监视器的方法，和设置输出监视器的如出一辙：
 
+``function_on_input`` 会在被监控模块执行前运行。默认函数保存输入对象本身，因此
+原地修改输入的模块仍会改变该引用。若需要保留修改前的数值，应传入
+``lambda x: x.clone()`` 等创建快照的函数。
+
 .. code-block:: python
 
     input_monitor = monitor.InputMonitor(net, neuron.IFNode)
@@ -260,7 +262,7 @@ English version: :doc:`../en/monitor`
         net(x_seq)
         print(f'input_monitor.records=\n{input_monitor.records}')
         functional.reset_net(net)
-        del input_monitor
+        input_monitor.close()
 
 输出为：
 
@@ -292,7 +294,7 @@ English version: :doc:`../en/monitor`
     net(x_seq).sum().backward()
     print(f'spike_seq_grad_monitor.records=\n{spike_seq_grad_monitor.records}')
     functional.reset_net(net)
-    del spike_seq_grad_monitor
+    spike_seq_grad_monitor.close()
 
 输出为：
 
@@ -354,7 +356,7 @@ English version: :doc:`../en/monitor`
         for param in net.parameters():
             param.grad.zero_()
 
-        input_grad_monitor.records.clear()
+        input_grad_monitor.clear_recorded_data()
 
 
 输出为：
@@ -377,9 +379,34 @@ English version: :doc:`../en/monitor`
     [tensor(4.3944), tensor(2.4396), tensor(0.8996), tensor(0.4376), tensor(0.0640), tensor(0.0122), tensor(0.0053), tensor(0.0016), tensor(0.0013), tensor(0.0005)]
 
 
+GPU 利用率采样
+-------------------------------------------
+:class:`spikingjelly.activation_based.monitor.GPUMonitor` 通过 ``nvidia-smi``
+定期采样整张 GPU 的利用率和显存占用。结果会包含同一 GPU 上的其他进程，不能替代
+:mod:`spikingjelly.activation_based.profiler` 中的模型级分析器。使用后必须停止并等待线程退出：
+
+.. code-block:: python
+
+    gpu_monitor = monitor.GPUMonitor(interval=10)
+    try:
+        train()
+    finally:
+        gpu_monitor.stop()
+        gpu_monitor.join()
+
 降低内存占用
 -------------------------------------------
 如果我们需要记录大量数据，当被记录的数据是脉冲时，可以通过一些方法来降低内存占用。
+
+启用梯度时，默认的恒等记录函数可能保留前向计算图。若记录不需要参与梯度计算，
+应在记录时分离张量：
+
+.. code-block:: python
+
+    spike_seq_monitor = monitor.OutputMonitor(
+        net, neuron.IFNode, function_on_output=torch.Tensor.detach
+    )
+
 为了能够进行浮点计算，尽管脉冲只含有0/1，但它们仍然被存储为浮点形式。因此，脉冲tensor的数据类型仍然为float32，或float16（如果使用混合精度训练）。
 
 将float32转换为bool类型，可以降低内存占用。但由于C++中的bool类型实际上仍然是8比特，这种方式只能把内存降低为原来的1/4：

--- a/docs/source/tutorials/en/monitor.rst
+++ b/docs/source/tutorials/en/monitor.rst
@@ -17,13 +17,13 @@ Firstly, let us build a simple single-step network. To avoid no spikes, we set a
 
 .. code-block:: python
 
-    spike_seq_monitor = monitor.OutputMonitor(net, neuron.IFNode)
     T = 4
     N = 1
     x_seq = torch.rand([T, N, 8])
 
-    with torch.no_grad():
-        net(x_seq)
+    with monitor.OutputMonitor(net, neuron.IFNode) as spike_seq_monitor:
+        with torch.no_grad():
+            net(x_seq)
 
 The recorded data will be stored in ``.records`` whose type is ``list``. The data are recorded by the order in how they are created:
 
@@ -129,18 +129,18 @@ The outputs are:
     spike_seq_monitor.records=[]
     spike_seq_monitor['1']=[]
 
-All ``monitor`` will remove hooks when they are deleted. However, python will not guarantee to call the ``__del__()`` function of the monitor even if we call ``del a_monitor`` manually:
+Leaving the context removes the hooks but preserves ``records`` for inspection.
+For a monitor created without ``with``, call ``close()`` when it is no longer
+needed:
 
 .. code-block:: python
 
-    del spike_seq_monitor
-    # hooks may still work
+    spike_seq_monitor.close()
 
-Instead, we should call ``remove_hooks`` to remove all hooks:
-
-.. code-block:: python
-
-    spike_seq_monitor.remove_hooks()
+``disable()`` only pauses recording and keeps the hooks so that ``enable()`` can
+resume it. ``close()`` permanently removes the hooks. Deleting a monitor variable
+is not a substitute for ``close()`` because a hook on a live module can still
+reference the monitor.
 
 
 :class:`OutputMonitor <spikingjelly.activation_based.monitor.OutputMonitor>` can also process the data when recording, which is implemented by ``function_on_output``. \
@@ -173,7 +173,7 @@ Then, we can set this function as ``function_on_output`` to get a firing rates m
         net(x_seq)
         print(f'after call fr_monitor.enable(), fr_monitor.records=\n{fr_monitor.records}')
         functional.reset_net(net)
-        del fr_monitor
+        fr_monitor.close()
 
 The outputs are:
 
@@ -207,7 +207,7 @@ Then, we use :class:`spikingjelly.activation_based.monitor.AttributeMonitor` to 
         net(x_seq)
         print(f'v_seq_monitor.records=\n{v_seq_monitor.records}')
         functional.reset_net(net)
-        del v_seq_monitor
+        v_seq_monitor.close()
 
 The outputs are:
 
@@ -232,6 +232,11 @@ Record Inputs
 -------------------------------------------
 To record inputs, we can use :class:`spikingjelly.activation_based.monitor.InputMonitor`, which is similar to :class:`spikingjelly.activation_based.monitor.OutputMonitor`:
 
+``function_on_input`` runs before the monitored module. The default function
+stores the input object itself, so an in-place module can still mutate the
+recorded reference. Pass a function such as ``lambda x: x.clone()`` when the
+pre-forward value must remain unchanged.
+
 .. code-block:: python
 
     input_monitor = monitor.InputMonitor(net, neuron.IFNode)
@@ -239,7 +244,7 @@ To record inputs, we can use :class:`spikingjelly.activation_based.monitor.Input
         net(x_seq)
         print(f'input_monitor.records=\n{input_monitor.records}')
         functional.reset_net(net)
-        del input_monitor
+        input_monitor.close()
 
 The outputs are:
 
@@ -270,7 +275,7 @@ We can use :class:`spikingjelly.activation_based.monitor.GradOutputMonitor` to r
     net(x_seq).sum().backward()
     print(f'spike_seq_grad_monitor.records=\n{spike_seq_grad_monitor.records}')
     functional.reset_net(net)
-    del spike_seq_grad_monitor
+    spike_seq_grad_monitor.close()
 
 The outputs are:
 
@@ -331,7 +336,7 @@ Let us build a deep SNN, tune ``alpha`` for surrogate functions, and compare the
         for param in net.parameters():
             param.grad.zero_()
 
-        input_grad_monitor.records.clear()
+        input_grad_monitor.clear_recorded_data()
 
 
 The outputs are:
@@ -354,9 +359,35 @@ The outputs are:
     [tensor(4.3944), tensor(2.4396), tensor(0.8996), tensor(0.4376), tensor(0.0640), tensor(0.0122), tensor(0.0053), tensor(0.0016), tensor(0.0013), tensor(0.0005)]
 
 
+GPU Utilization Sampling
+-------------------------------------------
+:class:`spikingjelly.activation_based.monitor.GPUMonitor` periodically samples
+whole-device utilization and memory through ``nvidia-smi``. It includes other
+processes using the same GPU and does not replace the model-level profilers in
+:mod:`spikingjelly.activation_based.profiler`. Always stop and join its thread:
+
+.. code-block:: python
+
+    gpu_monitor = monitor.GPUMonitor(interval=10)
+    try:
+        train()
+    finally:
+        gpu_monitor.stop()
+        gpu_monitor.join()
+
 Reduce Memory Consumption
 -------------------------------------------
 If we need to record huge amounts of data and the data are spikes, we can use some methods to reduce memory consumption.
+
+When gradients are enabled, the default identity recording function can retain
+the forward autograd graph. If gradients through the records are not required,
+detach at record time:
+
+.. code-block:: python
+
+    spike_seq_monitor = monitor.OutputMonitor(
+        net, neuron.IFNode, function_on_output=torch.Tensor.detach
+    )
 
 Although spike tensors only contain 0 and 1, they are still stored in float format. We can convert them to bool to reduce memory consumption. But it still uses 1/4, rather than 1/32 of the original memory consumption because bool in C++ requires 8 bits, rather than 1 bit: 
 

--- a/docs/source/tutorials/en/monitor.rst
+++ b/docs/source/tutorials/en/monitor.rst
@@ -338,6 +338,8 @@ Let us build a deep SNN, tune ``alpha`` for surrogate functions, and compare the
 
         input_grad_monitor.clear_recorded_data()
 
+    input_grad_monitor.close()
+
 
 The outputs are:
 

--- a/spikingjelly/activation_based/learning.py
+++ b/spikingjelly/activation_based/learning.py
@@ -837,9 +837,14 @@ class STDPLearner(base.MemoryModule):
         :return: The accumulated weight increment when ``on_grad=False``; otherwise ``None``
         :rtype: Optional[torch.Tensor]
         :raises NotImplementedError: Raised when the current ``step_mode`` / synapse-type combination is unsupported
+        :raises RuntimeError: Raised when the input and output monitors contain different numbers of records
         :raises ValueError: Raised when ``self.step_mode`` is neither ``'s'`` nor ``'m'``
         """
         length = len(self.in_spike_monitor.records)
+        if length != len(self.out_spike_monitor.records):
+            raise RuntimeError("Input and output monitor record counts differ.")
+        if length == 0:
+            return None
         delta_w = None
 
         if self.step_mode == "s":
@@ -859,9 +864,9 @@ class STDPLearner(base.MemoryModule):
         else:
             raise ValueError(self.step_mode)
 
-        for _ in range(length):
-            in_spike = self.in_spike_monitor.records.pop(0)  # [batch_size, N_in]
-            out_spike = self.out_spike_monitor.records.pop(0)  # [batch_size, N_out]
+        for i in range(length):
+            in_spike = self.in_spike_monitor.records[i]  # [batch_size, N_in]
+            out_spike = self.out_spike_monitor.records[i]  # [batch_size, N_out]
 
             self.trace_pre, self.trace_post, dw = stdp_f(
                 self.synapse,
@@ -881,7 +886,9 @@ class STDPLearner(base.MemoryModule):
 
         if on_grad:
             _accumulate_weight_gradient(self.synapse, delta_w)
-        else:
+        self.in_spike_monitor.clear_recorded_data()
+        self.out_spike_monitor.clear_recorded_data()
+        if not on_grad:
             return delta_w
 
 
@@ -1099,6 +1106,7 @@ class MSTDPLearner(base.MemoryModule):
         :return: The accumulated weight increment when ``on_grad=False``; otherwise ``None``
         :rtype: Optional[torch.Tensor]
         :raises NotImplementedError: Only some ``step_mode`` / synapse-type combinations are currently supported
+        :raises RuntimeError: Raised when the input and output monitors contain different numbers of records
         :raises ValueError: Raised when ``self.step_mode`` is invalid
         """
         # detach the reward so a graph-connected reward (e.g. produced by a
@@ -1108,6 +1116,10 @@ class MSTDPLearner(base.MemoryModule):
             reward = reward.detach()
 
         length = len(self.in_spike_monitor.records)
+        if length != len(self.out_spike_monitor.records):
+            raise RuntimeError("Input and output monitor record counts differ.")
+        if length == 0:
+            return None
         delta_w = None
 
         if self.step_mode == "s":
@@ -1122,7 +1134,7 @@ class MSTDPLearner(base.MemoryModule):
         else:
             raise ValueError(self.step_mode)
 
-        for _ in range(length):
+        for i in range(length):
             if self.eligibility is None:
                 self.eligibility = torch.zeros(
                     self.batch_size,
@@ -1136,8 +1148,8 @@ class MSTDPLearner(base.MemoryModule):
 
             delta_w = dw if (delta_w is None) else (delta_w + dw)
 
-            in_spike = self.in_spike_monitor.records.pop(0)  # [batch_size, N_in]
-            out_spike = self.out_spike_monitor.records.pop(0)  # [batch_size, N_out]
+            in_spike = self.in_spike_monitor.records[i]  # [batch_size, N_in]
+            out_spike = self.out_spike_monitor.records[i]  # [batch_size, N_out]
 
             self.trace_pre, self.trace_post, self.eligibility = stdp_f(
                 self.synapse,
@@ -1153,7 +1165,9 @@ class MSTDPLearner(base.MemoryModule):
 
         if on_grad:
             _accumulate_weight_gradient(self.synapse, delta_w)
-        else:
+        self.in_spike_monitor.clear_recorded_data()
+        self.out_spike_monitor.clear_recorded_data()
+        if not on_grad:
             return delta_w
 
 
@@ -1373,6 +1387,7 @@ class MSTDPETLearner(base.MemoryModule):
         :return: The accumulated weight increment when ``on_grad=False``; otherwise ``None``
         :rtype: Optional[torch.Tensor]
         :raises NotImplementedError: Only some ``step_mode`` / synapse-type combinations are currently supported
+        :raises RuntimeError: Raised when the input and output monitors contain different numbers of records
         :raises ValueError: Raised when ``self.step_mode`` is invalid
         """
         # detach the reward so a graph-connected reward (e.g. produced by a
@@ -1382,6 +1397,10 @@ class MSTDPETLearner(base.MemoryModule):
             reward = reward.detach()
 
         length = len(self.in_spike_monitor.records)
+        if length != len(self.out_spike_monitor.records):
+            raise RuntimeError("Input and output monitor record counts differ.")
+        if length == 0:
+            return None
         delta_w = None
 
         if self.step_mode == "s":
@@ -1396,7 +1415,7 @@ class MSTDPETLearner(base.MemoryModule):
         else:
             raise ValueError(self.step_mode)
 
-        for _ in range(length):
+        for i in range(length):
             if self.eligibility is None:
                 self.eligibility = torch.zeros_like(self.synapse.weight)
             if self.trace_e is None:
@@ -1413,8 +1432,8 @@ class MSTDPETLearner(base.MemoryModule):
 
             delta_w = dw if (delta_w is None) else (delta_w + dw)
 
-            in_spike = self.in_spike_monitor.records.pop(0)
-            out_spike = self.out_spike_monitor.records.pop(0)
+            in_spike = self.in_spike_monitor.records[i]
+            out_spike = self.out_spike_monitor.records[i]
 
             self.trace_pre, self.trace_post, self.eligibility = stdp_f(
                 self.synapse,
@@ -1430,5 +1449,7 @@ class MSTDPETLearner(base.MemoryModule):
 
         if on_grad:
             _accumulate_weight_gradient(self.synapse, delta_w)
-        else:
+        self.in_spike_monitor.clear_recorded_data()
+        self.out_spike_monitor.clear_recorded_data()
+        if not on_grad:
             return delta_w

--- a/spikingjelly/activation_based/monitor.py
+++ b/spikingjelly/activation_based/monitor.py
@@ -1,8 +1,7 @@
 import datetime
 import os
-import re
+import subprocess
 import threading
-import time
 from types import TracebackType
 from typing import Callable, Optional, Self, Union
 
@@ -758,10 +757,10 @@ class GPUMonitor(threading.Thread):
     def __init__(
         self,
         log_dir: Optional[str] = None,
-        gpu_ids: tuple = (0,),
+        gpu_ids: tuple[int, ...] = (0,),
         interval: float = 600.0,
-        start_now=True,
-    ):
+        start_now: bool = True,
+    ) -> None:
         r"""
         **API Language** - :ref:`中文 <GPUMonitor.__init__-cn>` | :ref:`English <GPUMonitor.__init__-en>`
 
@@ -793,6 +792,8 @@ class GPUMonitor(threading.Thread):
             后才开始记录数据
         :type start_now: bool
 
+        :raises ValueError: 当 ``gpu_ids`` 为空或 ``interval`` 不为正数时抛出
+
         ----
 
         .. _GPUMonitor.__init__-en:
@@ -822,6 +823,8 @@ class GPUMonitor(threading.Thread):
             it will start after the user call ``start()`` manually
         :type start_now: bool
 
+        :raises ValueError: If ``gpu_ids`` is empty or ``interval`` is not positive
+
         ----
 
         * **示例代码 | Example**
@@ -841,58 +844,119 @@ class GPUMonitor(threading.Thread):
             # 0 %, 376 MiB
         """
         super().__init__()
+        if not gpu_ids:
+            raise ValueError("gpu_ids must not be empty.")
+        if interval <= 0:
+            raise ValueError("interval must be positive.")
+
+        self.log_dir = log_dir
         self.gpu_ids = gpu_ids
         self.interval = interval
-        self.stopped = False
-        self.cmds = "nvidia-smi --query-gpu=utilization.gpu,memory.used --format=csv"
-        self.cmds += " -i "
-        id_str = []
-        for gpu_id in self.gpu_ids:
-            id_str.append(str(gpu_id))
-        self.cmds += ",".join(id_str)
+        self._stop_event = threading.Event()
+        self.command = [
+            "nvidia-smi",
+            "--query-gpu=index,utilization.gpu,memory.used",
+            "--format=csv,noheader,nounits",
+            "-i",
+            ",".join(map(str, gpu_ids)),
+        ]
         self.step = 0
-
-        if log_dir is None:
-            self.writer = None
-        else:
-            self.writer = SummaryWriter(os.path.join(log_dir, "gpu_monitor"))
+        self.writer = None
 
         if start_now:
             self.start()
 
-    def stop(self):
-        self.stopped = True
+    def stop(self) -> None:
+        r"""
+        **API Language** - :ref:`中文 <GPUMonitor.stop-cn>` | :ref:`English <GPUMonitor.stop-en>`
 
-    def run(self):
-        while not self.stopped:
-            with os.popen(self.cmds) as fp:
-                if self.writer is not None:
-                    outputs = fp.read()
-                    outputs = outputs.split("\n")[1:-1]
-                    # skip the first row (header) and the last row ("\n")
-                    for i in range(len(outputs)):
-                        utilization_memory = re.findall(r"\d+", outputs[i])
-                        utilization = int(utilization_memory[0])
-                        memory_used = int(utilization_memory[1])
-                        self.writer.add_scalar(
-                            f"utilization_{self.gpu_ids[i]}", utilization, self.step
+        ----
+
+        .. _GPUMonitor.stop-cn:
+
+        * **中文**
+
+        请求监视线程停止，并唤醒正在等待下一次采样的线程。调用方可随后调用
+        :meth:`threading.Thread.join` 等待线程结束。
+
+        ----
+
+        .. _GPUMonitor.stop-en:
+
+        * **English**
+
+        Request the monitor thread to stop and wake it while it is waiting for
+        the next sample. Call :meth:`threading.Thread.join` afterwards to wait
+        for termination.
+        """
+        self._stop_event.set()
+
+    def run(self) -> None:
+        if self._stop_event.is_set():
+            return
+
+        try:
+            if self.log_dir is not None:
+                self.writer = SummaryWriter(os.path.join(self.log_dir, "gpu_monitor"))
+
+            while not self._stop_event.is_set():
+                try:
+                    completed = subprocess.run(
+                        self.command,
+                        check=False,
+                        capture_output=True,
+                        text=True,
+                        timeout=5,
+                    )
+                except (OSError, subprocess.TimeoutExpired) as error:
+                    logger.error("GPU monitor stopped: {}", error)
+                    return
+
+                if completed.returncode:
+                    logger.error(
+                        "GPU monitor stopped: {}",
+                        completed.stderr.strip()
+                        or f"nvidia-smi exited with code {completed.returncode}",
+                    )
+                    return
+
+                output = completed.stdout.strip()
+                if not output:
+                    logger.error("GPU monitor stopped: nvidia-smi returned no data")
+                    return
+
+                try:
+                    samples = []
+                    for line in output.splitlines():
+                        gpu_id, utilization, memory_used = (
+                            value.strip() for value in line.split(",")
                         )
-                        self.writer.add_scalar(
-                            f"memory_used_{self.gpu_ids[i]}", memory_used, self.step
-                        )
-                else:
+                        samples.append((gpu_id, int(utilization), int(memory_used)))
+                except ValueError:
+                    logger.error(
+                        "GPU monitor stopped: malformed nvidia-smi output: {}",
+                        output,
+                    )
+                    return
+
+                if self.writer is None:
                     logger.info(
                         "GPU monitor sample at {}:\n{}",
                         datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-                        fp.read(),
+                        output,
                     )
-                    """
-                    2022-04-20 18:14:26
-                    utilization.gpu [%], memory.used [MiB]
-                    4 %, 1816 MiB
-                    0 %, 1840 MiB
-                    0 %, 1840 MiB
-                    0 %, 1720 MiB
-                    """
-            time.sleep(self.interval)
-            self.step += 1
+                else:
+                    for gpu_id, utilization, memory_used in samples:
+                        self.writer.add_scalar(
+                            f"utilization_{gpu_id}", utilization, self.step
+                        )
+                        self.writer.add_scalar(
+                            f"memory_used_{gpu_id}", memory_used, self.step
+                        )
+
+                self.step += 1
+                if self._stop_event.wait(self.interval):
+                    return
+        finally:
+            if self.writer is not None:
+                self.writer.close()

--- a/spikingjelly/activation_based/monitor.py
+++ b/spikingjelly/activation_based/monitor.py
@@ -3,7 +3,8 @@ import os
 import re
 import threading
 import time
-from typing import Callable, Union, Optional
+from types import TracebackType
+from typing import Callable, Optional, Self, Union
 
 import torch
 from torch import nn
@@ -20,7 +21,7 @@ def _unpack_len1_tuple(x: Union[tuple, torch.Tensor]):
 
 
 class BaseMonitor:
-    def __init__(self):
+    def __init__(self) -> None:
         r"""
         **API Language** - :ref:`中文 <BaseMonitor.__init__-cn>` | :ref:`English <BaseMonitor.__init__-en>`
 
@@ -72,29 +73,65 @@ class BaseMonitor:
         self.name_records_index[name].append(len(self.records))
         self.records.append(value)
 
-    def clear_recorded_data(self):
+    def clear_recorded_data(self) -> None:
         self.records.clear()
         for v in self.name_records_index.values():
             v.clear()
 
-    def enable(self):
+    def enable(self) -> None:
         self._enable = True
 
-    def disable(self):
+    def disable(self) -> None:
         self._enable = False
 
-    def is_enable(self):
+    def is_enable(self) -> bool:
         return self._enable
 
-    def remove_hooks(self):
+    def remove_hooks(self) -> None:
         for hook in self.hooks:
             hook.remove()
         self.hooks.clear()
 
-    def __del__(self):
+    def close(self) -> None:
+        r"""
+        **API Language** - :ref:`中文 <BaseMonitor.close-cn>` | :ref:`English <BaseMonitor.close-en>`
+
+        ----
+
+        .. _BaseMonitor.close-cn:
+
+        * **中文**
+
+        停止记录并永久移除所有钩子。已有记录会被保留。该方法可重复调用；关闭后如需
+        重新监控，应创建新的监视器。
+
+        ----
+
+        .. _BaseMonitor.close-en:
+
+        * **English**
+
+        Stop recording and permanently remove all hooks. Existing records are
+        preserved. This method is idempotent; create a new monitor to resume
+        monitoring after it has been closed.
+        """
         self.disable()
-        self.clear_recorded_data()
         self.remove_hooks()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> bool:
+        self.close()
+        return False
+
+    def __del__(self):
+        self.close()
 
 
 class OutputMonitor(BaseMonitor):
@@ -309,10 +346,10 @@ class InputMonitor(BaseMonitor):
         super().__init__()
         self.function_on_input = function_on_input
         for name, module in self._monitor_modules(net, instance):
-            self.hooks.append(module.register_forward_hook(self.create_hook(name)))
+            self.hooks.append(module.register_forward_pre_hook(self.create_hook(name)))
 
     def create_hook(self, name):
-        def hook(module, inputs, output):
+        def hook(module, inputs):
             if self.is_enable():
                 self._record(
                     name,

--- a/spikingjelly/activation_based/monitor.py
+++ b/spikingjelly/activation_based/monitor.py
@@ -706,10 +706,10 @@ class GPUMonitor(threading.Thread):
                 try:
                     samples = []
                     for line in output.splitlines():
-                        gpu_id, utilization, memory_used = (
+                        index, utilization, memory_used = (
                             value.strip() for value in line.split(",")
                         )
-                        samples.append((gpu_id, int(utilization), int(memory_used)))
+                        samples.append((index, int(utilization), int(memory_used)))
                 except ValueError:
                     logger.error(
                         "GPU monitor stopped: malformed nvidia-smi output: {}",
@@ -724,12 +724,12 @@ class GPUMonitor(threading.Thread):
                         output,
                     )
                 else:
-                    for gpu_id, utilization, memory_used in samples:
+                    for index, utilization, memory_used in samples:
                         self.writer.add_scalar(
-                            f"utilization_{gpu_id}", utilization, self.step
+                            f"utilization_{index}", utilization, self.step
                         )
                         self.writer.add_scalar(
-                            f"memory_used_{gpu_id}", memory_used, self.step
+                            f"memory_used_{index}", memory_used, self.step
                         )
 
                 self.step += 1

--- a/spikingjelly/activation_based/monitor.py
+++ b/spikingjelly/activation_based/monitor.py
@@ -30,7 +30,8 @@ class BaseMonitor:
 
         * **中文**
 
-        监视器基类。维护钩子句柄、被监视层列表、记录缓存以及启停状态。
+        监视器基类。维护钩子句柄、被监视层列表、记录缓存以及启停状态。监视器支持
+        上下文管理器；退出上下文或调用 :meth:`close` 会永久移除钩子，但保留已有记录。
 
 
         ----
@@ -39,8 +40,10 @@ class BaseMonitor:
 
         * **English**
 
-        Base monitor class. It maintains hook handles, monitored layer list, recorded data buffers,
-        and enable/disable state.
+        Base monitor class. It maintains hook handles, monitored layer list,
+        recorded data buffers, and enable/disable state. Monitors are context
+        managers; leaving the context or calling :meth:`close` permanently
+        removes hooks while preserving existing records.
         """
         self.hooks = []
         self.monitored_layers = []
@@ -150,7 +153,7 @@ class OutputMonitor(BaseMonitor):
         * **中文**
 
         对 ``net`` 中所有类型为 ``instance`` 的模块的输出使用 ``function_on_output`` 作用后，
-        记录到类型为 `list`` 的 ``self.records`` 中。可以通过 ``self.enable()`` 和 ``self.disable()``
+        记录到类型为 ``list`` 的 ``self.records`` 中。可以通过 ``self.enable()`` 和 ``self.disable()``
         来启用或停用这个监视器。可以通过 ``self.clear_recorded_data()`` 来清除已经记录的数据。
 
         阅读 :doc:`监视器教程 <../tutorials/cn/monitor>` 以获得更多信息。
@@ -187,45 +190,6 @@ class OutputMonitor(BaseMonitor):
         :param function_on_output: the function that applies on the monitored modules' outputs
         :type function_on_output: Callable
 
-        ----
-
-        * **示例代码 | Example**
-
-        .. code-block:: python
-
-            class Net(nn.Module):
-                def __init__(self):
-                    super().__init__()
-                    self.fc1 = layer.Linear(8, 4)
-                    self.sn1 = neuron.IFNode()
-                    self.fc2 = layer.Linear(4, 2)
-                    self.sn2 = neuron.IFNode()
-                    functional.set_step_mode(self, "m")
-
-                def forward(self, x_seq: torch.Tensor):
-                    x_seq = self.fc1(x_seq)
-                    x_seq = self.sn1(x_seq)
-                    x_seq = self.fc2(x_seq)
-                    x_seq = self.sn2(x_seq)
-                    return x_seq
-
-
-            net = Net()
-            for param in net.parameters():
-                param.data.abs_()
-
-            mtor = monitor.OutputMonitor(net, instance=neuron.IFNode)
-
-            with torch.no_grad():
-                y = net(torch.rand([1, 8]))
-                print(f"mtor.records={mtor.records}")
-                # mtor.records=[tensor([[0., 0., 0., 1.]]), tensor([[0., 0.]])]
-                print(f"mtor[0]={mtor[0]}")
-                # mtor[0]=tensor([[0., 0., 0., 1.]])
-                print(f"mtor.monitored_layers={mtor.monitored_layers}")
-                # mtor.monitored_layers=['sn1', 'sn2']
-                print(f"mtor['sn1']={mtor['sn1']}")
-                # mtor['sn1']=[tensor([[0., 0., 0., 1.]])]
         """
         super().__init__()
         self.function_on_output = function_on_output
@@ -259,9 +223,9 @@ class InputMonitor(BaseMonitor):
 
         * **中文**
 
-        对 ``net`` 中所有类型为 ``instance`` 的模块的输入使用 ``function_on_input`` 作用后，
-        记录到类型为 `list`` 的 ``self.records`` 中。可以通过 ``self.enable()`` 和 ``self.disable()``
-        来启用或停用这个监视器。可以通过 ``self.clear_recorded_data()`` 来清除已经记录的数据。
+        在 ``net`` 中所有类型为 ``instance`` 的模块执行前，将 ``function_on_input`` 作用于
+        模块输入，并把结果记录到 ``self.records``。默认函数保存输入引用；若模块会原地修改
+        输入且需要修改前的数值快照，应传入执行 ``clone()`` 的函数。
 
         阅读 :doc:`监视器教程 <../tutorials/cn/monitor>` 以获得更多信息。
 
@@ -280,10 +244,11 @@ class InputMonitor(BaseMonitor):
 
         * **English**
 
-        Applies ``function_on_input`` on inputs of all modules whose instances are
-        ``instance`` in ``net``, and records the data into ``self.records``, which is a
-        ``list``. Call ``self.enable()`` or ``self.disable()`` to enable or disable the
-        monitor. Call ``self.clear_recorded_data()`` to clear the recorded data.
+        Before each module whose instance is ``instance`` runs, apply
+        ``function_on_input`` to its inputs and append the result to
+        ``self.records``. The default function stores the input reference; pass
+        a function that calls ``clone()`` when an immutable pre-forward snapshot
+        is required for a module that mutates its input in place.
 
         Refer to the :doc:`Monitor Tutorial <../tutorials/en/monitor>` for more details.
 
@@ -297,50 +262,6 @@ class InputMonitor(BaseMonitor):
         :param function_on_input: the function that applies on the monitored modules' inputs
         :type function_on_input: Callable
 
-        ----
-
-        * **示例代码 | Example**
-
-        .. code-block:: python
-
-            import torch
-            import torch.nn as nn
-            from spikingjelly.activation_based import monitor, neuron, functional, layer
-
-
-            class Net(nn.Module):
-                def __init__(self):
-                    super().__init__()
-                    self.fc1 = layer.Linear(8, 4)
-                    self.sn1 = neuron.IFNode()
-                    self.fc2 = layer.Linear(4, 2)
-                    self.sn2 = neuron.IFNode()
-                    functional.set_step_mode(self, "m")
-
-                def forward(self, x_seq: torch.Tensor):
-                    x_seq = self.fc1(x_seq)
-                    x_seq = self.sn1(x_seq)
-                    x_seq = self.fc2(x_seq)
-                    x_seq = self.sn2(x_seq)
-                    return x_seq
-
-
-            net = Net()
-            for param in net.parameters():
-                param.data.abs_()
-
-            mtor = monitor.InputMonitor(net, instance=neuron.IFNode)
-
-            with torch.no_grad():
-                y = net(torch.rand([1, 8]))
-                print(f"mtor.records={mtor.records}")
-                # mtor.records=[tensor([[1.0165, 1.1934, 0.9347, 0.9539]]), tensor([[0.9115, 0.9508]])]
-                print(f"mtor[0]={mtor[0]}")
-                # mtor[0]=tensor([[1.0165, 1.1934, 0.9347, 0.9539]])
-                print(f"mtor.monitored_layers={mtor.monitored_layers}")
-                # mtor.monitored_layers=['sn1', 'sn2']
-                print(f"mtor['sn1']={mtor['sn1']}")
-                # mtor['sn1']=[tensor([[1.0165, 1.1934, 0.9347, 0.9539]])]
         """
         super().__init__()
         self.function_on_input = function_on_input
@@ -376,7 +297,7 @@ class AttributeMonitor(BaseMonitor):
 
         * **中文**
 
-        对 ``net`` 中所有类型为 ``instance`` 的模块 ``m`` 的成员 ``m.attribute_name`` 使用 ``function_on_attribute`` 作用后，记录到类型为 `list`` 的  ``self.records``。
+        对 ``net`` 中所有类型为 ``instance`` 的模块 ``m`` 的成员 ``m.attribute_name`` 使用 ``function_on_attribute`` 作用后，记录到类型为 ``list`` 的  ``self.records``。
         可以通过 ``self.enable()`` 和 ``self.disable()`` 来启用或停用这个监视器。
         可以通过 ``self.clear_recorded_data()`` 来清除已经记录的数据。
 
@@ -431,50 +352,6 @@ class AttributeMonitor(BaseMonitor):
             monitored module's attribute
         :type function_on_attribute: Callable
 
-        ----
-
-        * **示例代码 | Example**
-
-        .. code-block:: python
-
-            import torch
-            import torch.nn as nn
-            from spikingjelly.activation_based import monitor, neuron, functional, layer
-
-
-            class Net(nn.Module):
-                def __init__(self):
-                    super().__init__()
-                    self.fc1 = layer.Linear(8, 4)
-                    self.sn1 = neuron.IFNode()
-                    self.fc2 = layer.Linear(4, 2)
-                    self.sn2 = neuron.IFNode()
-                    functional.set_step_mode(self, "m")
-
-                def forward(self, x_seq: torch.Tensor):
-                    x_seq = self.fc1(x_seq)
-                    x_seq = self.sn1(x_seq)
-                    x_seq = self.fc2(x_seq)
-                    x_seq = self.sn2(x_seq)
-                    return x_seq
-
-
-            net = Net()
-            for param in net.parameters():
-                param.data.abs_()
-
-            mtor = monitor.AttributeMonitor("v", False, net, instance=neuron.IFNode)
-
-            with torch.no_grad():
-                y = net(torch.rand([1, 8]))
-                print(f"mtor.records={mtor.records}")
-                # mtor.records=[tensor([0.0000, 0.6854, 0.0000, 0.7968]), tensor([0.4472, 0.0000])]
-                print(f"mtor[0]={mtor[0]}")
-                # mtor[0]=tensor([0.0000, 0.6854, 0.0000, 0.7968])
-                print(f"mtor.monitored_layers={mtor.monitored_layers}")
-                # mtor.monitored_layers=['sn1', 'sn2']
-                print(f"mtor['sn1']={mtor['sn1']}")
-                # mtor['sn1']=[tensor([0.0000, 0.6854, 0.0000, 0.7968])]
         """
         super().__init__()
         self.attribute_name = attribute_name
@@ -515,7 +392,7 @@ class GradInputMonitor(BaseMonitor):
         * **中文**
 
         对 ``net`` 中所有类型为 ``instance`` 的模块的输入的梯度使用 ``function_on_grad_input``
-        作用后，记录到类型为 `list`` 的 ``self.records`` 中。
+        作用后，记录到类型为 ``list`` 的 ``self.records`` 中。
         可以通过 ``self.enable()`` 和 ``self.disable()`` 来启用或停用这个监视器。
         可以通过 ``self.clear_recorded_data()`` 来清除已经记录的数据。
 
@@ -523,7 +400,7 @@ class GradInputMonitor(BaseMonitor):
 
         .. note::
 
-            对于一个模块，输入为 :math:`X`，输出为 :math:`Y`，损失为 :math:`L`，则 ``GradOutputMonitor``
+            对于一个模块，输入为 :math:`X`，输出为 :math:`Y`，损失为 :math:`L`，则 ``GradInputMonitor``
             记录的是对输入的梯度 :math:`\frac{\partial L}{\partial X}`。
 
         :param net: 一个神经网络
@@ -566,45 +443,6 @@ class GradInputMonitor(BaseMonitor):
             monitored modules' inputs
         :type function_on_grad_input: Callable
 
-        ----
-
-        * **示例代码 | Example**
-
-        .. code-block:: python
-
-            class Net(nn.Module):
-                def __init__(self):
-                    super().__init__()
-                    self.fc1 = layer.Linear(8, 4)
-                    self.sn1 = neuron.IFNode()
-                    self.fc2 = layer.Linear(4, 2)
-                    self.sn2 = neuron.IFNode()
-                    functional.set_step_mode(self, "m")
-
-                def forward(self, x_seq: torch.Tensor):
-                    x_seq = self.fc1(x_seq)
-                    x_seq = self.sn1(x_seq)
-                    x_seq = self.fc2(x_seq)
-                    x_seq = self.sn2(x_seq)
-                    return x_seq
-
-
-            net = Net()
-            for param in net.parameters():
-                param.data.abs_()
-
-            mtor = monitor.GradInputMonitor(net, instance=neuron.IFNode)
-
-            with torch.no_grad():
-                y = net(torch.rand([1, 8]))
-                print(f"mtor.records={mtor.records}")
-                # mtor.records=[tensor([0.0000, 0.6854, 0.0000, 0.7968]), tensor([0.4472, 0.0000])]
-                print(f"mtor[0]={mtor[0]}")
-                # mtor[0]=tensor([0.0000, 0.6854, 0.0000, 0.7968])
-                print(f"mtor.monitored_layers={mtor.monitored_layers}")
-                # mtor.monitored_layers=['sn1', 'sn2']
-                print(f"mtor['sn1']={mtor['sn1']}")
-                # mtor['sn1']=[tensor([0.0000, 0.6854, 0.0000, 0.7968])]
         """
         super().__init__()
         self.function_on_grad_input = function_on_grad_input
@@ -641,7 +479,7 @@ class GradOutputMonitor(BaseMonitor):
         * **中文**
 
         对 ``net`` 中所有类型为 ``instance`` 的模块的输出的梯度使用 ``function_on_grad_output``
-        作用后，记录到类型为 `list`` 的 ``self.records`` 中。
+        作用后，记录到类型为 ``list`` 的 ``self.records`` 中。
         可以通过 ``self.enable()`` 和 ``self.disable()`` 来启用或停用这个监视器。
         可以通过 ``self.clear_recorded_data()`` 来清除已经记录的数据。
 
@@ -691,49 +529,6 @@ class GradOutputMonitor(BaseMonitor):
             monitored modules' outputs
         :type function_on_grad_output: Callable
 
-        ----
-
-        * **示例代码 | Example**
-
-        .. code-block:: python
-
-            import torch
-            import torch.nn as nn
-            from spikingjelly.activation_based import monitor, neuron, functional, layer
-
-
-            class Net(nn.Module):
-                def __init__(self):
-                    super().__init__()
-                    self.fc1 = layer.Linear(8, 4)
-                    self.sn1 = neuron.IFNode()
-                    self.fc2 = layer.Linear(4, 2)
-                    self.sn2 = neuron.IFNode()
-                    functional.set_step_mode(self, "m")
-
-                def forward(self, x_seq: torch.Tensor):
-                    x_seq = self.fc1(x_seq)
-                    x_seq = self.sn1(x_seq)
-                    x_seq = self.fc2(x_seq)
-                    x_seq = self.sn2(x_seq)
-                    return x_seq
-
-
-            net = Net()
-            for param in net.parameters():
-                param.data.abs_()
-
-            mtor = monitor.GradOutputMonitor(net, instance=neuron.IFNode)
-
-            net(torch.rand([1, 8])).sum().backward()
-            print(f"mtor.records={mtor.records}")
-            # mtor.records=[tensor([[1., 1.]]), tensor([[0.1372, 0.1081, 0.0880, 0.1089]])]
-            print(f"mtor[0]={mtor[0]}")
-            # mtor[0]=tensor([[1., 1.]])
-            print(f"mtor.monitored_layers={mtor.monitored_layers}")
-            # mtor.monitored_layers=['sn1', 'sn2']
-            print(f"mtor['sn1']={mtor['sn1']}")
-            # mtor['sn1']=[tensor([[0.1372, 0.1081, 0.0880, 0.1089]])]
         """
         super().__init__()
         self.function_on_grad_output = function_on_grad_output
@@ -825,23 +620,6 @@ class GPUMonitor(threading.Thread):
 
         :raises ValueError: If ``gpu_ids`` is empty or ``interval`` is not positive
 
-        ----
-
-        * **示例代码 | Example**
-
-        .. code-block:: python
-
-            import time
-
-            gm = GPUMonitor(interval=1)
-            time.sleep(2)  # make the main thread sleep
-            gm.stop()
-
-            # The outputs are:
-
-            # 2022-04-28 10:52:25
-            # utilization.gpu [%], memory.used [MiB]
-            # 0 %, 376 MiB
         """
         super().__init__()
         if not gpu_ids:

--- a/test/activation_based/test_learning.py
+++ b/test/activation_based/test_learning.py
@@ -112,6 +112,39 @@ def test_stdp_learner_matches_functional_update():
     )
     assert torch.allclose(delta_w, expected)
     assert delta_w.grad_fn is None
+    assert learner.in_spike_monitor.records == []
+    assert learner.out_spike_monitor.records == []
+    assert learner.in_spike_monitor[""] == []
+    assert learner.out_spike_monitor[""] == []
+
+
+@pytest.mark.parametrize(
+    ("learner_cls", "kwargs", "reward"),
+    (
+        (learning.STDPLearner, {}, None),
+        (learning.MSTDPLearner, {"batch_size": 3}, torch.zeros(3)),
+        (learning.MSTDPETLearner, {"tau_trace": 2.0}, torch.tensor(0.0)),
+    ),
+)
+def test_learners_validate_monitor_record_counts(learner_cls, kwargs, reward):
+    fc = layer.Linear(8, 5, bias=False)
+    sn = neuron.IFNode()
+    learner = learner_cls(
+        step_mode="s",
+        synapse=fc,
+        sn=sn,
+        tau_pre=2.0,
+        tau_post=2.0,
+        **kwargs,
+    )
+    step_args = () if reward is None else (reward,)
+
+    assert learner.step(*step_args) is None
+    assert fc.weight.grad is None
+
+    fc(torch.ones(3, 8))
+    with pytest.raises(RuntimeError, match="record counts differ"):
+        learner.step(*step_args)
 
 
 def test_stdp_learner_frees_tensors_across_runs():
@@ -258,6 +291,10 @@ def test_mstdp_learners_return_detached_delta_w():
         delta_w = learner.step(reward, on_grad=False)
         assert delta_w.grad_fn is None
         assert not delta_w.requires_grad
+        assert learner.in_spike_monitor.records == []
+        assert learner.out_spike_monitor.records == []
+        assert learner.in_spike_monitor[""] == []
+        assert learner.out_spike_monitor[""] == []
 
         functional.reset_net(sn)
         learner.reset()

--- a/test/activation_based/test_monitor.py
+++ b/test/activation_based/test_monitor.py
@@ -197,40 +197,15 @@ def test_gpu_monitor_writes_scalars_and_closes_writer(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "result",
+    "result_or_error",
     (
         SimpleNamespace(returncode=1, stdout="", stderr="failed"),
         SimpleNamespace(returncode=0, stdout="bad output", stderr=""),
+        subprocess.TimeoutExpired("nvidia-smi", 5),
+        FileNotFoundError("nvidia-smi"),
     ),
 )
-def test_gpu_monitor_stops_on_command_or_parse_error(monkeypatch, result):
-    errors = []
-    close_calls = []
-    fake_logger = SimpleNamespace(
-        info=lambda *_args: None,
-        error=lambda message, *args: errors.append(message.format(*args)),
-    )
-    monkeypatch.setattr(monitor, "logger", fake_logger)
-    monkeypatch.setattr(
-        monitor,
-        "SummaryWriter",
-        lambda _path: SimpleNamespace(close=lambda: close_calls.append(True)),
-    )
-    monkeypatch.setattr(monitor.subprocess, "run", lambda *_args, **_kwargs: result)
-
-    gpu_monitor = monitor.GPUMonitor(log_dir="logs", start_now=False)
-    gpu_monitor.run()
-
-    assert errors
-    assert gpu_monitor.step == 0
-    assert close_calls == [True]
-
-
-@pytest.mark.parametrize(
-    "command_error",
-    (subprocess.TimeoutExpired("nvidia-smi", 5), FileNotFoundError("nvidia-smi")),
-)
-def test_gpu_monitor_stops_on_command_exception(monkeypatch, command_error):
+def test_gpu_monitor_stops_on_error(monkeypatch, result_or_error):
     errors = []
     close_calls = []
     fake_logger = SimpleNamespace(
@@ -244,10 +219,12 @@ def test_gpu_monitor_stops_on_command_exception(monkeypatch, command_error):
         lambda _path: SimpleNamespace(close=lambda: close_calls.append(True)),
     )
 
-    def fail(*_args, **_kwargs):
-        raise command_error
+    def run(*_args, **_kwargs):
+        if isinstance(result_or_error, Exception):
+            raise result_or_error
+        return result_or_error
 
-    monkeypatch.setattr(monitor.subprocess, "run", fail)
+    monkeypatch.setattr(monitor.subprocess, "run", run)
     gpu_monitor = monitor.GPUMonitor(log_dir="logs", start_now=False)
     gpu_monitor.run()
 

--- a/test/activation_based/test_monitor.py
+++ b/test/activation_based/test_monitor.py
@@ -1,5 +1,8 @@
 import gc
+import subprocess
+import threading
 import weakref
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -125,3 +128,147 @@ def test_gradient_monitors_record_input_and_output_gradients():
     torch.testing.assert_close(grad_output_monitor.records[0], torch.ones_like(x))
     torch.testing.assert_close(grad_input_monitor[""][0], grad_input_monitor[0])
     torch.testing.assert_close(grad_output_monitor[""][0], grad_output_monitor[0])
+
+
+def test_gpu_monitor_stop_interrupts_interval(monkeypatch):
+    sampled = threading.Event()
+    calls = []
+
+    def run(command, **kwargs):
+        calls.append((command, kwargs))
+        sampled.set()
+        return SimpleNamespace(returncode=0, stdout="0, 5, 123\n", stderr="")
+
+    monkeypatch.setattr(monitor.subprocess, "run", run)
+    gpu_monitor = monitor.GPUMonitor(interval=600)
+    assert sampled.wait(1)
+
+    gpu_monitor.stop()
+    gpu_monitor.join(timeout=1)
+
+    assert not gpu_monitor.is_alive()
+    assert calls[0][0] == [
+        "nvidia-smi",
+        "--query-gpu=index,utilization.gpu,memory.used",
+        "--format=csv,noheader,nounits",
+        "-i",
+        "0",
+    ]
+    assert calls[0][1]["timeout"] == 5
+
+
+def test_gpu_monitor_writes_scalars_and_closes_writer(monkeypatch):
+    class Writer:
+        def __init__(self, log_dir):
+            self.log_dir = log_dir
+            self.scalars = []
+            self.close_calls = 0
+
+        def add_scalar(self, *args):
+            self.scalars.append(args)
+
+        def close(self):
+            self.close_calls += 1
+
+    monkeypatch.setattr(monitor, "SummaryWriter", Writer)
+    gpu_monitor = monitor.GPUMonitor(
+        log_dir="logs", gpu_ids=(2, 3), interval=1, start_now=False
+    )
+
+    def run(*_args, **_kwargs):
+        gpu_monitor.stop()
+        return SimpleNamespace(
+            returncode=0,
+            stdout="2, 10, 200\n3, 20, 300\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(monitor.subprocess, "run", run)
+    gpu_monitor.run()
+
+    assert gpu_monitor.writer.log_dir == "logs/gpu_monitor"
+    assert gpu_monitor.writer.scalars == [
+        ("utilization_2", 10, 0),
+        ("memory_used_2", 200, 0),
+        ("utilization_3", 20, 0),
+        ("memory_used_3", 300, 0),
+    ]
+    assert gpu_monitor.writer.close_calls == 1
+
+
+@pytest.mark.parametrize(
+    "result",
+    (
+        SimpleNamespace(returncode=1, stdout="", stderr="failed"),
+        SimpleNamespace(returncode=0, stdout="bad output", stderr=""),
+    ),
+)
+def test_gpu_monitor_stops_on_command_or_parse_error(monkeypatch, result):
+    errors = []
+    close_calls = []
+    fake_logger = SimpleNamespace(
+        info=lambda *_args: None,
+        error=lambda message, *args: errors.append(message.format(*args)),
+    )
+    monkeypatch.setattr(monitor, "logger", fake_logger)
+    monkeypatch.setattr(
+        monitor,
+        "SummaryWriter",
+        lambda _path: SimpleNamespace(close=lambda: close_calls.append(True)),
+    )
+    monkeypatch.setattr(monitor.subprocess, "run", lambda *_args, **_kwargs: result)
+
+    gpu_monitor = monitor.GPUMonitor(log_dir="logs", start_now=False)
+    gpu_monitor.run()
+
+    assert errors
+    assert gpu_monitor.step == 0
+    assert close_calls == [True]
+
+
+@pytest.mark.parametrize(
+    "command_error",
+    (subprocess.TimeoutExpired("nvidia-smi", 5), FileNotFoundError("nvidia-smi")),
+)
+def test_gpu_monitor_stops_on_command_exception(monkeypatch, command_error):
+    errors = []
+    close_calls = []
+    fake_logger = SimpleNamespace(
+        info=lambda *_args: None,
+        error=lambda message, *args: errors.append(message.format(*args)),
+    )
+    monkeypatch.setattr(monitor, "logger", fake_logger)
+    monkeypatch.setattr(
+        monitor,
+        "SummaryWriter",
+        lambda _path: SimpleNamespace(close=lambda: close_calls.append(True)),
+    )
+
+    def fail(*_args, **_kwargs):
+        raise command_error
+
+    monkeypatch.setattr(monitor.subprocess, "run", fail)
+    gpu_monitor = monitor.GPUMonitor(log_dir="logs", start_now=False)
+    gpu_monitor.run()
+
+    assert errors
+    assert gpu_monitor.step == 0
+    assert close_calls == [True]
+
+
+def test_gpu_monitor_validates_configuration_and_stopped_start(monkeypatch):
+    with pytest.raises(ValueError, match="gpu_ids"):
+        monitor.GPUMonitor(gpu_ids=(), start_now=False)
+    with pytest.raises(ValueError, match="interval"):
+        monitor.GPUMonitor(interval=0, start_now=False)
+
+    calls = []
+    monkeypatch.setattr(
+        monitor.subprocess, "run", lambda *_args, **_kwargs: calls.append(True)
+    )
+    gpu_monitor = monitor.GPUMonitor(start_now=False)
+    gpu_monitor.stop()
+    gpu_monitor.run()
+
+    assert calls == []
+    assert gpu_monitor.writer is None

--- a/test/activation_based/test_monitor.py
+++ b/test/activation_based/test_monitor.py
@@ -1,3 +1,7 @@
+import gc
+import weakref
+
+import pytest
 import torch
 from torch import nn
 
@@ -12,6 +16,11 @@ class StatefulModule(nn.Module):
     def forward(self, x):
         self.value += 1
         return x
+
+
+class InPlaceModule(nn.Module):
+    def forward(self, x):
+        return x.add_(1)
 
 
 def test_input_and_output_monitor_lifecycle():
@@ -58,6 +67,36 @@ def test_input_and_output_monitor_lifecycle():
     assert output_monitor.records == []
     assert input_monitor.hooks == []
     assert output_monitor.hooks == []
+
+
+def test_monitor_context_closes_hooks_and_preserves_records():
+    net = nn.Linear(2, 1)
+
+    with pytest.raises(RuntimeError):
+        with monitor.OutputMonitor(net) as output_monitor:
+            net(torch.ones(1, 2))
+            raise RuntimeError("stop")
+
+    assert len(output_monitor.records) == 1
+    assert output_monitor.hooks == []
+    assert net._forward_hooks == {}
+
+    monitor_ref = weakref.ref(output_monitor)
+    output_monitor.close()
+    del output_monitor
+    gc.collect()
+    assert monitor_ref() is None
+
+
+def test_input_monitor_records_before_forward():
+    net = InPlaceModule()
+    input_monitor = monitor.InputMonitor(net, function_on_input=torch.Tensor.clone)
+
+    x = torch.zeros(1)
+    y = net(x)
+
+    torch.testing.assert_close(input_monitor.records[0], torch.zeros(1))
+    torch.testing.assert_close(y, torch.ones(1))
 
 
 def test_attribute_monitor_before_and_after_forward():


### PR DESCRIPTION
## Summary

- add deterministic `BaseMonitor.close()` / context-manager ownership and run `InputMonitor` transforms before module forward
- consume paired STDP monitor records without stale name indexes or `pop(0)`, reject mismatches, and no-op on empty buffers
- make `GPUMonitor` promptly stoppable, shell-free, failure-aware, and responsible for closing its TensorBoard writer
- consolidate duplicated constructor examples into the bilingual monitor tutorials

Closes #737.

## Root cause

A hook registered on a live module owns a closure that strongly references its monitor:

```text
live module -> module._forward_hooks -> hook closure -> monitor
```

Deleting the caller's monitor variable therefore cannot reach `BaseMonitor.__del__()` while the module remains alive. The full diagnosis and its distinction from the autograd retention fixed by #576 / #703 are recorded in #737. This PR uses explicit `close()` / context-manager ownership instead of adding weak-reference hook machinery.

The learner-side issue was separate: direct `records.pop(0)` calls mutated the flat list without updating `name_records_index` and imposed quadratic FIFO consumption.

## Commits

1. `fix(monitor): make hook and record lifecycles explicit`
2. `fix(monitor): make GPU sampling stoppable`
3. `docs(monitor): consolidate usage examples`

## Validation

Local (macOS, Python 3.11):

- `pytest -q test/activation_based/test_monitor.py test/activation_based/test_learning.py` — 28 passed
- `uv format --check -- ...` — passed
- `uv run python tools/generate_changelog_rst.py --check` — passed
- `uv run sphinx-build -M html docs/source docs/build` — passed, no warnings
- `git diff --check` — passed

Remote g3 (7x RTX 4090, PyTorch 2.7.1+cu118, CUDA toolkit pinned per `ENV.md`):

- verified `spikingjelly.__file__` resolves to the dedicated remote source directory
- same targeted pytest command — 28 passed
- real `GPUMonitor(gpu_ids=(0,), interval=0.2)` smoke — 2 samples, stopped and joined successfully

## Deliberate limits

No weak-reference hook framework, custom record container, retry policy, extra GPU metrics, NVML dependency, or merger with the model-level profiler.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added safer monitor lifecycle management with context-manager support and explicit `close()` cleanup.
  * Input monitors now capture transformed inputs before module execution.
  * STDP learning validates matching records, handles empty data safely, and clears consumed records consistently.
  * Improved GPU utilization monitoring with responsive stopping, clearer error reporting, configuration validation, and reliable TensorBoard cleanup.
* **Documentation**
  * Updated monitoring tutorials with lifecycle guidance, memory-saving tips, input snapshots, and GPU sampling examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->