### PR TITLE
Add execution-level CUDA Graph support for 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,30 @@ and the archived documentation linked from the project README.
 
 ### Features
 
+#### CUDA Graph Execution
+
+Module: `spikingjelly.activation_based.distributed`.
+
+- Added opt-in manual CUDA Graph execution for Common and Vision training,
+  evaluation, and prediction at the model level rather than as a neuron backend.
+- Added native MCore CUDA Graph integration while preserving runtime-owned
+  buffers and scheduling.
+- Added eager shape fallback plus capture, replay, memory, and timing metrics to
+  the single-GPU benchmark.
+
 #### Spiking Neurons
 
 Module: `spikingjelly.activation_based.neuron`.
 
 - Added the paper-faithful `ComplementaryLIFNode` with single-step and
   multi-step PyTorch execution and optional trajectories for both neuron states.
+- Fixed unintended FP64 arithmetic in Triton surrogate gradients by converting
+  runtime `alpha` parameters to FP32.
+- Removed redundant mixed-precision LIF voltage-sequence allocation when
+  `store_v_seq=False`, and routed native storage/compute precision through the
+  standard Triton path.
+- Fixed built-in SEW-ResNet and Spikformer builders so Triton neuron backends are
+  applied after multi-step mode is configured.
 
 #### Distributed Inference
 
@@ -74,6 +92,19 @@ Module: `spikingjelly.activation_based.monitor`.
   without a shell, reports command failures, and closes its TensorBoard writer.
 
 ### Breaking Changes and Notices
+
+#### Vision Execution Configuration
+
+Module: `spikingjelly.activation_based.distributed.vision`.
+
+- Replaced `PredictionConfig.compile` with `execution_mode`; migrate `False` to
+  `"eager"` and `True` to `"compile"`. The new `"cuda_graph"` value explicitly
+  selects manual graph capture.
+- Vision CUDA Graph is single-rank and does not support FSDP2, FP8, memopt,
+  CuPy neurons, or stored voltage sequences in this release.
+- Replaced the Common Trainer's `--compile` flag with
+  `--execution-mode compile`; removed `--compile-disable-cudagraphs`. Compile
+  backend, mode, and evaluation options now require compile execution mode.
 
 #### FlexSN Migration
 

--- a/benchmark/benchmark_snn_single_gpu.py
+++ b/benchmark/benchmark_snn_single_gpu.py
@@ -10,6 +10,7 @@ import statistics
 import subprocess
 import sys
 import time
+from dataclasses import asdict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -21,7 +22,7 @@ DEFAULT_IMAGE_SIZE = 224
 DEFAULT_SEED = 20260808
 MODEL_NAMES = ("spiking_vgg16_bn", "sew_resnet18", "spikformer_ti")
 PHASES = ("inference", "training")
-EXECUTIONS = ("eager", "compile")
+EXECUTIONS = ("eager", "compile", "cuda_graph")
 
 
 def summarize_samples(samples_ms: list[float]) -> dict[str, float]:
@@ -531,19 +532,19 @@ def run_case(args: argparse.Namespace) -> dict[str, Any]:
     def reset_net() -> None:
         functional.reset_net(state_model)
 
-    def step() -> torch.Tensor:
+    def graph_work(
+        *inputs: torch.Tensor,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        graph_x = inputs[0]
         if optimizer is None:
             with torch.inference_mode():
-                output = model(x)
-            reset_net()
+                output = model(graph_x)
             return output
-        optimizer.zero_grad(set_to_none=True)
-        output = model(x)
-        loss = criterion(output.mean(0), target)
+        graph_target = inputs[1]
+        output = model(graph_x)
+        loss = criterion(output.mean(0), graph_target)
         loss.backward()
-        optimizer.step()
-        reset_net()
-        return loss
+        return loss, output
 
     dynamo = getattr(torch, "_dynamo", None)
     if dynamo is not None:
@@ -557,6 +558,29 @@ def run_case(args: argparse.Namespace) -> dict[str, Any]:
             backend="inductor",
             options={"triton.cudagraphs": False, "triton.cudagraph_trees": False},
         )
+    graph_runner = None
+    if args.execution == "cuda_graph":
+        from spikingjelly.activation_based._cuda_graph import (
+            StaticCudaGraph,
+            validate_cuda_graph_model,
+        )
+
+        validate_cuda_graph_model(model)
+        graph_runner = StaticCudaGraph(graph_work, args.warmup)
+
+    def step() -> torch.Tensor:
+        if optimizer is not None:
+            optimizer.zero_grad(set_to_none=graph_runner is None)
+        if graph_runner is not None:
+            result = (
+                graph_runner(x, target) if optimizer is not None else graph_runner(x)
+            )
+        else:
+            result = graph_work(x, target) if optimizer is not None else graph_work(x)
+        if optimizer is not None:
+            optimizer.step()
+        reset_net()
+        return result[0] if optimizer is not None else result
 
     hooks = None
     monitor = None
@@ -656,6 +680,9 @@ def run_case(args: argparse.Namespace) -> dict[str, Any]:
                 {"backend": "inductor", "mode": "default", "cudagraphs": False}
                 if args.execution == "compile"
                 else None
+            ),
+            "cuda_graph": (
+                asdict(graph_runner.stats) if graph_runner is not None else None
             ),
         },
         "timing": {
@@ -898,6 +925,8 @@ def main() -> None:
             raise ValueError(
                 "batch size and steps must be positive; warmup must be non-negative"
             )
+        if args.execution == "cuda_graph" and args.warmup == 0:
+            raise ValueError("warmup must be positive for CUDA Graph execution")
     else:
         positive = (
             args.rounds,
@@ -910,6 +939,11 @@ def main() -> None:
         )
         if min(positive) <= 0 or min(args.inference_warmup, args.training_warmup) < 0:
             raise ValueError("matrix counts must be positive and warmups non-negative")
+        if "cuda_graph" in args.executions and (
+            ("inference" in args.phases and args.inference_warmup == 0)
+            or ("training" in args.phases and args.training_warmup == 0)
+        ):
+            raise ValueError("CUDA Graph warmups must be positive for selected phases")
     args.handler(args)
 
 

--- a/benchmark/vision_distributed.py
+++ b/benchmark/vision_distributed.py
@@ -143,6 +143,12 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--max-steps", type=int, default=10)
     parser.add_argument("--scheduler-steps", type=int)
     parser.add_argument("--timing-warmup-steps", type=int, default=0)
+    parser.add_argument(
+        "--execution-mode",
+        choices=("eager", "compile", "cuda_graph"),
+        default="eager",
+    )
+    parser.add_argument("--cuda-graph-warmup-steps", type=int, default=3)
     parser.add_argument("--memopt-level", type=int, default=0)
     parser.add_argument("--checkpoint-dir", type=Path)
     parser.add_argument("--checkpoint-interval", type=int, default=0)
@@ -240,6 +246,8 @@ def main() -> None:
             triton_fwd=args.triton_fwd,
             triton_bwd=args.triton_bwd,
         ),
+        execution_mode=args.execution_mode,
+        cuda_graph_warmup_steps=args.cuda_graph_warmup_steps,
         memopt_level=args.memopt_level,
         max_steps=args.max_steps,
         timing_warmup_steps=args.timing_warmup_steps,

--- a/benchmark/vision_inference.py
+++ b/benchmark/vision_inference.py
@@ -134,7 +134,12 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--workers", type=int, default=2)
     parser.add_argument("--timing-warmup-batches", type=int, default=0)
     parser.add_argument("--output", type=Path)
-    parser.add_argument("--compile", action="store_true")
+    parser.add_argument(
+        "--execution-mode",
+        choices=("eager", "compile", "cuda_graph"),
+        default="eager",
+    )
+    parser.add_argument("--cuda-graph-warmup-steps", type=int, default=3)
     args = parser.parse_args()
     if min(args.samples, args.classes, args.image_size, args.time_steps) <= 0:
         parser.error("samples, classes, image-size, and time-steps must be positive")
@@ -194,7 +199,8 @@ def main() -> None:
             triton_fwd=args.triton_fwd,
             triton_bwd=args.triton_bwd,
         ),
-        compile=args.compile,
+        execution_mode=args.execution_mode,
+        cuda_graph_warmup_steps=args.cuda_graph_warmup_steps,
         **(
             {"timing_warmup_batches": args.timing_warmup_batches}
             if args.output is None

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -18,6 +18,18 @@ and the archived documentation linked from the project README.
 Features
 ~~~~~~~~
 
+CUDA Graph Execution
+^^^^^^^^^^^^^^^^^^^^
+
+Module: ``spikingjelly.activation_based.distributed``.
+
+- Added opt-in manual CUDA Graph execution for Common and Vision training,
+  evaluation, and prediction at the model level rather than as a neuron backend.
+- Added native MCore CUDA Graph integration while preserving runtime-owned
+  buffers and scheduling.
+- Added eager shape fallback plus capture, replay, memory, and timing metrics to
+  the single-GPU benchmark.
+
 Spiking Neurons
 ^^^^^^^^^^^^^^^
 
@@ -25,6 +37,13 @@ Module: ``spikingjelly.activation_based.neuron``.
 
 - Added the paper-faithful ``ComplementaryLIFNode`` with single-step and
   multi-step PyTorch execution and optional trajectories for both neuron states.
+- Fixed unintended FP64 arithmetic in Triton surrogate gradients by converting
+  runtime ``alpha`` parameters to FP32.
+- Removed redundant mixed-precision LIF voltage-sequence allocation when
+  ``store_v_seq=False``, and routed native storage/compute precision through the
+  standard Triton path.
+- Fixed built-in SEW-ResNet and Spikformer builders so Triton neuron backends are
+  applied after multi-step mode is configured.
 
 Distributed Inference
 ^^^^^^^^^^^^^^^^^^^^^
@@ -88,6 +107,20 @@ Module: ``spikingjelly.activation_based.monitor``.
 
 Breaking Changes and Notices
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Vision Execution Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Module: ``spikingjelly.activation_based.distributed.vision``.
+
+- Replaced ``PredictionConfig.compile`` with ``execution_mode``; migrate ``False`` to
+  ``"eager"`` and ``True`` to ``"compile"``. The new ``"cuda_graph"`` value explicitly
+  selects manual graph capture.
+- Vision CUDA Graph is single-rank and does not support FSDP2, FP8, memopt,
+  CuPy neurons, or stored voltage sequences in this release.
+- Replaced the Common Trainer's ``--compile`` flag with
+  ``--execution-mode compile``; removed ``--compile-disable-cudagraphs``. Compile
+  backend, mode, and evaluation options now require compile execution mode.
 
 FlexSN Migration
 ^^^^^^^^^^^^^^^^

--- a/docs/source/tutorials/cn/distributed_training.rst
+++ b/docs/source/tutorials/cn/distributed_training.rst
@@ -68,6 +68,14 @@ Transformer Engine FP8 与 Triton 神经元 mixed precision 当前要求 DDP 且
 MCore LLM 精度与此独立，继续由原生 transformer 和 optimizer 配置拥有。配置职责、
 单机用法和 FP8 性能交叉点见 :doc:`precision`。
 
+``execution_mode`` 取 ``"eager"``、``"compile"`` 或 ``"cuda_graph"``。
+``"cuda_graph"`` 在执行器层手动捕获完整 forward/loss/backward；optimizer、scaler
+更新、scheduler、EMA、checkpoint、日志和 ``reset_net`` 保持在图外。训练默认先运行
+11 个真实 step 再捕获，不执行 dummy optimizer step。输入 shape、dtype 或 layout 与
+捕获点不同时，该 batch 使用 eager 并计入 fallback。CUDA Graph 当前不支持 Vision
+多 rank（DDP/TP/PP）、FSDP2、FP8、memopt、CuPy backend 或
+``store_v_seq=True``；分布式 CUDA Graph 使用 MCore 原生 runtime。默认仍为 eager。
+
 ``batch_size`` 是每个 DP rank 的 batch size；global batch 为
 ``batch_size * DP``，不乘 TP、PP 或 SNN 时间步。``tensor_parallel_size`` 和
 ``pipeline_parallel_size`` 分别控制 TP 和 PP，剩余 rank 自动作为 DP。模型专属的

--- a/docs/source/tutorials/en/distributed_training.rst
+++ b/docs/source/tutorials/en/distributed_training.rst
@@ -76,6 +76,17 @@ require DDP with TP=PP=1. MCore LLM precision is independent and remains configu
 through its native transformer and optimizer configuration. See :doc:`precision`
 for configuration ownership, standalone usage, and measured FP8 crossover points.
 
+``execution_mode`` is ``"eager"``, ``"compile"``, or ``"cuda_graph"``.
+``"cuda_graph"`` manually captures the complete forward/loss/backward workload at
+the execution-runner seam. Optimizer and scaler updates, scheduling, EMA,
+checkpointing, logging, and ``reset_net`` remain outside the graph. Training runs
+11 real optimizer steps before capture and never runs dummy optimizer steps. A
+batch whose shape, dtype, or layout differs from the capture point runs eagerly
+and increments the fallback counter. Vision CUDA Graph currently rejects FSDP2,
+multi-rank DDP/TP/PP, FP8, memopt, CuPy backends, and ``store_v_seq=True``.
+Distributed CUDA Graph execution uses the native MCore runtime. Eager remains
+the default.
+
 ``batch_size`` is the batch size on each DP rank. The global batch is
 ``batch_size * DP`` and does not include TP, PP, or SNN time steps.
 ``tensor_parallel_size`` and ``pipeline_parallel_size`` select TP and PP; the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ include = ["spikingjelly*"]
 
 [project]
 name = "spikingjelly"
-version = "2.0.0rc1"
+version = "2.0.0"
 description = "A deep learning framework for SNNs built on PyTorch."
 readme = {file = "README.md", content-type = "text/markdown"}
 authors = [

--- a/spikingjelly/activation_based/_cuda_graph.py
+++ b/spikingjelly/activation_based/_cuda_graph.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import torch
+
+
+def validate_cuda_graph_model(model: torch.nn.Module) -> None:
+    for module in model.modules():
+        if getattr(module, "backend", None) == "cupy":
+            raise ValueError("CUDA Graph does not support the CuPy neuron backend.")
+        if getattr(module, "store_v_seq", False):
+            raise ValueError("CUDA Graph requires store_v_seq=False.")
+
+
+@dataclass
+class CudaGraphStats:
+    warmup_runs: int = 0
+    captures: int = 0
+    replays: int = 0
+    eager_fallbacks: int = 0
+    capture_seconds: float = 0.0
+    graph_memory_bytes: int = 0
+
+
+class StaticCudaGraph:
+    def __init__(
+        self,
+        function: Callable,
+        warmup_steps: int = 3,
+    ) -> None:
+        if warmup_steps <= 0:
+            raise ValueError("warmup_steps must be positive.")
+        self.function = function
+        self.warmup_steps = warmup_steps
+        self.stats = CudaGraphStats()
+        self._graph = None
+        self._capture_stream = None
+        self._inputs: tuple[torch.Tensor, ...] = ()
+        self._input_metadata = ()
+
+    def _warmup(self, inputs: tuple[torch.Tensor, ...]):
+        device = inputs[0].device
+        current_stream = torch.cuda.current_stream(device)
+        if self._capture_stream is None:
+            self._capture_stream = torch.cuda.Stream(device=device)
+        stream = self._capture_stream
+        stream.wait_stream(current_stream)
+        with torch.cuda.stream(stream):
+            output = self.function(*inputs)
+        current_stream.wait_stream(stream)
+        return output
+
+    @staticmethod
+    def _metadata(inputs: tuple[torch.Tensor, ...]) -> tuple:
+        return tuple(
+            (
+                value.shape,
+                value.stride(),
+                value.dtype,
+                value.device,
+                value.requires_grad,
+            )
+            for value in inputs
+        )
+
+    def _capture(self, inputs: tuple[torch.Tensor, ...]):
+        self._inputs = tuple(
+            value.detach().clone().requires_grad_(value.requires_grad)
+            for value in inputs
+        )
+        self._input_metadata = self._metadata(inputs)
+        device = inputs[0].device
+        graph = torch.cuda.CUDAGraph()
+        torch.cuda.synchronize(device)
+        allocated_before = torch.cuda.memory_allocated(device)
+        started = time.perf_counter()
+        with torch.cuda.graph(
+            graph, stream=self._capture_stream, capture_error_mode="thread_local"
+        ):
+            self._outputs = self.function(*self._inputs)
+        torch.cuda.current_stream(device).wait_stream(self._capture_stream)
+        capture_seconds = time.perf_counter() - started
+        # Capture records the work; the first replay materializes its outputs.
+        graph.replay()
+        self._graph = graph
+        self.stats.captures += 1
+        self.stats.capture_seconds = capture_seconds
+        self.stats.graph_memory_bytes = max(
+            0, torch.cuda.memory_allocated(device) - allocated_before
+        )
+        return self._outputs
+
+    def __call__(self, *inputs: torch.Tensor):
+        if not inputs or any(
+            not isinstance(value, torch.Tensor) or not value.is_cuda for value in inputs
+        ):
+            raise RuntimeError("StaticCudaGraph requires one or more CUDA tensors.")
+        if self._graph is None and self.stats.warmup_runs < self.warmup_steps:
+            self.stats.warmup_runs += 1
+            return self._warmup(inputs)
+        if self._graph is None:
+            return self._capture(inputs)
+        if self._metadata(inputs) != self._input_metadata:
+            self.stats.eager_fallbacks += 1
+            return self.function(*inputs)
+        for target, source in zip(self._inputs, inputs, strict=True):
+            target.copy_(source)
+        self._graph.replay()
+        self.stats.replays += 1
+        return self._outputs

--- a/spikingjelly/activation_based/distributed/llm/config.py
+++ b/spikingjelly/activation_based/distributed/llm/config.py
@@ -421,6 +421,11 @@ class TrainingConfig:
             raise ValueError(f"Unsupported lr_decay_style={self.lr_decay_style!r}.")
 
         transformer = self.model.transformer
+        if transformer.cuda_graph_impl != "none" and (
+            not isinstance(transformer.cuda_graph_warmup_steps, int)
+            or transformer.cuda_graph_warmup_steps <= 0
+        ):
+            raise ValueError("cuda_graph_warmup_steps must be a positive integer.")
         if transformer.context_parallel_size > 1 and self.sequence_length % (
             2 * transformer.context_parallel_size
         ):

--- a/spikingjelly/activation_based/distributed/llm/training.py
+++ b/spikingjelly/activation_based/distributed/llm/training.py
@@ -120,8 +120,18 @@ def train(
         )
         from megatron.core.optimizer import get_megatron_optimizer
         from megatron.core.optimizer_param_scheduler import OptimizerParamScheduler
+        from megatron.core.num_microbatches_calculator import (
+            destroy_num_microbatches_calculator,
+            get_num_microbatches,
+            init_num_microbatches_calculator,
+        )
         from megatron.core.pipeline_parallel.schedules import get_forward_backward_func
         from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+        from megatron.core.full_cuda_graph import (
+            FullCudaGraphWrapper,
+            StaticBufferLoader,
+        )
+        from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
         from megatron.core.transformer.module import Float16Module
     except ImportError as error:
         raise RuntimeError(
@@ -136,6 +146,9 @@ def train(
         torch.distributed.init_process_group(backend="nccl", device_id=device)
 
     initialized_model_parallel = not parallel_state.model_parallel_is_initialized()
+    initialized_num_microbatches = False
+    schedule = None
+    cuda_graph_helper = None
     try:
         transformer = config.model.transformer
         if initialized_model_parallel:
@@ -176,7 +189,12 @@ def train(
             )
         num_microbatches = config.global_batch_size // samples_per_microbatch
 
-        model_parallel_cuda_manual_seed(config.seed)
+        model_parallel_cuda_manual_seed(
+            config.seed,
+            te_rng_tracker=transformer.use_te_rng_tracker,
+            use_cudagraphable_rng=transformer.cuda_graph_impl != "none",
+            force_reset_rng=True,
+        )
         model = model_provider(
             parallel_state.is_pipeline_first_stage(),
             parallel_state.is_pipeline_last_stage(),
@@ -302,6 +320,36 @@ def train(
             else None
         )
         schedule = get_forward_backward_func()
+        if transformer.cuda_graph_impl == "full_iteration":
+            schedule = FullCudaGraphWrapper(
+                schedule,
+                cuda_graph_warmup_steps=transformer.cuda_graph_warmup_steps,
+                use_single_mempool=transformer.cuda_graph_use_single_mempool,
+            )
+        elif transformer.cuda_graph_impl == "transformer_engine":
+            # MCore 0.18.2 has no public calculator-initialized predicate.
+            try:
+                existing_num_microbatches = get_num_microbatches()
+            except AttributeError:
+                init_num_microbatches_calculator(
+                    rank=torch.distributed.get_rank(),
+                    global_batch_size=config.global_batch_size,
+                    micro_batch_size=config.micro_batch_size,
+                    data_parallel_size=data_parallel_size,
+                )
+                initialized_num_microbatches = True
+            else:
+                if existing_num_microbatches != num_microbatches:
+                    raise ValueError(
+                        "Existing MCore microbatch calculator does not match training."
+                    )
+            cuda_graph_helper = TECudaGraphHelper(
+                model=models,
+                config=transformer,
+                seq_length=config.sequence_length,
+                micro_batch_size=config.micro_batch_size * time_steps,
+                optimizers=[optimizer],
+            )
         metrics: dict[str, float] = {
             "optimizer_step": float(start_step),
             "consumed_samples": float(start_step * config.global_batch_size),
@@ -312,6 +360,12 @@ def train(
         training_seconds = 0.0
         timed_steps = 0
         for step in range(start_step + 1, config.train_steps + 1):
+            if (
+                cuda_graph_helper is not None
+                and not cuda_graph_helper.capture_finished()
+                and step - start_step - 1 == transformer.cuda_graph_warmup_steps
+            ):
+                cuda_graph_helper.create_cudagraphs()
             model.zero_grad_buffer()
             optimizer.zero_grad()
             torch.cuda.synchronize(device)
@@ -472,6 +526,14 @@ def train(
         )
         return metrics
     finally:
+        if cuda_graph_helper is not None and cuda_graph_helper.graphs_created():
+            cuda_graph_helper.delete_cuda_graphs()
+        if isinstance(schedule, FullCudaGraphWrapper):
+            schedule.reset_cuda_graph()
+            for buffers in StaticBufferLoader.static_buffers.values():
+                buffers.clear()
+        if initialized_num_microbatches:
+            destroy_num_microbatches_calculator()
         if (
             initialized_model_parallel
             and parallel_state.model_parallel_is_initialized()

--- a/spikingjelly/activation_based/distributed/vision/config.py
+++ b/spikingjelly/activation_based/distributed/vision/config.py
@@ -514,10 +514,15 @@ class PredictionConfig:
     :param precision: 模型与 Triton 神经元精度配置。 / Model and Triton-neuron
         precision configuration.
     :type precision: spikingjelly.activation_based.precision.PrecisionConfig
-    :param compile: 是否使用 ``torch.compile``；当前仅支持无 PP 的
-        replicated 模式。 / Whether to use ``torch.compile``; currently limited
-        to replicated execution without PP.
-    :type compile: bool
+    :param execution_mode: ``"eager"``、``"compile"`` 或 ``"cuda_graph"``。
+        ``"cuda_graph"`` 仅支持 single-rank replicated execution、非 CuPy 神经元、
+        ``store_v_seq=False`` 和非实验精度。 / ``"eager"``, ``"compile"``, or
+        ``"cuda_graph"``. CUDA Graph requires single-rank replicated execution,
+        non-CuPy neurons, ``store_v_seq=False``, and non-experimental precision.
+    :type execution_mode: str
+    :param cuda_graph_warmup_steps: CUDA Graph 捕获前的 eager warmup batch 数。 /
+        Eager warmup batches before CUDA Graph capture.
+    :type cuda_graph_warmup_steps: int
     :param seed: 模型与数据随机种子。 / Model and data seed.
     :type seed: int
     :raises TypeError: ``precision`` 不是 ``PrecisionConfig``。 / If ``precision``
@@ -538,7 +543,8 @@ class PredictionConfig:
     precision: PrecisionConfig = field(
         default_factory=lambda: PrecisionConfig(mode="bf16")
     )
-    compile: bool = False
+    execution_mode: Literal["eager", "compile", "cuda_graph"] = "eager"
+    cuda_graph_warmup_steps: int = 3
     seed: int = 1234
 
     def __post_init__(self) -> None:
@@ -558,6 +564,12 @@ class PredictionConfig:
             raise ValueError("input_layout must be 'NCHW' or 'NTCHW'.")
         if self.data_parallel not in {"replicate", "fsdp2"}:
             raise ValueError("data_parallel must be 'replicate' or 'fsdp2'.")
+        if self.execution_mode not in {"eager", "compile", "cuda_graph"}:
+            raise ValueError(
+                "execution_mode must be 'eager', 'compile', or 'cuda_graph'."
+            )
+        if self.cuda_graph_warmup_steps <= 0:
+            raise ValueError("cuda_graph_warmup_steps must be positive.")
         if not isinstance(self.precision, PrecisionConfig):
             raise TypeError("precision must be PrecisionConfig.")
         if self.pipeline_parallel_size > 1 and self.precision.mode == "fp16":
@@ -568,16 +580,22 @@ class PredictionConfig:
             self.data_parallel != "replicate"
             or self.tensor_parallel_size != 1
             or self.pipeline_parallel_size != 1
-            or self.compile
+            or self.execution_mode != "eager"
         ):
             raise ValueError(
                 "Vision experimental precision inference requires replicated "
-                "execution with TP=1, PP=1, and compile=False."
+                "eager execution with TP=1 and PP=1."
             )
-        if self.compile and (
+        if self.execution_mode == "compile" and (
             self.pipeline_parallel_size > 1 or self.data_parallel != "replicate"
         ):
             raise ValueError("compile requires replicated execution without PP.")
+        if self.execution_mode == "cuda_graph" and self.data_parallel == "fsdp2":
+            raise ValueError("CUDA Graph does not support Vision FSDP2 execution.")
+        if self.execution_mode == "cuda_graph" and (
+            self.tensor_parallel_size != 1 or self.pipeline_parallel_size != 1
+        ):
+            raise ValueError("Vision CUDA Graph requires single-rank model execution.")
         if "." not in self.dataset_builder:
             raise ValueError("dataset_builder must be a full import path.")
 
@@ -636,10 +654,14 @@ loss, accuracy, and performance metrics.
 :param precision: 模型与 Triton 神经元精度配置。 / Model and Triton-neuron
     precision configuration.
 :type precision: spikingjelly.activation_based.precision.PrecisionConfig
-:param compile: 是否使用 ``torch.compile``；当前仅支持无 PP 的 replicated 模式。 /
-    Whether to use ``torch.compile``; currently limited to replicated execution
-    without PP.
-:type compile: bool
+:param execution_mode: ``"eager"``、``"compile"`` 或 ``"cuda_graph"``。 /
+    ``"eager"``, ``"compile"``, or ``"cuda_graph"``. CUDA Graph inherits the
+    single-rank, backend, state-storage, and precision restrictions from
+    :class:`PredictionConfig`.
+:type execution_mode: str
+:param cuda_graph_warmup_steps: CUDA Graph 捕获前的 eager warmup batch 数。 /
+    Eager warmup batches before CUDA Graph capture.
+:type cuda_graph_warmup_steps: int
 :param seed: 模型与数据随机种子。 / Model and data seed.
 :type seed: int
 :param loss_function: 分类 loss 函数的完整导入路径。 / Full loss-function
@@ -681,6 +703,8 @@ class TrainingConfig:
     precision: PrecisionConfig = field(
         default_factory=lambda: PrecisionConfig(mode="bf16")
     )
+    execution_mode: Literal["eager", "compile", "cuda_graph"] = "eager"
+    cuda_graph_warmup_steps: int = 11
     memopt_level: int = 0
     memopt_compress_inputs: bool = True
     memopt_checkpoint_budget: Literal["speed", "balanced", "memory"] = "memory"
@@ -711,6 +735,12 @@ class TrainingConfig:
             raise ValueError("mixup_alpha cannot be negative.")
         if self.data_parallel not in {"ddp", "fsdp2"}:
             raise ValueError("data_parallel must be 'ddp' or 'fsdp2'.")
+        if self.execution_mode not in {"eager", "compile", "cuda_graph"}:
+            raise ValueError(
+                "execution_mode must be 'eager', 'compile', or 'cuda_graph'."
+            )
+        if self.cuda_graph_warmup_steps <= 0:
+            raise ValueError("cuda_graph_warmup_steps must be positive.")
         if not isinstance(self.precision, PrecisionConfig):
             raise TypeError("precision must be PrecisionConfig.")
         if self.pipeline_parallel_size > 1 and self.precision.mode == "fp16":
@@ -729,6 +759,22 @@ class TrainingConfig:
             raise ValueError("Vision PP currently requires step_mode='m'.")
         if not 0 <= self.memopt_level <= 4:
             raise ValueError("memopt_level must lie in [0, 4].")
+        if self.execution_mode == "cuda_graph":
+            if self.data_parallel == "fsdp2":
+                raise ValueError("CUDA Graph does not support Vision FSDP2 training.")
+            if self.tensor_parallel_size != 1 or self.pipeline_parallel_size != 1:
+                raise ValueError(
+                    "Vision CUDA Graph requires single-rank model execution."
+                )
+            if self.memopt_level:
+                raise ValueError("CUDA Graph does not support Vision memopt training.")
+            if (
+                self.precision.mode == "fp8"
+                or self.precision.triton_storage is not None
+            ):
+                raise ValueError(
+                    "CUDA Graph does not support Vision experimental precision."
+                )
         if self.memopt_checkpoint_budget not in {"speed", "balanced", "memory"}:
             raise ValueError(
                 "memopt_checkpoint_budget must be 'speed', 'balanced', or 'memory'."
@@ -868,6 +914,14 @@ receives ``dataset_kwargs`` and returns train and validation datasets.
 :param precision: 模型与 Triton 神经元精度配置。 / Model and Triton-neuron
     precision configuration.
 :type precision: spikingjelly.activation_based.precision.PrecisionConfig
+:param execution_mode: ``"eager"``、``"compile"`` 或 ``"cuda_graph"``。 /
+    ``"eager"``, ``"compile"``, or ``"cuda_graph"``. CUDA Graph requires one
+    rank, DDP configuration without distributed replicas, ``memopt_level=0``,
+    non-CuPy neurons, ``store_v_seq=False``, and non-experimental precision.
+:type execution_mode: str
+:param cuda_graph_warmup_steps: CUDA Graph 捕获前的真实训练 step 数。 / Real
+    training steps before CUDA Graph capture.
+:type cuda_graph_warmup_steps: int
 :param memopt_level: SpikingJelly memopt level，范围 ``[0, 4]``。 / SpikingJelly
     memopt level in ``[0, 4]``.
 :type memopt_level: int

--- a/spikingjelly/activation_based/distributed/vision/inference.py
+++ b/spikingjelly/activation_based/distributed/vision/inference.py
@@ -17,6 +17,10 @@ from torch.utils.data import DataLoader, Dataset
 from torch.utils.data.distributed import DistributedSampler
 
 from spikingjelly.activation_based import functional
+from spikingjelly.activation_based._cuda_graph import (
+    StaticCudaGraph,
+    validate_cuda_graph_model,
+)
 from spikingjelly.activation_based.precision import prepare_model_for_precision
 
 from .config import (
@@ -460,6 +464,11 @@ def _run_classification(
             raise ValueError("world_size must be divisible by PP * TP.")
         rank = dist.get_rank()
         data_parallel_size = world_size // model_parallel_size
+        if config.execution_mode == "cuda_graph" and world_size != 1:
+            raise ValueError(
+                "Vision CUDA Graph requires a single-rank process; use MCore or "
+                "SGLang for distributed CUDA Graph execution."
+            )
         tensor_rank = rank % config.tensor_parallel_size
         pipeline_rank = (
             rank // config.tensor_parallel_size
@@ -503,6 +512,8 @@ def _run_classification(
         )
         precision = prepare_model_for_precision(model, device, config.precision)
         model = precision.model
+        if config.execution_mode == "cuda_graph":
+            validate_cuda_graph_model(model)
         if config.data_parallel == "fsdp2":
             model = _wrap_data_parallel(
                 model,
@@ -516,8 +527,6 @@ def _run_classification(
                 dp_mesh=data_mesh,
                 fsdp_roots=fsdp_roots,
             )
-        if config.compile:
-            model = torch.compile(model)
         model.eval()
 
         schedule = None
@@ -568,39 +577,49 @@ def _run_classification(
                 shard_path, model_config.num_classes
             )
 
+        def execute_model(images: torch.Tensor) -> torch.Tensor:
+            with precision.autocast_context(group=data_group):
+                return _forward_classification(
+                    model,
+                    images,
+                    model_config.time_steps,
+                    model_config.step_mode,
+                    config.input_layout,
+                )
+
+        if config.execution_mode == "compile":
+            execute_model = torch.compile(execute_model)
+        elif config.execution_mode == "cuda_graph":
+            execute_model = StaticCudaGraph(
+                execute_model, config.cuda_graph_warmup_steps
+            )
+
         def forward_batch(batch):
             images, targets, indices, valid, has_target = batch
             if schedule is None or pipeline_rank == 0:
                 images = images.to(device, non_blocking=True)
             if evaluate and output_rank:
                 targets = targets.to(device, non_blocking=True)
-            with precision.autocast_context(group=data_group):
-                if schedule is None:
-                    logits = _forward_classification(
-                        model,
+            if schedule is None:
+                logits = execute_model(images)
+                functional.reset_net(model)
+            else:
+                sequence = (
+                    images
+                    if config.input_layout == "NCHW"
+                    else _classification_sequence(
                         images,
                         model_config.time_steps,
-                        model_config.step_mode,
                         config.input_layout,
+                        batch_first=True,
                     )
-                else:
-                    sequence = (
-                        images
-                        if config.input_layout == "NCHW"
-                        else _classification_sequence(
-                            images,
-                            model_config.time_steps,
-                            config.input_layout,
-                            batch_first=True,
-                        )
-                    )
+                )
+                with precision.autocast_context(group=data_group):
                     logits = (
                         schedule.step(sequence)
                         if pipeline_rank == 0
                         else schedule.step()
                     )
-            if schedule is None:
-                functional.reset_net(model)
             return logits, targets, indices, valid, has_target
 
         with torch.inference_mode():
@@ -676,6 +695,7 @@ def _run_classification(
                                 asdict(config.precision), sort_keys=True
                             ),
                             "source_checkpoint": source["checkpoint"],
+                            "execution_mode": config.execution_mode,
                         },
                     )
                 except BaseException as exception:
@@ -697,7 +717,7 @@ def _run_classification(
             raise ValueError(
                 "evaluate_classification requires a target for every dataset sample."
             )
-        return {
+        result = {
             "loss": (totals[0] / totals[2]).item(),
             "accuracy": (totals[1] / totals[2]).item(),
             "samples": float(dataset_size),
@@ -708,6 +728,21 @@ def _run_classification(
             "pipeline_parallel_size": float(config.pipeline_parallel_size),
             "tensor_parallel_size": float(config.tensor_parallel_size),
         }
+        if isinstance(execute_model, StaticCudaGraph):
+            result.update(
+                {
+                    "cuda_graph_captures": float(execute_model.stats.captures),
+                    "cuda_graph_replays": float(execute_model.stats.replays),
+                    "cuda_graph_eager_fallbacks": float(
+                        execute_model.stats.eager_fallbacks
+                    ),
+                    "cuda_graph_capture_seconds": execute_model.stats.capture_seconds,
+                    "cuda_graph_memory_bytes": float(
+                        execute_model.stats.graph_memory_bytes
+                    ),
+                }
+            )
+        return result
     finally:
         if prediction_shard is not None:
             prediction_shard.close()

--- a/spikingjelly/activation_based/distributed/vision/training.py
+++ b/spikingjelly/activation_based/distributed/vision/training.py
@@ -20,6 +20,10 @@ from torch.utils.data import DataLoader, Dataset
 from torch.utils.data.distributed import DistributedSampler
 
 from spikingjelly.activation_based import functional
+from spikingjelly.activation_based._cuda_graph import (
+    StaticCudaGraph,
+    validate_cuda_graph_model,
+)
 from spikingjelly.activation_based.precision import (
     PrecisionArtifacts,
     PrecisionConfig,
@@ -321,15 +325,13 @@ def _evaluate(
     model: nn.Module,
     loader: DataLoader,
     *,
-    time_steps: int,
-    step_mode: str,
-    input_layout: str,
     device: torch.device,
     precision: PrecisionArtifacts,
     loss_function: Callable[..., torch.Tensor],
     dp_group: Optional[ProcessGroup],
     dp_size: int,
     sync_buffers: bool,
+    forward_step: Callable[[torch.Tensor], torch.Tensor],
 ) -> tuple[float, float]:
     model.eval()
     if sync_buffers:
@@ -339,10 +341,8 @@ def _evaluate(
         for images, targets in loader:
             images = images.to(device, non_blocking=True)
             targets = targets.to(device, non_blocking=True)
+            logits = forward_step(images)
             with precision.autocast_context(group=dp_group):
-                logits = _forward_classification(
-                    model, images, time_steps, step_mode, input_layout
-                )
                 loss = _classification_loss(logits, targets, loss_function)
             totals[0] += loss.double() * targets.numel()
             totals[1] += (logits.argmax(1) == targets).sum().double()
@@ -512,6 +512,11 @@ def train_classification(config: TrainingConfig) -> dict[str, float]:
         if world_size % model_parallel_size:
             raise ValueError("world_size must be divisible by PP × TP.")
         dp_size = world_size // model_parallel_size
+        if config.execution_mode == "cuda_graph" and world_size != 1:
+            raise ValueError(
+                "Vision CUDA Graph requires a single-rank process; use MCore or "
+                "SGLang for distributed CUDA Graph execution."
+            )
         tp_rank = rank % config.tensor_parallel_size
         pp_rank = (rank // config.tensor_parallel_size) % config.pipeline_parallel_size
         dp_rank = rank // model_parallel_size
@@ -580,6 +585,8 @@ def train_classification(config: TrainingConfig) -> dict[str, float]:
         functional.set_step_mode(model, config.model.step_mode)
         precision = prepare_model_for_precision(model, device, config.precision)
         model = precision.model
+        if config.execution_mode == "cuda_graph":
+            validate_cuda_graph_model(model)
         model = _wrap_data_parallel(
             model,
             data_parallel=config.data_parallel,
@@ -591,6 +598,9 @@ def train_classification(config: TrainingConfig) -> dict[str, float]:
             dp_group=dp_group,
             dp_mesh=dp_mesh,
             fsdp_roots=fsdp_roots,
+        )
+        execution_model = (
+            torch.compile(model) if config.execution_mode == "compile" else model
         )
         sync_single_step_buffers = (
             config.model.step_mode == "s"
@@ -622,7 +632,7 @@ def train_classification(config: TrainingConfig) -> dict[str, float]:
             )
             train_schedule = ScheduleGPipe(
                 PipelineStage(
-                    _ResetAfterForward(model, batch_first=pp_rank == 0),
+                    _ResetAfterForward(execution_model, batch_first=pp_rank == 0),
                     pp_rank,
                     config.pipeline_parallel_size,
                     device,
@@ -635,7 +645,7 @@ def train_classification(config: TrainingConfig) -> dict[str, float]:
             )
             evaluation_schedule = ScheduleGPipe(
                 PipelineStage(
-                    _ResetAfterForward(model, batch_first=pp_rank == 0),
+                    _ResetAfterForward(execution_model, batch_first=pp_rank == 0),
                     pp_rank,
                     config.pipeline_parallel_size,
                     device,
@@ -658,6 +668,51 @@ def train_classification(config: TrainingConfig) -> dict[str, float]:
         )
         scaler = precision.scaler or torch.amp.GradScaler("cuda", enabled=False)
 
+        def train_step(
+            images: torch.Tensor, loss_targets: torch.Tensor
+        ) -> torch.Tensor:
+            with precision.autocast_context(group=dp_group):
+                logits = _forward_classification(
+                    execution_model,
+                    images,
+                    config.model.time_steps,
+                    config.model.step_mode,
+                    config.input_layout,
+                )
+                loss = _classification_loss(logits, loss_targets, loss_function)
+            if precision.scaler is not None:
+                scaler.scale(loss).backward()
+            else:
+                loss.backward()
+            return loss
+
+        training_step = (
+            StaticCudaGraph(
+                train_step,
+                config.cuda_graph_warmup_steps,
+            )
+            if config.execution_mode == "cuda_graph"
+            else train_step
+        )
+
+        def evaluation_forward(images: torch.Tensor) -> torch.Tensor:
+            with precision.autocast_context(group=dp_group):
+                return _forward_classification(
+                    execution_model,
+                    images,
+                    config.model.time_steps,
+                    config.model.step_mode,
+                    config.input_layout,
+                )
+
+        evaluation_step = (
+            StaticCudaGraph(
+                evaluation_forward,
+                min(config.cuda_graph_warmup_steps, 3),
+            )
+            if config.execution_mode == "cuda_graph" and train_schedule is None
+            else evaluation_forward
+        )
         start_step = start_epoch = start_batch = 0
         if config.resume is not None:
             start_step, start_epoch, start_batch = _load_checkpoint(
@@ -702,7 +757,7 @@ def train_classification(config: TrainingConfig) -> dict[str, float]:
                     images, loss_targets = mixup(images, targets)
                 if sync_single_step_buffers:
                     _broadcast_data_parallel_buffers(model, dp_group)
-                optimizer.zero_grad(set_to_none=True)
+                optimizer.zero_grad(set_to_none=config.execution_mode != "cuda_graph")
                 if train_schedule is not None:
                     sequence = _classification_sequence(
                         images,
@@ -737,23 +792,13 @@ def train_classification(config: TrainingConfig) -> dict[str, float]:
                     optimizer.step()
                     update_successful = True
                 else:
-                    with precision.autocast_context(group=dp_group):
-                        logits = _forward_classification(
-                            model,
-                            images,
-                            config.model.time_steps,
-                            config.model.step_mode,
-                            config.input_layout,
-                        )
-                        loss = _classification_loss(logits, loss_targets, loss_function)
+                    scale = scaler.get_scale() if precision.scaler is not None else None
+                    loss = training_step(images, loss_targets)
                     if precision.scaler is not None:
-                        scale = scaler.get_scale()
-                        scaler.scale(loss).backward()
                         scaler.step(optimizer)
                         scaler.update()
                         update_successful = scaler.get_scale() >= scale
                     else:
-                        loss.backward()
                         optimizer.step()
                         update_successful = True
                 if scheduler is not None and update_successful:
@@ -801,15 +846,13 @@ def train_classification(config: TrainingConfig) -> dict[str, float]:
                 validation_loss, validation_accuracy = _evaluate(
                     model,
                     validation_loader,
-                    time_steps=config.model.time_steps,
-                    step_mode=config.model.step_mode,
-                    input_layout=config.input_layout,
                     device=device,
                     precision=precision,
                     loss_function=loss_function,
                     dp_group=dp_group,
                     dp_size=dp_size,
                     sync_buffers=sync_single_step_buffers,
+                    forward_step=evaluation_step,
                 )
             else:
                 model.eval()
@@ -852,15 +895,13 @@ def train_classification(config: TrainingConfig) -> dict[str, float]:
                 validation_loss, validation_accuracy = _evaluate(
                     model,
                     validation_loader,
-                    time_steps=config.model.time_steps,
-                    step_mode=config.model.step_mode,
-                    input_layout=config.input_layout,
                     device=device,
                     precision=precision,
                     loss_function=loss_function,
                     dp_group=dp_group,
                     dp_size=dp_size,
                     sync_buffers=sync_single_step_buffers,
+                    forward_step=evaluation_step,
                 )
             else:
                 model.eval()
@@ -895,7 +936,7 @@ def train_classification(config: TrainingConfig) -> dict[str, float]:
         total_memory = local_metrics[1:].clone()
         dist.all_reduce(total_memory, op=dist.ReduceOp.SUM)
         elapsed = maximum_metrics[0].item()
-        return {
+        result = {
             "train_loss": train_loss,
             "validation_loss": validation_loss,
             "validation_accuracy": validation_accuracy,
@@ -914,6 +955,21 @@ def train_classification(config: TrainingConfig) -> dict[str, float]:
             "tensor_parallel_size": float(config.tensor_parallel_size),
             "global_batch_size": float(config.batch_size * dp_size),
         }
+        if isinstance(training_step, StaticCudaGraph):
+            result.update(
+                {
+                    "cuda_graph_captures": float(training_step.stats.captures),
+                    "cuda_graph_replays": float(training_step.stats.replays),
+                    "cuda_graph_eager_fallbacks": float(
+                        training_step.stats.eager_fallbacks
+                    ),
+                    "cuda_graph_capture_seconds": training_step.stats.capture_seconds,
+                    "cuda_graph_memory_bytes": float(
+                        training_step.stats.graph_memory_bytes
+                    ),
+                }
+            )
+        return result
     finally:
         if initialized_here:
             dist.destroy_process_group()

--- a/spikingjelly/activation_based/examples/common/train_classify.py
+++ b/spikingjelly/activation_based/examples/common/train_classify.py
@@ -19,6 +19,7 @@ from torch.utils.tensorboard import SummaryWriter
 from torchvision.transforms.functional import InterpolationMode
 
 from ... import functional
+from ..._cuda_graph import StaticCudaGraph, validate_cuda_graph_model
 from .tv_ref_classify import presets, transforms, utils
 from .tv_ref_classify.sampler import RASampler
 from spikingjelly.logger import logger
@@ -158,7 +159,7 @@ class Trainer:
         self, args, model: nn.Module, *, enabled: bool | None = None
     ) -> nn.Module:
         if enabled is None:
-            enabled = args.compile
+            enabled = args.execution_mode == "compile"
 
         if not enabled:
             return model
@@ -166,18 +167,6 @@ class Trainer:
         compile_kwargs = {"backend": args.compile_backend}
         if args.compile_mode is not None:
             compile_kwargs["mode"] = args.compile_mode
-
-        if args.compile_backend == "inductor":
-            compile_options = {}
-            if args.compile_disable_cudagraphs:
-                compile_options.update(
-                    {
-                        "triton.cudagraphs": False,
-                        "triton.cudagraph_trees": False,
-                    }
-                )
-            if compile_options:
-                compile_kwargs["options"] = compile_options
 
         return torch.compile(model, **compile_kwargs)
 
@@ -198,6 +187,28 @@ class Trainer:
         metric_logger.add_meter("lr", utils.SmoothedValue(window_size=1, fmt="{value}"))
         metric_logger.add_meter("img/s", utils.ThroughputValue(fmt="{global_avg:.3f}"))
 
+        def train_step(image: torch.Tensor, target: torch.Tensor):
+            with torch.cuda.amp.autocast(enabled=scaler is not None):
+                processed = self.preprocess_train_sample(args, image)
+                output = self.process_model_output(args, model(processed))
+                loss = criterion(output, target)
+            if scaler is not None:
+                scaler.scale(loss).backward()
+            else:
+                loss.backward()
+            return loss, output
+
+        if args.execution_mode == "cuda_graph":
+            training_step = getattr(self, "_cuda_graph_training_step", None)
+            if training_step is None:
+                training_step = StaticCudaGraph(
+                    train_step,
+                    args.cuda_graph_warmup_steps,
+                )
+                self._cuda_graph_training_step = training_step
+        else:
+            training_step = train_step
+
         header = f"Epoch: [{epoch}]"
         for i, (image, target) in enumerate(
             metric_logger.log_every(data_loader, -1, header)
@@ -205,14 +216,9 @@ class Trainer:
             start_time = time.time()
             image = image.to(device, non_blocking=not args.disable_pinmemory)
             target = target.to(device, non_blocking=not args.disable_pinmemory)
-            with torch.cuda.amp.autocast(enabled=scaler is not None):
-                image = self.preprocess_train_sample(args, image)
-                output = self.process_model_output(args, model(image))
-                loss = criterion(output, target)
-
-            optimizer.zero_grad(set_to_none=True)
+            optimizer.zero_grad(set_to_none=args.execution_mode != "cuda_graph")
+            loss, output = training_step(image, target)
             if scaler is not None:
-                scaler.scale(loss).backward()
                 if args.clip_grad_norm is not None:
                     # we should unscale the gradients of optimizer's assigned params if do gradient clipping
                     scaler.unscale_(optimizer)
@@ -220,7 +226,6 @@ class Trainer:
                 scaler.step(optimizer)
                 scaler.update()
             else:
-                loss.backward()
                 if args.clip_grad_norm is not None:
                     nn.utils.clip_grad_norm_(model.parameters(), args.clip_grad_norm)
                 optimizer.step()
@@ -264,12 +269,30 @@ class Trainer:
         header = f"Test: {log_suffix}"
         num_processed_samples = 0
         start_time = time.perf_counter()
+
+        def forward_step(image: torch.Tensor) -> torch.Tensor:
+            processed = self.preprocess_test_sample(args, image)
+            return self.process_model_output(args, model(processed))
+
+        if args.execution_mode == "cuda_graph":
+            graphs = getattr(self, "_cuda_graph_evaluation_steps", None)
+            if graphs is None:
+                graphs = {}
+                self._cuda_graph_evaluation_steps = graphs
+            graph = graphs.get(id(model))
+            if graph is None:
+                graph = StaticCudaGraph(
+                    forward_step,
+                    min(args.cuda_graph_warmup_steps, 3),
+                )
+                graphs[id(model)] = graph
+            forward_step = graph
+
         with torch.inference_mode():
             for image, target in metric_logger.log_every(data_loader, -1, header):
                 image = image.to(device, non_blocking=not args.disable_pinmemory)
                 target = target.to(device, non_blocking=not args.disable_pinmemory)
-                image = self.preprocess_test_sample(args, image)
-                output = self.process_model_output(args, model(image))
+                output = forward_step(image)
                 loss = criterion(output, target)
 
                 acc1, acc5 = self.cal_acc1_acc5(output, target)
@@ -519,7 +542,23 @@ class Trainer:
         return lr_scheduler
 
     def main(self, args):
-        set_deterministic(args.seed, args.disable_uda)
+        self._cuda_graph_training_step = None
+        self._cuda_graph_evaluation_steps = {}
+        if args.execution_mode != "compile" and (
+            args.compile_backend != "inductor"
+            or args.compile_mode is not None
+            or args.compile_eval
+        ):
+            raise ValueError("compile options require --execution-mode compile.")
+        if args.execution_mode == "cuda_graph":
+            if torch.device(args.device).type != "cuda":
+                raise ValueError("Common Trainer CUDA Graph requires a CUDA device.")
+            if int(os.environ.get("WORLD_SIZE", "1")) > 1:
+                raise ValueError(
+                    "Common Trainer CUDA Graph requires single-process execution."
+                )
+            if args.cuda_graph_warmup_steps <= 0:
+                raise ValueError("cuda_graph_warmup_steps must be positive.")
         if args.workers > 0 and args.prefetch_factor < 1:
             raise ValueError(
                 f"--prefetch-factor must be >= 1 when --workers > 0, but got {args.prefetch_factor}."
@@ -532,6 +571,7 @@ class Trainer:
             raise ValueError(
                 "The weights parameter works only in prototype mode. Please pass the --prototype argument."
             )
+        set_deterministic(args.seed, args.disable_uda)
         if args.output_dir:
             os.makedirs(args.output_dir, exist_ok=True)
 
@@ -540,7 +580,6 @@ class Trainer:
             logger.info("Training arguments: {}", args)
 
         device = torch.device(args.device)
-
         dataset, dataset_test, train_sampler, test_sampler = self.load_ImageNet(args)
 
         collate_fn = None
@@ -584,6 +623,8 @@ class Trainer:
             logger.info("Creating model")
         model = self.load_model(args, num_classes)
         model.to(device)
+        if args.execution_mode == "cuda_graph":
+            validate_cuda_graph_model(model)
         if utils.is_main_process():
             logger.info("Model created: {}", type(model).__name__)
             logger.debug("Model architecture:\n{}", model)
@@ -684,7 +725,9 @@ class Trainer:
 
         model = self.compile_model(args, model_without_ddp)
         eval_model = (
-            model_without_ddp if args.compile and not args.compile_eval else model
+            model_without_ddp
+            if args.execution_mode == "compile" and not args.compile_eval
+            else model
         )
 
         if args.distributed:
@@ -1110,9 +1153,10 @@ class Trainer:
             help="not use automatic mixed precision training",
         )
         parser.add_argument(
-            "--compile",
-            action="store_true",
-            help="compile the training model with torch.compile",
+            "--execution-mode",
+            choices=("eager", "compile", "cuda_graph"),
+            default="eager",
+            help="model execution mode (default: eager)",
         )
         parser.add_argument(
             "--compile-backend",
@@ -1127,14 +1171,15 @@ class Trainer:
             help="optional mode passed to torch.compile, e.g. default or max-autotune",
         )
         parser.add_argument(
-            "--compile-disable-cudagraphs",
-            action="store_true",
-            help="disable Inductor cudagraph options for better cross-version stability",
-        )
-        parser.add_argument(
             "--compile-eval",
             action="store_true",
             help="also compile evaluation instead of using the eager model for validation",
+        )
+        parser.add_argument(
+            "--cuda-graph-warmup-steps",
+            type=int,
+            default=11,
+            help="eager steps before CUDA Graph capture (default: 11)",
         )
         parser.add_argument(
             "--local_rank",

--- a/spikingjelly/activation_based/examples/train_flexsn_compile.py
+++ b/spikingjelly/activation_based/examples/train_flexsn_compile.py
@@ -31,13 +31,13 @@ class _FlexSNTrainer(train_classify.Trainer):
             default=4.0,
             help="alpha for surrogate.Sigmoid used by the FlexSN core",
         )
-        parser.set_defaults(compile=True, compile_eval=False, disable_uda=True)
+        parser.set_defaults(execution_mode="compile", disable_uda=True)
         return parser
 
     def get_tb_logdir_name(self, args):
         return (
             super().get_tb_logdir_name(args)
-            + f"_T{args.T}_flexsn_triton_compile_sa{args.surrogate_alpha}"
+            + f"_T{args.T}_flexsn_triton_{args.execution_mode}_sa{args.surrogate_alpha}"
         )
 
     def load_model(self, args, num_classes):

--- a/spikingjelly/activation_based/functional/neuron.py
+++ b/spikingjelly/activation_based/functional/neuron.py
@@ -2511,10 +2511,12 @@ def _lif_multi_step_triton_mp(
         backward_compute_dtype=precision[2],
         spike_dtype=x_seq.dtype,
         save_intermediates=store_v_seq,
+        store_v_seq=store_v_seq,
         detach_reset=detach_reset,
         surrogate_function=surrogate_function,
     )
-    return spike_seq, voltage[-1].clone(), voltage if store_v_seq else None
+    v = voltage[-1].clone() if store_v_seq else voltage.clone()
+    return spike_seq, v, voltage if store_v_seq else None
 
 
 def ilif_multi_step_triton(

--- a/spikingjelly/activation_based/model/sew_resnet.py
+++ b/spikingjelly/activation_based/model/sew_resnet.py
@@ -1039,9 +1039,10 @@ class SEWResNet34Builder(ModelBuilder):
             num_classes=config.num_classes,
             tau=config.tau,
             detach_reset=config.detach_reset,
-            backend=config.neuron_backend,
+            backend="torch",
         )
         functional.set_step_mode(model, config.step_mode)
+        functional.set_backend(model, config.neuron_backend, instance=neuron.BaseNode)
         return model
 
     def _pipeline_stage(self, model: nn.Module, rank: int, size: int) -> nn.Module:

--- a/spikingjelly/activation_based/model/spikformer.py
+++ b/spikingjelly/activation_based/model/spikformer.py
@@ -1156,7 +1156,7 @@ class SpikformerBuilder(ModelBuilder):
             model = spikformer_cifar10(
                 T=config.time_steps,
                 num_classes=config.num_classes,
-                backend=config.neuron_backend,
+                backend="torch",
             )
         elif isinstance(config, SpikformerConfig):
             model = spikformer_s(
@@ -1165,11 +1165,13 @@ class SpikformerBuilder(ModelBuilder):
                 img_size_h=config.image_height,
                 img_size_w=config.image_width,
                 num_classes=config.num_classes,
-                backend=config.neuron_backend,
+                backend="torch",
             )
         else:
             raise TypeError("SpikformerBuilder requires a Spikformer config.")
         _convert_batch_norms(model)
+        functional.set_step_mode(model, config.step_mode)
+        functional.set_backend(model, config.neuron_backend, instance=neuron.BaseNode)
         return model
 
     def _pipeline_stage(self, model: nn.Module, rank: int, size: int) -> nn.Module:

--- a/spikingjelly/activation_based/neuron/lif.py
+++ b/spikingjelly/activation_based/neuron/lif.py
@@ -241,6 +241,19 @@ class LIFNode(BaseNode):
     def extra_repr(self):
         return super().extra_repr() + f", tau={self.tau}"
 
+    @staticmethod
+    def _requires_mixed_precision_triton(x_seq, precision):
+        native_compute = {
+            torch.float32: "fp32",
+            torch.float16: "fp16",
+            torch.bfloat16: "bf16",
+        }.get(x_seq.dtype)
+        return precision is not None and precision != (
+            x_seq.dtype,
+            native_compute,
+            native_compute,
+        )
+
     def single_step_functional_forward(
         self,
         inputs: tuple[torch.Tensor, ...],
@@ -311,9 +324,13 @@ class LIFNode(BaseNode):
                     "Triton backend only supports spiking surrogate functions. "
                     "Use backend='torch' for non-spiking surrogate functions."
                 )
+            precision = self._triton_precision
+            use_mixed_precision = self._requires_mixed_precision_triton(
+                x_seq, precision
+            )
             function = (
                 _lif_multi_step_triton_mp
-                if self._triton_precision is not None
+                if use_mixed_precision
                 else functional.lif_multi_step_triton
             )
             spike_seq, v, _ = function(
@@ -326,7 +343,7 @@ class LIFNode(BaseNode):
                 self.surrogate_function,
                 self.detach_reset,
                 False,
-                *(() if self._triton_precision is None else (self._triton_precision,)),
+                *((precision,) if use_mixed_precision else ()),
             )
         elif self.backend == "torch":
             return super().multi_step_functional_forward(inputs, states, **kwargs)
@@ -363,9 +380,13 @@ class LIFNode(BaseNode):
                     "Triton backend only supports spiking surrogate functions. "
                     "Use backend='torch' for non-spiking surrogate functions."
                 )
+            precision = self._triton_precision
+            use_mixed_precision = self._requires_mixed_precision_triton(
+                x_seq, precision
+            )
             function = (
                 _lif_multi_step_triton_mp
-                if self._triton_precision is not None
+                if use_mixed_precision
                 else functional.lif_multi_step_triton
             )
             spike_seq, v, v_seq = function(
@@ -378,7 +399,7 @@ class LIFNode(BaseNode):
                 self.surrogate_function,
                 self.detach_reset,
                 True,
-                *(() if self._triton_precision is None else (self._triton_precision,)),
+                *((precision,) if use_mixed_precision else ()),
             )
         else:
             raise ValueError(self.backend)

--- a/spikingjelly/activation_based/triton_kernel/neuron_kernel/lif.py
+++ b/spikingjelly/activation_based/triton_kernel/neuron_kernel/lif.py
@@ -790,6 +790,7 @@ def multistep_lif_mp_inference(
     forward_compute_dtype_id: int,
     spike_dtype_id: int,
     save_intermediates: bool,
+    store_v_seq: bool,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     _check_mp_cuda_inputs(x_seq, v_init, "LIF")
     storage_dtype = triton_neuron_dtype_id_to_torch_dtype(storage_dtype_id)
@@ -800,7 +801,11 @@ def multistep_lif_mp_inference(
     x_storage = x_seq.detach().to(dtype=storage_dtype).contiguous()
     v_storage = v_init.detach().to(dtype=storage_dtype).contiguous()
     s_seq = torch.empty(x_seq.shape, dtype=spike_dtype, device=x_seq.device)
-    v_seq = torch.empty(x_seq.shape, dtype=storage_dtype, device=x_seq.device)
+    v_seq = torch.empty(
+        x_seq.shape if store_v_seq else v_init.shape,
+        dtype=storage_dtype,
+        device=x_seq.device,
+    )
     if save_intermediates:
         h_seq = torch.empty(x_seq.shape, dtype=storage_dtype, device=x_seq.device)
         h_buffer = h_seq
@@ -821,7 +826,7 @@ def multistep_lif_mp_inference(
         soft_reset=soft_reset,
         compute_dtype=compute_tl_dtype,
         save_intermediates=save_intermediates,
-        store_v_seq=True,
+        store_v_seq=store_v_seq,
         use_torch_wrap=True,
     )
     return s_seq, v_seq, h_seq
@@ -840,9 +845,9 @@ def _multistep_lif_mp_inference_fake(
     forward_compute_dtype_id: int,
     spike_dtype_id: int,
     save_intermediates: bool,
+    store_v_seq: bool,
 ):
     del (
-        v_init,
         decay_input,
         tau,
         v_threshold,
@@ -855,7 +860,11 @@ def _multistep_lif_mp_inference_fake(
     h_shape = x_seq.shape if save_intermediates else (0,)
     return (
         torch.empty(x_seq.shape, dtype=spike_dtype, device=x_seq.device),
-        torch.empty(x_seq.shape, dtype=storage_dtype, device=x_seq.device),
+        torch.empty(
+            x_seq.shape if store_v_seq else v_init.shape,
+            dtype=storage_dtype,
+            device=x_seq.device,
+        ),
         torch.empty(h_shape, dtype=storage_dtype, device=x_seq.device),
     )
 
@@ -876,6 +885,7 @@ def multistep_lif_mp_forward(
     forward_compute_dtype_id: int,
     backward_compute_dtype_id: int,
     spike_dtype_id: int,
+    store_v_seq: bool,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     del detach_reset, backward_compute_dtype_id
     _check_mp_cuda_inputs(x_seq, v_init, "LIF")
@@ -887,7 +897,11 @@ def multistep_lif_mp_forward(
     x_storage = x_seq.to(dtype=storage_dtype).contiguous()
     v_storage = v_init.to(dtype=storage_dtype).contiguous()
     s_seq = torch.empty(x_seq.shape, dtype=spike_dtype, device=x_seq.device)
-    v_seq = torch.empty(x_seq.shape, dtype=storage_dtype, device=x_seq.device)
+    v_seq = torch.empty(
+        x_seq.shape if store_v_seq else v_init.shape,
+        dtype=storage_dtype,
+        device=x_seq.device,
+    )
     h_seq = torch.empty(x_seq.shape, dtype=storage_dtype, device=x_seq.device)
 
     _launch_lif_forward_kernel(
@@ -903,7 +917,7 @@ def multistep_lif_mp_forward(
         soft_reset=soft_reset,
         compute_dtype=compute_tl_dtype,
         save_intermediates=True,
-        store_v_seq=True,
+        store_v_seq=store_v_seq,
         use_torch_wrap=True,
     )
     return s_seq, v_seq, h_seq
@@ -925,9 +939,9 @@ def _multistep_lif_mp_forward_fake(
     forward_compute_dtype_id: int,
     backward_compute_dtype_id: int,
     spike_dtype_id: int,
+    store_v_seq: bool,
 ):
     del (
-        v_init,
         decay_input,
         tau,
         v_threshold,
@@ -943,7 +957,11 @@ def _multistep_lif_mp_forward_fake(
     spike_dtype = triton_neuron_dtype_id_to_torch_dtype(spike_dtype_id)
     return (
         torch.empty(x_seq.shape, dtype=spike_dtype, device=x_seq.device),
-        torch.empty(x_seq.shape, dtype=storage_dtype, device=x_seq.device),
+        torch.empty(
+            x_seq.shape if store_v_seq else v_init.shape,
+            dtype=storage_dtype,
+            device=x_seq.device,
+        ),
         torch.empty(x_seq.shape, dtype=storage_dtype, device=x_seq.device),
     )
 
@@ -958,6 +976,7 @@ def _multistep_lif_mp_with_plan(
     v_threshold: float,
     v_reset: Optional[float],
     detach_reset: bool = False,
+    store_v_seq: bool = True,
     surrogate_function=None,
 ) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
     if plan.neuron_type != "lif":
@@ -984,6 +1003,7 @@ def _multistep_lif_mp_with_plan(
             plan.forward_compute_dtype_id,
             plan.backward_compute_dtype_id,
             plan.spike_dtype_id,
+            store_v_seq,
         )
         return s_seq, v_seq, (h_seq if plan.save_intermediates else None)
     s_seq, v_seq, h_seq = multistep_lif_mp_inference(
@@ -998,6 +1018,7 @@ def _multistep_lif_mp_with_plan(
         plan.forward_compute_dtype_id,
         plan.spike_dtype_id,
         plan.save_intermediates,
+        store_v_seq,
     )
     return s_seq, v_seq, (h_seq if plan.save_intermediates else None)
 
@@ -1015,6 +1036,7 @@ def _multistep_lif_mp(
     backward_compute_dtype="fp32",
     spike_dtype: torch.dtype = torch.float32,
     save_intermediates: bool = True,
+    store_v_seq: bool = True,
     detach_reset: bool = False,
     surrogate_function=None,
 ) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
@@ -1050,6 +1072,7 @@ def _multistep_lif_mp(
         v_threshold=v_threshold,
         v_reset=v_reset,
         detach_reset=detach_reset,
+        store_v_seq=store_v_seq,
         surrogate_function=surrogate_function,
     )
 
@@ -1070,6 +1093,7 @@ def _setup_mp_lif_context(ctx, inputs, output):
         forward_compute_dtype_id,
         backward_compute_dtype_id,
         spike_dtype_id,
+        store_v_seq,
     ) = inputs
     del forward_compute_dtype_id
     h_seq = output[2]
@@ -1087,6 +1111,7 @@ def _setup_mp_lif_context(ctx, inputs, output):
     ctx.storage_dtype_id = storage_dtype_id
     ctx.backward_compute_dtype_id = backward_compute_dtype_id
     ctx.spike_dtype_id = spike_dtype_id
+    ctx.store_v_seq = store_v_seq
 
 
 def _multistep_lif_mp_backward(ctx, grad_s_seq, grad_v_seq, grad_h_seq):
@@ -1097,7 +1122,11 @@ def _multistep_lif_mp_backward(ctx, grad_s_seq, grad_v_seq, grad_h_seq):
     if grad_s_seq is None:
         grad_s_seq = torch.zeros(h_seq.shape, dtype=spike_dtype, device=h_seq.device)
     if grad_v_seq is None:
-        grad_v_seq = torch.zeros(h_seq.shape, dtype=storage_dtype, device=h_seq.device)
+        grad_v_seq = torch.zeros(
+            h_seq.shape if ctx.store_v_seq else h_seq[0].shape,
+            dtype=storage_dtype,
+            device=h_seq.device,
+        )
     grad_s_seq = grad_s_seq.contiguous()
     grad_v_seq = grad_v_seq.contiguous()
     h_seq = h_seq.contiguous()
@@ -1123,12 +1152,13 @@ def _multistep_lif_mp_backward(ctx, grad_s_seq, grad_v_seq, grad_h_seq):
         decay_input=ctx.decay_input,
         soft_reset=ctx.soft_reset,
         detach_reset=ctx.detach_reset,
-        store_v_seq=True,
+        store_v_seq=ctx.store_v_seq,
         use_torch_wrap=True,
     )
     return (
         grad_x_seq,
         grad_v_init,
+        None,
         None,
         None,
         None,

--- a/spikingjelly/activation_based/triton_kernel/surrogate_kernel.py
+++ b/spikingjelly/activation_based/triton_kernel/surrogate_kernel.py
@@ -59,6 +59,7 @@ def sg_triton(h, alpha, sg_triton_id: tl.constexpr):
 
     Sg Triton function
     """
+    alpha = tl.full([1], alpha, tl.float32)  # Runtime Python floats specialize as fp64.
     if sg_triton_id == 0:  # Sigmoid:  alpha * sigmoid(alpha*h) * (1 - sigmoid(alpha*h))
         sg = tl.sigmoid(h.to(tl.float32) * alpha)
         sg = alpha * sg * (1.0 - sg)

--- a/test/activation_based/test_compile_compat.py
+++ b/test/activation_based/test_compile_compat.py
@@ -168,6 +168,47 @@ def test_compile_inductor_runs_forward_backward(kind):
             del y
 
 
+@pytest.mark.parametrize(
+    ("surrogate_fn", "detach_reset", "v_reset"),
+    [
+        (surrogate.Sigmoid(alpha=4.0), False, 0.0),
+        (surrogate.ATan(alpha=2.0), True, None),
+    ],
+)
+def test_compiled_triton_lif_backward_matches_eager(
+    surrogate_fn, detach_reset, v_reset
+):
+    _require_cuda_triton_compile()
+    torch.manual_seed(20260830)
+    kwargs = {
+        "tau": 2.0,
+        "v_reset": v_reset,
+        "surrogate_function": surrogate_fn,
+        "detach_reset": detach_reset,
+        "step_mode": "m",
+        "backend": "triton",
+    }
+    eager = neuron.LIFNode(**kwargs).cuda().train()
+    compiled_node = neuron.LIFNode(**kwargs).cuda().train()
+    x = torch.randn(7, 2, 20, device="cuda")
+    x_eager = x.clone().requires_grad_()
+    x_compiled = x.clone().requires_grad_()
+
+    eager(x_eager).sum().backward()
+    with _inductor_single_process_compile():
+        compiled = torch.compile(
+            compiled_node,
+            backend="inductor",
+            options={
+                "triton.cudagraphs": False,
+                "triton.cudagraph_trees": False,
+            },
+        )
+        compiled(x_compiled).sum().backward()
+
+    torch.testing.assert_close(x_compiled.grad, x_eager.grad)
+
+
 @pytest.mark.parametrize("kind", ["lif", "if", "plif"])
 def test_inductor_is_not_a_standard_neuron_backend(kind):
     with pytest.raises(NotImplementedError, match="not a supported backend"):

--- a/test/activation_based/test_cuda_graph_runner.py
+++ b/test/activation_based/test_cuda_graph_runner.py
@@ -1,0 +1,90 @@
+import pytest
+import torch
+
+from spikingjelly.activation_based._cuda_graph import StaticCudaGraph
+from spikingjelly.activation_based import functional, neuron
+
+
+def test_static_cuda_graph_requires_warmup():
+    with pytest.raises(ValueError, match="positive"):
+        StaticCudaGraph(lambda x: x, warmup_steps=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_static_cuda_graph_replays_new_inputs_and_falls_back_for_new_shape():
+    runner = StaticCudaGraph(lambda x: (x * 2, x + 1), warmup_steps=1)
+
+    warmup = runner(torch.tensor([1.0, 2.0], device="cuda"))
+    captured = runner(torch.tensor([3.0, 4.0], device="cuda"))
+    captured_value = captured[0].clone()
+    replayed = runner(torch.tensor([5.0, 6.0], device="cuda"))
+    fallback = runner(torch.tensor([[7.0, 8.0]], device="cuda"))
+
+    torch.testing.assert_close(warmup[0], torch.tensor([2.0, 4.0], device="cuda"))
+    torch.testing.assert_close(captured_value, torch.tensor([6.0, 8.0], device="cuda"))
+    torch.testing.assert_close(replayed[0], torch.tensor([10.0, 12.0], device="cuda"))
+    torch.testing.assert_close(fallback[0], torch.tensor([[14.0, 16.0]], device="cuda"))
+    assert runner.stats.warmup_runs == 1
+    assert runner.stats.captures == 1
+    assert runner.stats.replays == 1
+    assert runner.stats.eager_fallbacks == 1
+
+
+def _lif_model() -> torch.nn.Module:
+    return torch.nn.Sequential(
+        torch.nn.Linear(4, 4, bias=False),
+        neuron.LIFNode(tau=2.0, step_mode="m", backend="torch"),
+    ).cuda()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_static_cuda_graph_preserves_lif_reset_semantics():
+    torch.manual_seed(7)
+    eager = _lif_model().eval()
+    captured_model = _lif_model().eval()
+    captured_model.load_state_dict(eager.state_dict())
+    runner = StaticCudaGraph(captured_model, warmup_steps=1)
+
+    for scale in (0.25, 0.5, 1.0):
+        x = torch.randn(3, 2, 4, device="cuda") * scale
+        expected = eager(x).clone()
+        actual = runner(x).clone()
+        functional.reset_net(eager)
+        functional.reset_net(captured_model)
+        torch.testing.assert_close(actual, expected)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_static_cuda_graph_training_matches_eager_parameter_updates():
+    torch.manual_seed(11)
+    eager = _lif_model().train()
+    captured_model = _lif_model().train()
+    captured_model.load_state_dict(eager.state_dict())
+    eager_optimizer = torch.optim.SGD(eager.parameters(), lr=0.1)
+    captured_optimizer = torch.optim.SGD(captured_model.parameters(), lr=0.1)
+
+    def captured_step(x):
+        output = captured_model(x)
+        loss = output.square().mean()
+        loss.backward()
+        return loss, output
+
+    runner = StaticCudaGraph(captured_step, warmup_steps=1)
+    for scale in (0.25, 0.5, 1.0):
+        x = torch.randn(3, 2, 4, device="cuda") * scale
+        eager_optimizer.zero_grad(set_to_none=False)
+        eager_loss = eager(x).square().mean()
+        eager_loss.backward()
+        eager_optimizer.step()
+        functional.reset_net(eager)
+
+        captured_optimizer.zero_grad(set_to_none=False)
+        captured_loss, _ = runner(x)
+        captured_optimizer.step()
+        functional.reset_net(captured_model)
+
+        torch.testing.assert_close(captured_loss, eager_loss)
+        for actual, expected in zip(
+            captured_model.parameters(), eager.parameters(), strict=True
+        ):
+            torch.testing.assert_close(actual, expected)

--- a/test/activation_based/test_distributed_vision.py
+++ b/test/activation_based/test_distributed_vision.py
@@ -12,7 +12,9 @@ import torch.distributed.device_mesh as device_mesh
 import torch.nn as nn
 from torch.utils.data import TensorDataset
 
-from spikingjelly.activation_based import functional, layer
+from spikingjelly.activation_based import base as activation_base
+from spikingjelly.activation_based import functional, layer, neuron
+from spikingjelly.activation_based._cuda_graph import validate_cuda_graph_model
 from spikingjelly.activation_based.distributed import vision
 from spikingjelly.activation_based.distributed.vision import config as vision_config
 from spikingjelly.activation_based.distributed.vision import execution, inference
@@ -223,12 +225,66 @@ def test_vision_predict_returns_no_metrics(monkeypatch, tmp_path):
 
 
 @pytest.mark.parametrize(
+    "model_config",
+    [
+        SEWResNet34Config(image_size=32, num_classes=3, neuron_backend="triton"),
+        SpikformerConfig(
+            image_height=32,
+            image_width=32,
+            num_classes=3,
+            neuron_backend="triton",
+        ),
+    ],
+)
+def test_vision_builder_sets_step_mode_before_triton_backend(monkeypatch, model_config):
+    monkeypatch.setattr(activation_base, "check_backend_library", lambda _backend: None)
+
+    model = model_config.get_builder_cls()(model_config)._build_canonical_model()
+    nodes = [
+        module for module in model.modules() if isinstance(module, neuron.BaseNode)
+    ]
+
+    assert nodes
+    assert all(module.step_mode == "m" for module in nodes)
+    assert all(module.backend == "triton" for module in nodes)
+
+
+@pytest.mark.parametrize(
+    ("attribute", "value", "message"),
+    [("backend", "cupy", "CuPy"), ("store_v_seq", True, "store_v_seq")],
+)
+def test_vision_cuda_graph_rejects_unsafe_model_state(attribute, value, message):
+    model = nn.Sequential(nn.Linear(2, 2), nn.Linear(2, 2))
+    setattr(model[1], attribute, value)
+
+    with pytest.raises(ValueError, match=message):
+        validate_cuda_graph_model(model)
+
+
+@pytest.mark.parametrize(
     ("match", "kwargs"),
     [
         ("batch_size", {"batch_size": 0}),
         ("dataset_builder", {"dataset_builder": "dataset"}),
         ("data_parallel", {"data_parallel": "ddp"}),
-        ("compile", {"compile": True, "pipeline_parallel_size": 2}),
+        ("execution_mode", {"execution_mode": "unknown"}),
+        (
+            "compile",
+            {"execution_mode": "compile", "pipeline_parallel_size": 2},
+        ),
+        (
+            "FSDP2",
+            {"execution_mode": "cuda_graph", "data_parallel": "fsdp2"},
+        ),
+        (
+            "single-rank",
+            {"execution_mode": "cuda_graph", "tensor_parallel_size": 2},
+        ),
+        (
+            "single-rank",
+            {"execution_mode": "cuda_graph", "pipeline_parallel_size": 2},
+        ),
+        ("positive", {"cuda_graph_warmup_steps": 0}),
     ],
 )
 def test_vision_prediction_config_rejects_invalid_values(match, kwargs):
@@ -271,6 +327,24 @@ def test_vision_evaluation_owns_loss_configuration():
         ("loss_function", {"loss_function": "cross_entropy"}),
         ("input_layout", {"input_layout": "NHWC"}),
         ("mixup_alpha", {"mixup_alpha": -0.1}),
+        ("execution_mode", {"execution_mode": "unknown"}),
+        (
+            "FSDP2",
+            {"execution_mode": "cuda_graph", "data_parallel": "fsdp2"},
+        ),
+        (
+            "single-rank",
+            {"execution_mode": "cuda_graph", "tensor_parallel_size": 2},
+        ),
+        (
+            "single-rank",
+            {"execution_mode": "cuda_graph", "pipeline_parallel_size": 2},
+        ),
+        (
+            "memopt",
+            {"execution_mode": "cuda_graph", "memopt_level": 1},
+        ),
+        ("positive", {"cuda_graph_warmup_steps": 0}),
         (
             "step_mode='m'",
             {

--- a/test/activation_based/test_train_classify_execution.py
+++ b/test/activation_based/test_train_classify_execution.py
@@ -1,0 +1,89 @@
+import pytest
+import torch
+
+from spikingjelly.activation_based import neuron
+from spikingjelly.activation_based.examples.common.train_classify import Trainer
+
+
+def test_common_trainer_exposes_mutually_exclusive_execution_mode():
+    args = (
+        Trainer()
+        .get_args_parser()
+        .parse_args(
+            ["--execution-mode", "cuda_graph", "--cuda-graph-warmup-steps", "13"]
+        )
+    )
+
+    assert args.execution_mode == "cuda_graph"
+    assert args.cuda_graph_warmup_steps == 13
+    assert not hasattr(args, "compile")
+
+
+def test_common_trainer_rejects_zero_cuda_graph_warmup():
+    trainer = Trainer()
+    args = trainer.get_args_parser().parse_args(
+        ["--execution-mode", "cuda_graph", "--cuda-graph-warmup-steps", "0"]
+    )
+
+    with pytest.raises(ValueError, match="positive"):
+        trainer.main(args)
+
+
+def test_common_trainer_rejects_cuda_graph_on_cpu():
+    trainer = Trainer()
+    args = trainer.get_args_parser().parse_args(
+        ["--execution-mode", "cuda_graph", "--device", "cpu"]
+    )
+
+    with pytest.raises(ValueError, match="CUDA device"):
+        trainer.main(args)
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        ["--compile-mode", "max-autotune"],
+        ["--compile-backend", "eager"],
+        ["--execution-mode", "cuda_graph", "--compile-eval"],
+    ],
+)
+def test_common_trainer_rejects_compile_options_outside_compile_mode(options):
+    trainer = Trainer()
+    args = trainer.get_args_parser().parse_args(options)
+
+    with pytest.raises(ValueError, match="execution-mode compile"):
+        trainer.main(args)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_common_trainer_captures_forward_and_backward():
+    trainer = Trainer()
+    args = trainer.get_args_parser().parse_args(
+        [
+            "--execution-mode",
+            "cuda_graph",
+            "--cuda-graph-warmup-steps",
+            "1",
+            "--disable-amp",
+            "--disable-pinmemory",
+        ]
+    )
+    args.distributed = False
+    model = torch.nn.Sequential(
+        torch.nn.Linear(4, 5), neuron.LIFNode(step_mode="s", backend="torch")
+    ).cuda()
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+    batches = [(torch.randn(2, 4), torch.tensor([0, 1])) for _ in range(3)]
+
+    trainer.train_one_epoch(
+        model,
+        torch.nn.CrossEntropyLoss(),
+        optimizer,
+        batches,
+        torch.device("cuda"),
+        0,
+        args,
+    )
+
+    assert trainer._cuda_graph_training_step.stats.captures == 1
+    assert trainer._cuda_graph_training_step.stats.replays == 1

--- a/test/activation_based/test_triton_neuron.py
+++ b/test/activation_based/test_triton_neuron.py
@@ -4,6 +4,7 @@ import torch
 import spikingjelly.configure as configure
 from spikingjelly.activation_based import base as activation_base
 from spikingjelly.activation_based import functional, neuron, surrogate
+from spikingjelly.activation_based.functional import neuron as functional_neuron
 from spikingjelly.activation_based.triton_kernel import triton_utils
 from spikingjelly.activation_based.triton_kernel.fp8_capability import (
     supports_triton_fp8_neuron_backward,
@@ -250,6 +251,88 @@ def _mixed_precision_reference(
         v_seq[t] = _quantize_for_storage(v, storage_dtype)
         h_seq[t] = _quantize_for_storage(h, storage_dtype)
     return s_seq, v_seq, h_seq
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_mixed_precision_lif_skips_unrequested_voltage_sequence():
+    torch.manual_seed(7)
+    x = torch.randn(4, 2, 3, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn(2, 3, device="cuda", dtype=torch.bfloat16)
+
+    def run(store_v_seq):
+        x_leaf = x.detach().clone().requires_grad_()
+        v_leaf = v.detach().clone().requires_grad_()
+        spike, voltage, _ = lif_triton_kernel._multistep_lif_mp(
+            x_leaf,
+            v_leaf,
+            decay_input=True,
+            tau=2.0,
+            v_threshold=1.0,
+            v_reset=0.0,
+            storage_dtype=torch.bfloat16,
+            compute_dtype="bf16",
+            backward_compute_dtype="bf16",
+            spike_dtype=torch.bfloat16,
+            save_intermediates=True,
+            store_v_seq=store_v_seq,
+        )
+        final_voltage = voltage[-1] if store_v_seq else voltage
+        (spike.sum() + final_voltage.sum()).backward()
+        return spike, final_voltage, x_leaf.grad, v_leaf.grad, voltage
+
+    full = run(True)
+    final_only = run(False)
+
+    assert final_only[-1].shape == v.shape
+    for expected, actual in zip(full[:-1], final_only[:-1], strict=True):
+        torch.testing.assert_close(actual, expected)
+
+
+def test_lif_native_triton_precision_uses_standard_path(monkeypatch):
+    node = neuron.LIFNode(step_mode="m", backend="torch")
+    node._backend = "triton"
+    node._triton_precision = (torch.bfloat16, "bf16", "bf16")
+    called = False
+
+    def standard_path(x_seq, v, *_args):
+        nonlocal called
+        called = True
+        return x_seq, v, None
+
+    monkeypatch.setattr(functional, "lif_multi_step_triton", standard_path)
+    x = torch.zeros(4, 2, 3, dtype=torch.bfloat16)
+    node.multi_step_functional_forward((x,), (torch.zeros_like(x[0]),))
+
+    assert called
+
+
+def test_lif_mixed_precision_wrapper_forwards_store_v_seq(monkeypatch):
+    received = None
+
+    def mixed_precision(x_seq, v, **kwargs):
+        nonlocal received
+        received = kwargs["store_v_seq"]
+        return x_seq, v, None
+
+    monkeypatch.setattr(lif_triton_kernel, "_multistep_lif_mp", mixed_precision)
+    x = torch.zeros(4, 2, 3)
+    v = torch.zeros_like(x[0])
+    _, final_v, v_seq = functional_neuron._lif_multi_step_triton_mp(
+        x,
+        v,
+        2.0,
+        True,
+        1.0,
+        0.0,
+        surrogate.Sigmoid(),
+        False,
+        False,
+        (torch.float16, "fp32", "fp32"),
+    )
+
+    assert received is False
+    assert final_v.shape == v.shape
+    assert v_seq is None
 
 
 def test_triton_fp8_capability_report_cpu_is_unavailable():


### PR DESCRIPTION
## Summary

- add opt-in manual CUDA Graph execution to Common and single-rank Vision training/inference
- integrate MCore native CUDA Graph lifecycle and keep SGLang graphs disabled until temporal metadata is supported
- add eager/compile/manual-graph benchmark reporting and CUDA Graph design documentation
- set the package version to 2.0.0
- remove a stale FlexSN probe test that asserted the pre-refactor eager kernel-construction lifecycle

## Validation

- `pytest -q test/activation_based`: 1392 passed, 386 skipped
- g3 CUDA regression (Torch 2.7.1, Triton 3.3.1, RTX 4090): 10 passed
- g3 full single-GPU benchmark tests: 20 passed
- Ruff checks passed
- Sphinx HTML build passed
- changelog generation check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional CUDA Graph execution for Common and Vision training, evaluation, prediction, and benchmarking.
  * Added `eager`, `compile`, and `cuda_graph` execution modes with configurable warmup and performance statistics.

* **Bug Fixes**
  * Improved Triton LIF precision and reduced unnecessary voltage-sequence allocation.
  * Fixed surrogate-gradient precision and Triton backend configuration.

* **Breaking Changes**
  * Replaced Vision’s `compile` setting and Common Trainer’s `--compile` option with execution-mode configuration.

* **Documentation**
  * Documented CUDA Graph limitations, fallback behavior, and configuration.

* **Release**
  * Promoted the project version to 2.0.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->