### PR TITLE
Add end-to-end FP8 benchmarks and nsys profiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,8 @@ Module: `spikingjelly.activation_based.precision`.
 - Added `triton_storage`, `triton_fwd`, and `triton_bwd` to `PrecisionConfig` for
   training-time configuration of existing multi-step Triton IF, LIF, and PLIF
   nodes. Sensitive surrogate operations continue to compute locally in FP32.
+- Added `fp8_fallback_dtype` for CUDA operations outside converted Transformer
+  Engine modules; BF16 is the default for numerical range.
 - Transformer Engine conversion leaves Linear and pointwise Conv1d layers whose
   dimensions violate FP8 alignment in high precision and reports them as
   unsupported instead of failing during forward.

--- a/benchmark/benchmark_snn_single_gpu.py
+++ b/benchmark/benchmark_snn_single_gpu.py
@@ -561,9 +561,13 @@ def run_case(args: argparse.Namespace) -> dict[str, Any]:
     model.train(args.phase == "training")
     metadata["precision"] = precision.describe()
     x, target = _make_batch(args, device)
-    coverage_tracker = _FP8CoverageTracker(
-        state_model,
-        metadata["precision"]["conversion_report"],
+    coverage_tracker = (
+        _FP8CoverageTracker(
+            state_model,
+            metadata["precision"]["conversion_report"],
+        )
+        if args.precision == "fp8"
+        else None
     )
     optimizer = (
         torch.optim.SGD(model.parameters(), lr=args.lr, momentum=args.momentum)
@@ -651,8 +655,9 @@ def run_case(args: argparse.Namespace) -> dict[str, Any]:
         step()
         torch.cuda.synchronize(device)
         first_step_wall_ms = (time.perf_counter() - first_started) * 1000.0
-        coverage_tracker.close()
-        metadata["fp8_coverage"] = coverage_tracker.report()
+        if coverage_tracker is not None:
+            coverage_tracker.close()
+            metadata["fp8_coverage"] = coverage_tracker.report()
 
         for _ in range(args.warmup):
             step()
@@ -663,12 +668,18 @@ def run_case(args: argparse.Namespace) -> dict[str, Any]:
         reserved_before = torch.cuda.memory_reserved(device)
         starts = [torch.cuda.Event(enable_timing=True) for _ in range(args.steps)]
         ends = [torch.cuda.Event(enable_timing=True) for _ in range(args.steps)]
-        for index in range(args.steps):
-            starts[index].record()
-            with _nvtx_range(f"benchmark_step:{index}", args.profile):
-                step()
-            ends[index].record()
-        ends[-1].synchronize()
+        if args.profile:
+            torch.cuda.profiler.start()
+        try:
+            for index in range(args.steps):
+                starts[index].record()
+                with _nvtx_range(f"benchmark_step:{index}", args.profile):
+                    step()
+                ends[index].record()
+            ends[-1].synchronize()
+        finally:
+            if args.profile:
+                torch.cuda.profiler.stop()
         samples_ms = [
             start.elapsed_time(end) for start, end in zip(starts, ends, strict=True)
         ]
@@ -687,9 +698,8 @@ def run_case(args: argparse.Namespace) -> dict[str, Any]:
             hooks.close()
             hooks = None
     finally:
-        if args.profile:
-            torch.cuda.profiler.stop()
-        coverage_tracker.close()
+        if coverage_tracker is not None:
+            coverage_tracker.close()
         if hooks is not None:
             hooks.close()
         _stop_monitor(monitor)

--- a/benchmark/benchmark_snn_single_gpu.py
+++ b/benchmark/benchmark_snn_single_gpu.py
@@ -648,8 +648,6 @@ def run_case(args: argparse.Namespace) -> dict[str, Any]:
             pass
 
     try:
-        if args.profile:
-            torch.cuda.profiler.start()
         torch.cuda.synchronize(device)
         first_started = time.perf_counter()
         step()

--- a/benchmark/benchmark_snn_single_gpu.py
+++ b/benchmark/benchmark_snn_single_gpu.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import argparse
-from contextlib import suppress
+from contextlib import contextmanager, suppress
 import json
 import os
 import platform
@@ -16,12 +16,32 @@ from typing import Any
 
 import torch
 
+if __package__:
+    from .fp8_coverage import _FP8CoverageTracker
+else:
+    from fp8_coverage import _FP8CoverageTracker
+from spikingjelly.activation_based.precision import (
+    PrecisionConfig,
+    prepare_model_for_precision,
+)
+
 DEFAULT_T = 4
 DEFAULT_IMAGE_SIZE = 224
 DEFAULT_SEED = 20260808
 MODEL_NAMES = ("spiking_vgg16_bn", "sew_resnet18", "spikformer_ti")
 PHASES = ("inference", "training")
 EXECUTIONS = ("eager", "compile")
+
+
+@contextmanager
+def _nvtx_range(name: str, enabled: bool):
+    if enabled:
+        torch.cuda.nvtx.range_push(name)
+    try:
+        yield
+    finally:
+        if enabled:
+            torch.cuda.nvtx.range_pop()
 
 
 def summarize_samples(samples_ms: list[float]) -> dict[str, float]:
@@ -382,6 +402,7 @@ class _ProfileHooks:
         self.output = output
         self.records: list[dict[str, Any]] = []
         self.handles = []
+        self.metadata_modules: set[str] = set()
         for name, module in model.named_modules():
             if name and any(
                 token in type(module).__name__ for token in self._INTERESTING
@@ -394,27 +415,30 @@ class _ProfileHooks:
     def _pre_hook(self, name: str, module: torch.nn.Module):
         def hook(_module, inputs):
             torch.cuda.nvtx.range_push(f"module:{type(module).__name__}:{name}")
-            self.records.append(
-                {
-                    "event": "input",
-                    "module": name,
-                    "type": type(module).__name__,
-                    "value": _tensor_metadata(inputs),
-                }
-            )
+            if name not in self.metadata_modules:
+                self.records.append(
+                    {
+                        "event": "input",
+                        "module": name,
+                        "type": type(module).__name__,
+                        "value": _tensor_metadata(inputs),
+                    }
+                )
 
         return hook
 
     def _post_hook(self, name: str):
         def hook(module, _inputs, output):
-            self.records.append(
-                {
-                    "event": "output",
-                    "module": name,
-                    "type": type(module).__name__,
-                    "value": _tensor_metadata(output),
-                }
-            )
+            if name not in self.metadata_modules:
+                self.records.append(
+                    {
+                        "event": "output",
+                        "module": name,
+                        "type": type(module).__name__,
+                        "value": _tensor_metadata(output),
+                    }
+                )
+                self.metadata_modules.add(name)
             torch.cuda.nvtx.range_pop()
 
         return hook
@@ -517,10 +541,30 @@ def run_case(args: argparse.Namespace) -> dict[str, Any]:
         )
 
     metadata = _environment_metadata(source_root, device, package_file, gpu_selector)
-    model = _build_model(args.model, "triton", args.T, args.num_classes).to(device)
+    model = _build_model(args.model, args.neuron_backend, args.T, args.num_classes).to(
+        device
+    )
+    precision = prepare_model_for_precision(
+        model,
+        device,
+        PrecisionConfig(
+            mode=args.precision,
+            fp8_recipe=args.fp8_recipe,
+            fp8_fallback_dtype=args.fp8_fallback_dtype,
+            triton_storage=args.triton_storage,
+            triton_fwd=args.triton_fwd,
+            triton_bwd=args.triton_bwd,
+        ),
+    )
+    model = precision.model
     state_model = model
     model.train(args.phase == "training")
+    metadata["precision"] = precision.describe()
     x, target = _make_batch(args, device)
+    coverage_tracker = _FP8CoverageTracker(
+        state_model,
+        metadata["precision"]["conversion_report"],
+    )
     optimizer = (
         torch.optim.SGD(model.parameters(), lr=args.lr, momentum=args.momentum)
         if args.phase == "training"
@@ -533,16 +577,29 @@ def run_case(args: argparse.Namespace) -> dict[str, Any]:
 
     def step() -> torch.Tensor:
         if optimizer is None:
-            with torch.inference_mode():
-                output = model(x)
-            reset_net()
+            with _nvtx_range("forward", args.profile):
+                with torch.inference_mode(), precision.autocast_context():
+                    output = model(x)
+            with _nvtx_range("reset", args.profile):
+                reset_net()
             return output
-        optimizer.zero_grad(set_to_none=True)
-        output = model(x)
-        loss = criterion(output.mean(0), target)
-        loss.backward()
-        optimizer.step()
-        reset_net()
+        with _nvtx_range("zero_grad", args.profile):
+            optimizer.zero_grad(set_to_none=True)
+        with _nvtx_range("forward", args.profile):
+            with precision.autocast_context():
+                output = model(x)
+        with _nvtx_range("loss", args.profile):
+            loss = criterion(output.mean(0), target)
+        with _nvtx_range("backward", args.profile):
+            precision.backward(loss, optimizer, step_optimizer=False)
+        with _nvtx_range("optimizer", args.profile):
+            if precision.scaler is None:
+                optimizer.step()
+            else:
+                precision.scaler.step(optimizer)
+                precision.scaler.update()
+        with _nvtx_range("reset", args.profile):
+            reset_net()
         return loss
 
     dynamo = getattr(torch, "_dynamo", None)
@@ -559,6 +616,8 @@ def run_case(args: argparse.Namespace) -> dict[str, Any]:
         )
 
     hooks = None
+    if args.profile and args.tensor_metadata:
+        hooks = _ProfileHooks(state_model, args.tensor_metadata)
     monitor = None
     if args.monitor_log:
         args.monitor_log.parent.mkdir(parents=True, exist_ok=True)
@@ -585,11 +644,15 @@ def run_case(args: argparse.Namespace) -> dict[str, Any]:
             pass
 
     try:
+        if args.profile:
+            torch.cuda.profiler.start()
         torch.cuda.synchronize(device)
         first_started = time.perf_counter()
         step()
         torch.cuda.synchronize(device)
         first_step_wall_ms = (time.perf_counter() - first_started) * 1000.0
+        coverage_tracker.close()
+        metadata["fp8_coverage"] = coverage_tracker.report()
 
         for _ in range(args.warmup):
             step()
@@ -602,11 +665,8 @@ def run_case(args: argparse.Namespace) -> dict[str, Any]:
         ends = [torch.cuda.Event(enable_timing=True) for _ in range(args.steps)]
         for index in range(args.steps):
             starts[index].record()
-            if args.profile:
-                torch.cuda.nvtx.range_push(f"benchmark_step:{index}")
-            step()
-            if args.profile:
-                torch.cuda.nvtx.range_pop()
+            with _nvtx_range(f"benchmark_step:{index}", args.profile):
+                step()
             ends[index].record()
         ends[-1].synchronize()
         samples_ms = [
@@ -615,15 +675,21 @@ def run_case(args: argparse.Namespace) -> dict[str, Any]:
         peak_allocated_bytes = torch.cuda.max_memory_allocated(device)
         peak_reserved_bytes = torch.cuda.max_memory_reserved(device)
 
-        if args.tensor_metadata:
+        if args.tensor_metadata and hooks is None:
             hooks = _ProfileHooks(state_model, args.tensor_metadata)
-            torch.cuda.nvtx.range_push("layout_metadata_step")
-            step()
-            torch.cuda.nvtx.range_pop()
+            with _nvtx_range("layout_metadata_step", True):
+                step()
+            torch.cuda.synchronize(device)
+            hooks.close()
+            hooks = None
+        if hooks is not None:
             torch.cuda.synchronize(device)
             hooks.close()
             hooks = None
     finally:
+        if args.profile:
+            torch.cuda.profiler.stop()
+        coverage_tracker.close()
         if hooks is not None:
             hooks.close()
         _stop_monitor(monitor)
@@ -637,13 +703,15 @@ def run_case(args: argparse.Namespace) -> dict[str, Any]:
             "model": args.model,
             "phase": args.phase,
             "execution": args.execution,
-            "backend": "triton",
+            "backend": args.neuron_backend,
             "dtype": "float32",
             "T": args.T,
             "batch_size": args.batch_size,
             "image_size": args.image_size,
             "num_classes": args.num_classes,
             "channels_last": args.channels_last,
+            "neuron_backend": args.neuron_backend,
+            "precision": args.precision,
             "warmup": args.warmup,
             "steps": args.steps,
             "seed": args.seed,
@@ -744,6 +812,14 @@ def run_matrix(args: argparse.Namespace) -> dict[str, Any]:
                             str(args.seed),
                             "--device",
                             str(args.device),
+                            "--neuron-backend",
+                            args.neuron_backend,
+                            "--precision",
+                            args.precision,
+                            "--fp8-recipe",
+                            args.fp8_recipe,
+                            "--fp8-fallback-dtype",
+                            args.fp8_fallback_dtype,
                             "--source-label",
                             label,
                             "--round",
@@ -768,6 +844,10 @@ def run_matrix(args: argparse.Namespace) -> dict[str, Any]:
                             command.extend(
                                 ["--require-gpu-name", args.require_gpu_name]
                             )
+                        if args.triton_storage is not None:
+                            command.extend(["--triton-storage", args.triton_storage])
+                        command.extend(["--triton-fwd", args.triton_fwd])
+                        command.extend(["--triton-bwd", args.triton_bwd])
                         env = os.environ.copy()
                         env["SJ_BENCH_SOURCE_ROOT"] = str(source_root)
                         env["PYTHONPATH"] = str(source_root)
@@ -835,6 +915,32 @@ def _add_case_parser(subparsers) -> None:
     parser.add_argument("--num-classes", type=int, default=1000)
     parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
     parser.add_argument("--device", type=int, default=0)
+    parser.add_argument(
+        "--neuron-backend", choices=("torch", "triton"), default="triton"
+    )
+    parser.add_argument(
+        "--precision", choices=("fp32", "fp16", "bf16", "fp8"), default="fp32"
+    )
+    parser.add_argument(
+        "--fp8-recipe",
+        choices=("auto", "delayed", "current", "block", "mxfp8"),
+        default="auto",
+    )
+    parser.add_argument(
+        "--fp8-fallback-dtype",
+        choices=("fp32", "fp16", "bf16"),
+        default="bf16",
+    )
+    parser.add_argument(
+        "--triton-storage",
+        choices=("fp32", "fp16", "bf16", "float8_e4m3fn", "float8_e5m2"),
+    )
+    parser.add_argument(
+        "--triton-fwd", choices=("fp32", "fp16", "bf16", "fp8"), default="fp32"
+    )
+    parser.add_argument(
+        "--triton-bwd", choices=("fp32", "fp16", "bf16", "fp8"), default="fp32"
+    )
     parser.add_argument("--lr", type=float, default=0.1)
     parser.add_argument("--momentum", type=float, default=0.9)
     parser.add_argument("--channels-last", action="store_true")
@@ -875,6 +981,32 @@ def _add_matrix_parser(subparsers) -> None:
     parser.add_argument("--num-classes", type=int, default=1000)
     parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
     parser.add_argument("--device", type=int, default=0)
+    parser.add_argument(
+        "--neuron-backend", choices=("torch", "triton"), default="triton"
+    )
+    parser.add_argument(
+        "--precision", choices=("fp32", "fp16", "bf16", "fp8"), default="fp32"
+    )
+    parser.add_argument(
+        "--fp8-recipe",
+        choices=("auto", "delayed", "current", "block", "mxfp8"),
+        default="auto",
+    )
+    parser.add_argument(
+        "--fp8-fallback-dtype",
+        choices=("fp32", "fp16", "bf16"),
+        default="bf16",
+    )
+    parser.add_argument(
+        "--triton-storage",
+        choices=("fp32", "fp16", "bf16", "float8_e4m3fn", "float8_e5m2"),
+    )
+    parser.add_argument(
+        "--triton-fwd", choices=("fp32", "fp16", "bf16", "fp8"), default="fp32"
+    )
+    parser.add_argument(
+        "--triton-bwd", choices=("fp32", "fp16", "bf16", "fp8"), default="fp32"
+    )
     parser.add_argument("--channels-last", action="store_true")
     parser.add_argument("--require-gpu-name", default="")
     parser.add_argument("--output-dir", type=Path, required=True)

--- a/benchmark/benchmark_train_precision_snn_fc.py
+++ b/benchmark/benchmark_train_precision_snn_fc.py
@@ -574,7 +574,7 @@ def benchmark_one_precision(
         device,
         PrecisionConfig(
             mode=precision,
-            fp8_recipe=args.fp8_recipe,
+            fp8_recipe=args.fp8_recipe if precision == "fp8" else "auto",
             fp8_fallback_dtype=args.fp8_fallback_dtype
             if precision == "fp8"
             else "bf16",
@@ -585,20 +585,22 @@ def benchmark_one_precision(
     )
     model = artifacts.model
     precision_report = artifacts.describe()
-    coverage_tracker = _FP8CoverageTracker(
-        model,
-        precision_report["conversion_report"],
-    )
-    model.eval()
-    try:
-        functional.reset_net(model)
-        with torch.inference_mode(), artifacts.autocast_context():
-            model(x_seq)
-    finally:
-        coverage_tracker.close()
-        functional.reset_net(model)
-        model.train()
-    coverage_report = coverage_tracker.report()
+    coverage_report = {}
+    if precision == "fp8":
+        coverage_tracker = _FP8CoverageTracker(
+            model,
+            precision_report["conversion_report"],
+        )
+        model.eval()
+        try:
+            functional.reset_net(model)
+            with torch.inference_mode(), artifacts.autocast_context():
+                model(x_seq)
+        finally:
+            coverage_tracker.close()
+            functional.reset_net(model)
+            model.train()
+        coverage_report = coverage_tracker.report()
     optimizer = torch.optim.SGD(
         model.parameters(),
         lr=args.lr,
@@ -666,12 +668,18 @@ def benchmark_one_precision(
             model.eval()
             if profile_hooks is not None:
                 profile_hooks.active = False
-            for _ in range(args.warmup):
-                run_inference_step(model, artifacts, x_seq, device)
-            sync_if_needed(device)
-            if device.type == "cuda":
-                torch.cuda.empty_cache()
-                torch.cuda.reset_peak_memory_stats(device)
+            if profile_enabled:
+                torch.cuda.profiler.stop()
+            try:
+                for _ in range(args.warmup):
+                    run_inference_step(model, artifacts, x_seq, device)
+                sync_if_needed(device)
+                if device.type == "cuda":
+                    torch.cuda.empty_cache()
+                    torch.cuda.reset_peak_memory_stats(device)
+            finally:
+                if profile_enabled:
+                    torch.cuda.profiler.start()
 
             if profile_hooks is not None:
                 profile_hooks.active = True

--- a/benchmark/benchmark_train_precision_snn_fc.py
+++ b/benchmark/benchmark_train_precision_snn_fc.py
@@ -1,13 +1,19 @@
 import argparse
+from contextlib import contextmanager
 import json
 import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
+from typing import Any, Iterator
 
 import torch
 import torch.nn as torch_nn
 import torch.nn.functional as F
 
+if __package__:
+    from .fp8_coverage import _FP8CoverageTracker
+else:
+    from fp8_coverage import _FP8CoverageTracker
 from spikingjelly.activation_based import functional, layer, neuron, surrogate
 from spikingjelly.activation_based.precision import (
     PrecisionArtifacts,
@@ -36,6 +42,133 @@ class BenchResult:
     inference_peak_allocated_mb: float
     inference_peak_reserved_mb: float
     conversion_report: dict
+    precision_report: dict
+    coverage_report: dict
+
+
+def _tensor_metadata(value: Any) -> Any:
+    if torch.is_tensor(value):
+        return {
+            "shape": list(value.shape),
+            "dtype": str(value.dtype),
+            "device": str(value.device),
+            "stride": list(value.stride()),
+            "contiguous": value.is_contiguous(),
+            "bytes": value.numel() * value.element_size(),
+        }
+    if isinstance(value, (tuple, list)):
+        return [_tensor_metadata(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _tensor_metadata(item) for key, item in value.items()}
+    return type(value).__name__
+
+
+@contextmanager
+def _nvtx_range(name: str, enabled: bool) -> Iterator[None]:
+    if enabled:
+        torch.cuda.nvtx.range_push(name)
+    try:
+        yield
+    finally:
+        if enabled:
+            torch.cuda.nvtx.range_pop()
+
+
+@contextmanager
+def _cuda_profiler_capture(enabled: bool) -> Iterator[None]:
+    if enabled:
+        torch.cuda.profiler.start()
+    try:
+        yield
+    finally:
+        if enabled:
+            torch.cuda.profiler.stop()
+
+
+class _ProfileHooks:
+    def __init__(self, model: torch_nn.Module, output: Path):
+        self.output = output
+        self.records: list[dict[str, Any]] = []
+        self.handles = []
+        self.active = False
+        self.metadata_modules: set[str] = set()
+        self.open_ranges = 0
+
+        for name, module in model.net.named_children():
+            self.handles.append(
+                module.register_forward_pre_hook(self._forward_pre(name, module))
+            )
+            self.handles.append(
+                module.register_forward_hook(self._forward_post(name), always_call=True)
+            )
+            self.handles.append(
+                module.register_full_backward_pre_hook(self._backward_pre(name, module))
+            )
+            self.handles.append(
+                module.register_full_backward_hook(self._backward_post())
+            )
+
+    def _push(self, name: str) -> None:
+        torch.cuda.nvtx.range_push(name)
+        self.open_ranges += 1
+
+    def _pop(self) -> None:
+        torch.cuda.nvtx.range_pop()
+        self.open_ranges -= 1
+
+    def _record(
+        self, event: str, name: str, module: torch_nn.Module, value: Any
+    ) -> None:
+        if not self.active:
+            return
+        record = {"event": event, "module": name, "type": type(module).__name__}
+        if name not in self.metadata_modules:
+            record["value"] = _tensor_metadata(value)
+            self.records.append(record)
+            if event == "forward_output":
+                self.metadata_modules.add(name)
+
+    def _forward_pre(self, name: str, module: torch_nn.Module):
+        def hook(_module: torch_nn.Module, inputs: tuple[Any, ...]) -> None:
+            if self.active:
+                self._push(f"module_forward:{name}:{type(module).__name__}")
+                self._record("forward_input", name, module, inputs)
+
+        return hook
+
+    def _forward_post(self, name: str):
+        def hook(module: torch_nn.Module, _inputs: Any, output: Any) -> None:
+            if self.active:
+                self._record("forward_output", name, module, output)
+                self._pop()
+
+        return hook
+
+    def _backward_pre(self, name: str, module: torch_nn.Module):
+        def hook(_module: torch_nn.Module, _grad_output: tuple[Any, ...]) -> None:
+            if self.active:
+                self._push(f"module_backward:{name}:{type(module).__name__}")
+
+        return hook
+
+    def _backward_post(self):
+        def hook(_module: torch_nn.Module, _grad_input: Any, _grad_output: Any) -> None:
+            if self.active:
+                self._pop()
+
+        return hook
+
+    def close(self) -> None:
+        for handle in self.handles:
+            handle.remove()
+        self.handles.clear()
+        while self.open_ranges:
+            torch.cuda.nvtx.range_pop()
+            self.open_ranges -= 1
+        self.output.parent.mkdir(parents=True, exist_ok=True)
+        with self.output.open("w", encoding="utf-8") as file:
+            for record in self.records:
+                file.write(json.dumps(record) + "\n")
 
 
 class TemporalSelfAttentionBlock(torch_nn.Module):
@@ -150,6 +283,58 @@ def parse_args() -> argparse.Namespace:
         help="Precision modes to benchmark.",
     )
     parser.add_argument(
+        "--fp8-recipe",
+        choices=("auto", "delayed", "current", "block", "mxfp8"),
+        default="auto",
+        help="Transformer Engine FP8 scaling recipe.",
+    )
+    parser.add_argument(
+        "--fp8-fallback-dtype",
+        choices=("fp32", "fp16", "bf16"),
+        default="bf16",
+        help="Autocast dtype for non-TE CUDA operations in FP8 runs.",
+    )
+    parser.add_argument(
+        "--triton-storage",
+        choices=("none", "fp32", "fp16", "bf16", "float8_e4m3fn", "float8_e5m2"),
+        default="none",
+        help="Optional Triton neuron state storage dtype.",
+    )
+    parser.add_argument(
+        "--triton-fwd",
+        choices=("fp8", "fp16", "bf16", "fp32"),
+        default="fp32",
+        help="Triton neuron forward compute dtype.",
+    )
+    parser.add_argument(
+        "--triton-bwd",
+        choices=("fp8", "fp16", "bf16", "fp32"),
+        default="fp32",
+        help="Triton neuron backward compute dtype.",
+    )
+    parser.add_argument(
+        "--profile",
+        action="store_true",
+        help="Capture bounded NVTX/CUDA-profiler ranges for one precision.",
+    )
+    parser.add_argument(
+        "--profile-module-hooks",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Add per-module forward/backward NVTX ranges during profiling.",
+    )
+    parser.add_argument(
+        "--profile-steps",
+        type=int,
+        default=10,
+        help="Number of training and inference steps inside a profile capture.",
+    )
+    parser.add_argument(
+        "--tensor-metadata-output",
+        type=Path,
+        help="Optional JSONL path for first-step module tensor metadata.",
+    )
+    parser.add_argument(
         "--json", action="store_true", help="Print the full benchmark report as JSON."
     )
     parser.add_argument(
@@ -203,6 +388,17 @@ def build_model(args: argparse.Namespace) -> DeepFCSNN:
     )
 
 
+def validate_profile_args(args: argparse.Namespace) -> None:
+    if not args.profile:
+        return
+    if args.profile_steps <= 0:
+        raise ValueError("profile_steps must be positive when profiling is enabled.")
+    if len(args.precisions) != 1:
+        raise ValueError("profile mode requires exactly one precision.")
+    if args.output is None:
+        raise ValueError("profile mode requires --output for the benchmark JSON.")
+
+
 def validate_precision_shape_constraints(args: argparse.Namespace) -> None:
     constrained_dims = {
         "input_dim": args.input_dim,
@@ -248,58 +444,75 @@ def run_training_step(
     x_seq: torch.Tensor,
     target: torch.Tensor,
     device: torch.device,
+    nvtx_step: str | None = None,
 ) -> dict[str, float]:
-    functional.reset_net(model)
-    optimizer.zero_grad(set_to_none=True)
+    profile = nvtx_step is not None
+    with _nvtx_range(nvtx_step or "", profile):
+        with _nvtx_range("reset", profile):
+            functional.reset_net(model)
+        with _nvtx_range("zero_grad", profile):
+            optimizer.zero_grad(set_to_none=True)
 
-    cuda_events = make_timing_events(device)
-    if cuda_events is not None:
-        cuda_events["step_start"].record()
-        cuda_events["forward_start"].record()
-        with artifacts.autocast_context():
-            logits = model(x_seq)
-            loss = criterion(logits, target)
-        cuda_events["forward_end"].record()
-        cuda_events["backward_start"].record()
-        artifacts.backward(loss, optimizer, step_optimizer=False)
-        cuda_events["backward_end"].record()
-        cuda_events["optimizer_start"].record()
-        _step_optimizer(artifacts, optimizer)
-        cuda_events["optimizer_end"].record()
-        cuda_events["step_end"].record()
-        sync_if_needed(device)
+        cuda_events = make_timing_events(device)
+        if cuda_events is not None:
+            cuda_events["step_start"].record()
+            cuda_events["forward_start"].record()
+            with _nvtx_range("forward", profile):
+                with artifacts.autocast_context():
+                    logits = model(x_seq)
+            with _nvtx_range("loss", profile):
+                loss = criterion(logits, target)
+            cuda_events["forward_end"].record()
+            cuda_events["backward_start"].record()
+            with _nvtx_range("backward", profile):
+                artifacts.backward(loss, optimizer, step_optimizer=False)
+            cuda_events["backward_end"].record()
+            cuda_events["optimizer_start"].record()
+            with _nvtx_range("optimizer", profile):
+                _step_optimizer(artifacts, optimizer)
+            cuda_events["optimizer_end"].record()
+            cuda_events["step_end"].record()
+            sync_if_needed(device)
+            return {
+                "forward_ms": _event_elapsed_ms(
+                    cuda_events["forward_start"], cuda_events["forward_end"]
+                ),
+                "backward_ms": _event_elapsed_ms(
+                    cuda_events["backward_start"], cuda_events["backward_end"]
+                ),
+                "optimizer_ms": _event_elapsed_ms(
+                    cuda_events["optimizer_start"], cuda_events["optimizer_end"]
+                ),
+                "total_step_ms": _event_elapsed_ms(
+                    cuda_events["step_start"], cuda_events["step_end"]
+                ),
+            }
+
+        def forward_section():
+            with _nvtx_range("forward", profile):
+                with artifacts.autocast_context():
+                    logits = model(x_seq)
+            with _nvtx_range("loss", profile):
+                return logits, criterion(logits, target)
+
+        def backward_section() -> None:
+            with _nvtx_range("backward", profile):
+                artifacts.backward(loss, optimizer, step_optimizer=False)
+
+        def optimizer_section() -> None:
+            with _nvtx_range("optimizer", profile):
+                _step_optimizer(artifacts, optimizer)
+
+        forward_ms, (_, loss) = _time_cpu_section(forward_section)
+
+        backward_ms, _ = _time_cpu_section(backward_section)
+        optimizer_ms, _ = _time_cpu_section(optimizer_section)
         return {
-            "forward_ms": _event_elapsed_ms(
-                cuda_events["forward_start"], cuda_events["forward_end"]
-            ),
-            "backward_ms": _event_elapsed_ms(
-                cuda_events["backward_start"], cuda_events["backward_end"]
-            ),
-            "optimizer_ms": _event_elapsed_ms(
-                cuda_events["optimizer_start"], cuda_events["optimizer_end"]
-            ),
-            "total_step_ms": _event_elapsed_ms(
-                cuda_events["step_start"], cuda_events["step_end"]
-            ),
+            "forward_ms": forward_ms,
+            "backward_ms": backward_ms,
+            "optimizer_ms": optimizer_ms,
+            "total_step_ms": forward_ms + backward_ms + optimizer_ms,
         }
-
-    def forward_section():
-        with artifacts.autocast_context():
-            logits = model(x_seq)
-            return logits, criterion(logits, target)
-
-    forward_ms, (logits, loss) = _time_cpu_section(forward_section)
-    backward_ms, _ = _time_cpu_section(
-        lambda: artifacts.backward(loss, optimizer, step_optimizer=False)
-    )
-    optimizer_ms, _ = _time_cpu_section(lambda: _step_optimizer(artifacts, optimizer))
-    _ = logits
-    return {
-        "forward_ms": forward_ms,
-        "backward_ms": backward_ms,
-        "optimizer_ms": optimizer_ms,
-        "total_step_ms": forward_ms + backward_ms + optimizer_ms,
-    }
 
 
 def run_inference_step(
@@ -307,28 +520,35 @@ def run_inference_step(
     artifacts: PrecisionArtifacts,
     x_seq: torch.Tensor,
     device: torch.device,
+    nvtx_step: str | None = None,
 ) -> float:
-    functional.reset_net(model)
-    if device.type == "cuda":
-        start = torch.cuda.Event(enable_timing=True)
-        end = torch.cuda.Event(enable_timing=True)
-        start.record()
-        with torch.inference_mode(), artifacts.autocast_context():
-            output = model(x_seq)
-        end.record()
-        sync_if_needed(device)
+    profile = nvtx_step is not None
+    with _nvtx_range(nvtx_step or "", profile):
+        with _nvtx_range("reset", profile):
+            functional.reset_net(model)
+
+        if device.type == "cuda":
+            start = torch.cuda.Event(enable_timing=True)
+            end = torch.cuda.Event(enable_timing=True)
+            start.record()
+            with _nvtx_range("forward", profile):
+                with torch.inference_mode(), artifacts.autocast_context():
+                    output = model(x_seq)
+            end.record()
+            sync_if_needed(device)
+            if not torch.isfinite(output).all():
+                raise RuntimeError("Inference produced non-finite output.")
+            return _event_elapsed_ms(start, end)
+
+        def forward_section():
+            with _nvtx_range("forward", profile):
+                with torch.inference_mode(), artifacts.autocast_context():
+                    return model(x_seq)
+
+        inference_ms, output = _time_cpu_section(forward_section)
         if not torch.isfinite(output).all():
             raise RuntimeError("Inference produced non-finite output.")
-        return _event_elapsed_ms(start, end)
-
-    def forward_section():
-        with torch.inference_mode(), artifacts.autocast_context():
-            return model(x_seq)
-
-    inference_ms, output = _time_cpu_section(forward_section)
-    if not torch.isfinite(output).all():
-        raise RuntimeError("Inference produced non-finite output.")
-    return inference_ms
+        return inference_ms
 
 
 def benchmark_one_precision(
@@ -339,16 +559,46 @@ def benchmark_one_precision(
     target: torch.Tensor,
     device: torch.device,
 ) -> BenchResult:
+    profile_enabled = args.profile
+    training_steps = args.profile_steps if profile_enabled else args.steps
+    inference_steps = args.profile_steps if profile_enabled else args.inference_steps
     model = build_model(args).to(device)
     model.load_state_dict(model_state, strict=True)
     model.train()
 
+    triton_storage = args.triton_storage
+    if triton_storage == "none":
+        triton_storage = None
     artifacts = prepare_model_for_precision(
         model,
         device,
-        PrecisionConfig(mode=precision),
+        PrecisionConfig(
+            mode=precision,
+            fp8_recipe=args.fp8_recipe,
+            fp8_fallback_dtype=args.fp8_fallback_dtype
+            if precision == "fp8"
+            else "bf16",
+            triton_storage=triton_storage,
+            triton_fwd=args.triton_fwd,
+            triton_bwd=args.triton_bwd,
+        ),
     )
     model = artifacts.model
+    precision_report = artifacts.describe()
+    coverage_tracker = _FP8CoverageTracker(
+        model,
+        precision_report["conversion_report"],
+    )
+    model.eval()
+    try:
+        functional.reset_net(model)
+        with torch.inference_mode(), artifacts.autocast_context():
+            model(x_seq)
+    finally:
+        coverage_tracker.close()
+        functional.reset_net(model)
+        model.train()
+    coverage_report = coverage_tracker.report()
     optimizer = torch.optim.SGD(
         model.parameters(),
         lr=args.lr,
@@ -364,74 +614,114 @@ def benchmark_one_precision(
         torch.cuda.empty_cache()
         torch.cuda.reset_peak_memory_stats(device)
 
+    profile_hooks = None
+    if profile_enabled and args.profile_module_hooks:
+        metadata_output = args.tensor_metadata_output
+        if metadata_output is None:
+            metadata_output = Path(f"{args.output}.tensors.jsonl")
+        profile_hooks = _ProfileHooks(model, metadata_output)
+
     forward_ms = 0.0
     backward_ms = 0.0
     optimizer_ms = 0.0
     total_step_ms = 0.0
-    wall_start = time.perf_counter()
-    for _ in range(args.steps):
-        step_metrics = run_training_step(
-            model, artifacts, optimizer, criterion, x_seq, target, device
-        )
-        forward_ms += step_metrics["forward_ms"]
-        backward_ms += step_metrics["backward_ms"]
-        optimizer_ms += step_metrics["optimizer_ms"]
-        total_step_ms += step_metrics["total_step_ms"]
-    sync_if_needed(device)
-    wall_elapsed = time.perf_counter() - wall_start
-
     peak_allocated_mb = float("nan")
     peak_reserved_mb = float("nan")
-    if device.type == "cuda":
-        peak_allocated_mb = torch.cuda.max_memory_allocated(device) / 1024 / 1024
-        peak_reserved_mb = torch.cuda.max_memory_reserved(device) / 1024 / 1024
-
-    optimizer.zero_grad(set_to_none=True)
-    optimizer.state.clear()
-    artifacts.scaler = None
-    model.eval()
-    for _ in range(args.warmup):
-        run_inference_step(model, artifacts, x_seq, device)
-    sync_if_needed(device)
-    if device.type == "cuda":
-        torch.cuda.empty_cache()
-        torch.cuda.reset_peak_memory_stats(device)
-
     inference_ms = 0.0
-    inference_wall_start = time.perf_counter()
-    for _ in range(args.inference_steps):
-        inference_ms += run_inference_step(model, artifacts, x_seq, device)
-    sync_if_needed(device)
-    inference_wall_elapsed = time.perf_counter() - inference_wall_start
-
     inference_peak_allocated_mb = float("nan")
     inference_peak_reserved_mb = float("nan")
-    if device.type == "cuda":
-        inference_peak_allocated_mb = (
-            torch.cuda.max_memory_allocated(device) / 1024 / 1024
-        )
-        inference_peak_reserved_mb = (
-            torch.cuda.max_memory_reserved(device) / 1024 / 1024
-        )
+    try:
+        with _cuda_profiler_capture(profile_enabled):
+            if profile_hooks is not None:
+                profile_hooks.active = True
+            wall_start = time.perf_counter()
+            for index in range(training_steps):
+                step_metrics = run_training_step(
+                    model,
+                    artifacts,
+                    optimizer,
+                    criterion,
+                    x_seq,
+                    target,
+                    device,
+                    nvtx_step=f"benchmark_step:training:{index}"
+                    if profile_enabled
+                    else None,
+                )
+                forward_ms += step_metrics["forward_ms"]
+                backward_ms += step_metrics["backward_ms"]
+                optimizer_ms += step_metrics["optimizer_ms"]
+                total_step_ms += step_metrics["total_step_ms"]
+            sync_if_needed(device)
+            wall_elapsed = time.perf_counter() - wall_start
+
+            if device.type == "cuda":
+                peak_allocated_mb = (
+                    torch.cuda.max_memory_allocated(device) / 1024 / 1024
+                )
+                peak_reserved_mb = torch.cuda.max_memory_reserved(device) / 1024 / 1024
+
+            optimizer.zero_grad(set_to_none=True)
+            optimizer.state.clear()
+            model.eval()
+            if profile_hooks is not None:
+                profile_hooks.active = False
+            for _ in range(args.warmup):
+                run_inference_step(model, artifacts, x_seq, device)
+            sync_if_needed(device)
+            if device.type == "cuda":
+                torch.cuda.empty_cache()
+                torch.cuda.reset_peak_memory_stats(device)
+
+            if profile_hooks is not None:
+                profile_hooks.active = True
+            inference_wall_start = time.perf_counter()
+            for index in range(inference_steps):
+                inference_ms += run_inference_step(
+                    model,
+                    artifacts,
+                    x_seq,
+                    device,
+                    nvtx_step=f"benchmark_step:inference:{index}"
+                    if profile_enabled
+                    else None,
+                )
+            sync_if_needed(device)
+            inference_wall_elapsed = time.perf_counter() - inference_wall_start
+            if profile_hooks is not None:
+                profile_hooks.active = False
+
+            if device.type == "cuda":
+                inference_peak_allocated_mb = (
+                    torch.cuda.max_memory_allocated(device) / 1024 / 1024
+                )
+                inference_peak_reserved_mb = (
+                    torch.cuda.max_memory_reserved(device) / 1024 / 1024
+                )
+    finally:
+        if profile_hooks is not None:
+            profile_hooks.close()
 
     return BenchResult(
         precision=precision,
         batch_size=args.batch_size,
-        steps=args.steps,
+        steps=training_steps,
         warmup=args.warmup,
-        forward_ms=forward_ms / args.steps,
-        backward_ms=backward_ms / args.steps,
-        optimizer_ms=optimizer_ms / args.steps,
-        total_step_ms=total_step_ms / args.steps,
-        samples_per_sec=(args.batch_size * args.steps) / wall_elapsed,
+        forward_ms=forward_ms / training_steps,
+        backward_ms=backward_ms / training_steps,
+        optimizer_ms=optimizer_ms / training_steps,
+        total_step_ms=total_step_ms / training_steps,
+        samples_per_sec=(args.batch_size * training_steps) / wall_elapsed,
         peak_allocated_mb=peak_allocated_mb,
         peak_reserved_mb=peak_reserved_mb,
-        inference_ms=inference_ms / args.inference_steps,
-        inference_samples_per_sec=(args.batch_size * args.inference_steps)
+        inference_ms=inference_ms / inference_steps,
+        inference_samples_per_sec=(args.batch_size * inference_steps)
         / inference_wall_elapsed,
         inference_peak_allocated_mb=inference_peak_allocated_mb,
         inference_peak_reserved_mb=inference_peak_reserved_mb,
-        conversion_report=artifacts.describe()["conversion_report"],
+        conversion_report=precision_report["conversion_report"],
+        precision_report=precision_report,
+        coverage_report=coverage_report,
     )
 
 
@@ -459,6 +749,7 @@ def print_table(results: list[BenchResult]) -> None:
 
 def main() -> None:
     args = parse_args()
+    validate_profile_args(args)
     device = torch.device(args.device)
 
     if device.type != "cuda":
@@ -507,6 +798,14 @@ def main() -> None:
         "steps": args.steps,
         "inference_steps": args.inference_steps,
         "backend": args.backend,
+        "fp8_recipe": args.fp8_recipe,
+        "fp8_fallback_dtype": args.fp8_fallback_dtype,
+        "triton_storage": args.triton_storage,
+        "triton_fwd": args.triton_fwd,
+        "triton_bwd": args.triton_bwd,
+        "profile": args.profile,
+        "profile_steps": args.profile_steps,
+        "profile_module_hooks": args.profile_module_hooks,
         "results": [asdict(result) for result in results],
     }
     if args.output is not None:

--- a/benchmark/fp8_coverage.py
+++ b/benchmark/fp8_coverage.py
@@ -10,6 +10,10 @@ from spikingjelly.activation_based.precision.float8_base import Float8LinearStep
 from spikingjelly.activation_based.precision.float8_conv import (
     Float8PointwiseConv1dStepModule,
 )
+from spikingjelly.activation_based.precision.float8_te import (
+    Float8TELayerNormLinearModule,
+    Float8TELayerNormMLPModule,
+)
 
 
 def _first_tensor(value: Any) -> torch.Tensor | None:
@@ -32,6 +36,14 @@ def _module_macs(module: nn.Module, output: Any) -> int:
     output_tensor = _first_tensor(output)
     if output_tensor is None:
         return 0
+    if isinstance(module, Float8TELayerNormLinearModule):
+        weight = module.wrapped.weight
+        return output_tensor.numel() * weight.shape[1]
+    if isinstance(module, Float8TELayerNormMLPModule):
+        fc1_weight = getattr(module.wrapped, module._state_key_map["1.weight"])
+        fc2_weight = getattr(module.wrapped, module._state_key_map["3.weight"])
+        tokens = output_tensor.numel() // fc2_weight.shape[0]
+        return tokens * (fc1_weight.numel() + fc2_weight.numel())
     if isinstance(module, (nn.Linear, Float8LinearStepModule)):
         return output_tensor.numel() * module.in_features
     if isinstance(module, Float8PointwiseConv1dStepModule):
@@ -65,6 +77,8 @@ class _FP8CoverageTracker:
             nn.Conv2d,
             Float8LinearStepModule,
             Float8PointwiseConv1dStepModule,
+            Float8TELayerNormLinearModule,
+            Float8TELayerNormMLPModule,
         )
         for name, module in model.named_modules():
             if any(name.startswith(prefix + ".") for prefix in selected_prefixes):

--- a/benchmark/fp8_coverage.py
+++ b/benchmark/fp8_coverage.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from spikingjelly.activation_based.precision.float8_base import Float8LinearStepModule
+from spikingjelly.activation_based.precision.float8_conv import (
+    Float8PointwiseConv1dStepModule,
+)
+
+
+def _first_tensor(value: Any) -> torch.Tensor | None:
+    if torch.is_tensor(value):
+        return value
+    if isinstance(value, (tuple, list)):
+        for item in value:
+            tensor = _first_tensor(item)
+            if tensor is not None:
+                return tensor
+    if isinstance(value, dict):
+        for item in value.values():
+            tensor = _first_tensor(item)
+            if tensor is not None:
+                return tensor
+    return None
+
+
+def _module_macs(module: nn.Module, output: Any) -> int:
+    output_tensor = _first_tensor(output)
+    if output_tensor is None:
+        return 0
+    if isinstance(module, (nn.Linear, Float8LinearStepModule)):
+        return output_tensor.numel() * module.in_features
+    if isinstance(module, Float8PointwiseConv1dStepModule):
+        return output_tensor.numel() * module.in_channels
+    if isinstance(module, (nn.Conv1d, nn.Conv2d)):
+        kernel_elements = math.prod(module.kernel_size)
+        return (
+            output_tensor.numel()
+            * (module.in_channels // module.groups)
+            * kernel_elements
+        )
+    return 0
+
+
+class _FP8CoverageTracker:
+    def __init__(
+        self,
+        model: nn.Module,
+        conversion_report: dict,
+    ) -> None:
+        converted = {
+            "" if name == "<root>" else name
+            for name in conversion_report.get("converted_modules", ())
+        }
+        self._records: dict[str, dict[str, Any]] = {}
+        self._handles = []
+        selected_prefixes: list[str] = []
+        types = (
+            nn.Linear,
+            nn.Conv1d,
+            nn.Conv2d,
+            Float8LinearStepModule,
+            Float8PointwiseConv1dStepModule,
+        )
+        for name, module in model.named_modules():
+            if any(name.startswith(prefix + ".") for prefix in selected_prefixes):
+                continue
+            if not isinstance(module, types):
+                continue
+            selected_prefixes.append(name)
+            requested_fp8 = name in converted
+            self._records[name] = {
+                "name": name or "<root>",
+                "type": type(module).__name__,
+                "requested_fp8": requested_fp8,
+                "calls": 0,
+                "macs": 0,
+            }
+            self._handles.append(
+                module.register_forward_hook(self._hook(name), always_call=True)
+            )
+
+    def _hook(self, name: str):
+        def hook(module: nn.Module, _inputs: tuple[Any, ...], output: Any) -> None:
+            record = self._records[name]
+            record["calls"] += 1
+            record["macs"] += _module_macs(module, output)
+
+        return hook
+
+    def close(self) -> None:
+        for handle in self._handles:
+            handle.remove()
+        self._handles.clear()
+
+    def report(self) -> dict[str, Any]:
+        executed = [record for record in self._records.values() if record["calls"]]
+        total_macs = sum(record["macs"] for record in executed)
+        fp8_macs = sum(record["macs"] for record in executed if record["requested_fp8"])
+        return {
+            "executed_module_count": len(executed),
+            "requested_fp8_module_count": sum(
+                record["requested_fp8"] for record in executed
+            ),
+            "total_dense_macs": total_macs,
+            "requested_fp8_dense_macs": fp8_macs,
+            "requested_fp8_dense_mac_coverage": (
+                fp8_macs / total_macs if total_macs else 0.0
+            ),
+            "modules": executed,
+        }

--- a/benchmark/test/test_fp8_benchmark.py
+++ b/benchmark/test/test_fp8_benchmark.py
@@ -21,6 +21,10 @@ from benchmark.fp8_efficiency import (
 )
 from benchmark.fp8_coverage import _FP8CoverageTracker
 from spikingjelly.activation_based.precision.float8_base import Float8LinearStepModule
+from spikingjelly.activation_based.precision.float8_te import (
+    Float8TELayerNormLinearModule,
+    Float8TELayerNormMLPModule,
+)
 
 
 def _patch_cuda_timing(monkeypatch):
@@ -97,6 +101,49 @@ def test_coverage_tracker_weights_executed_dense_macs():
     assert report["requested_fp8_module_count"] == 1
     assert report["total_dense_macs"] == 2 * 4 * 8 * 8 * 3 * 3 * 3 + 2 * 8 * 4
     assert report["requested_fp8_dense_macs"] == 2 * 8 * 4
+
+
+def test_coverage_tracker_counts_fused_transformer_engine_modules():
+    class FusedMLP(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.fc1_weight = torch.nn.Parameter(torch.randn(8, 4))
+            self.fc2_weight = torch.nn.Parameter(torch.randn(4, 8))
+
+        def forward(self, x):
+            x = torch.nn.functional.linear(x, self.fc1_weight)
+            x = torch.nn.functional.gelu(x)
+            return torch.nn.functional.linear(x, self.fc2_weight)
+
+    class Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = Float8TELayerNormLinearModule(
+                torch.nn.Linear(4, 8, bias=False),
+                {"1.weight": "weight"},
+            )
+            self.mlp = Float8TELayerNormMLPModule(
+                FusedMLP(),
+                {"1.weight": "fc1_weight", "3.weight": "fc2_weight"},
+            )
+
+        def forward(self, x):
+            return self.linear(x), self.mlp(x)
+
+    model = Model()
+    tracker = _FP8CoverageTracker(
+        model,
+        {"converted_modules": ["linear", "mlp"]},
+    )
+    try:
+        model(torch.randn(2, 4))
+    finally:
+        tracker.close()
+
+    report = tracker.report()
+
+    assert report["requested_fp8_dense_macs"] == 2 * 4 * 8 + 2 * (8 * 4 + 4 * 8)
+    assert report["requested_fp8_dense_mac_coverage"] == 1.0
 
 
 def test_model_benchmark_timing_uses_requested_cuda_device(monkeypatch):

--- a/benchmark/test/test_fp8_benchmark.py
+++ b/benchmark/test/test_fp8_benchmark.py
@@ -19,6 +19,8 @@ from benchmark.fp8_efficiency import (
     assess_triton_efficiency,
     require_efficiency,
 )
+from benchmark.fp8_coverage import _FP8CoverageTracker
+from spikingjelly.activation_based.precision.float8_base import Float8LinearStepModule
 
 
 def _patch_cuda_timing(monkeypatch):
@@ -67,6 +69,34 @@ def _patch_cuda_timing(monkeypatch):
     monkeypatch.setattr(torch.cuda, "max_memory_allocated", require_active_device)
     monkeypatch.setattr(torch.cuda, "max_memory_reserved", require_active_device)
     return entered_devices, event_synchronize_calls, created_events
+
+
+def test_coverage_tracker_weights_executed_dense_macs():
+    class Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = torch.nn.Conv2d(3, 4, 3, padding=1, bias=False)
+            self.linear = Float8LinearStepModule(torch.nn.Linear(4, 8), step_mode="s")
+
+        def forward(self, image, features):
+            return self.conv(image), self.linear(features)
+
+    model = Model()
+    tracker = _FP8CoverageTracker(
+        model,
+        {"converted_modules": ["linear"]},
+    )
+    try:
+        model(torch.randn(2, 3, 8, 8), torch.randn(2, 4))
+    finally:
+        tracker.close()
+
+    report = tracker.report()
+
+    assert report["executed_module_count"] == 2
+    assert report["requested_fp8_module_count"] == 1
+    assert report["total_dense_macs"] == 2 * 4 * 8 * 8 * 3 * 3 * 3 + 2 * 8 * 4
+    assert report["requested_fp8_dense_macs"] == 2 * 8 * 4
 
 
 def test_model_benchmark_timing_uses_requested_cuda_device(monkeypatch):

--- a/benchmark/test/test_snn_single_gpu_benchmark.py
+++ b/benchmark/test/test_snn_single_gpu_benchmark.py
@@ -1,7 +1,9 @@
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+import torch
 
 import benchmark.benchmark_snn_single_gpu as benchmark
 import benchmark.probe_snn_compile_boundary as probe
@@ -41,6 +43,8 @@ def test_case_parser_keeps_required_reproduction_fields(tmp_path: Path):
             "100",
             "--steps",
             "500",
+            "--fp8-fallback-dtype",
+            "bf16",
             "--output",
             str(tmp_path / "result.json"),
         ]
@@ -52,6 +56,12 @@ def test_case_parser_keeps_required_reproduction_fields(tmp_path: Path):
         "inference",
         "compile",
     )
+    assert (args.neuron_backend, args.precision, args.fp8_recipe) == (
+        "triton",
+        "fp32",
+        "auto",
+    )
+    assert args.fp8_fallback_dtype == "bf16"
 
 
 def test_source_parser_requires_one_baseline_and_one_candidate(tmp_path: Path):
@@ -62,6 +72,35 @@ def test_source_parser_requires_one_baseline_and_one_candidate(tmp_path: Path):
         benchmark.parse_source_specs([f"baseline={tmp_path}"])
     with pytest.raises(ValueError, match="unique"):
         benchmark.parse_source_specs([f"baseline={tmp_path}", f"baseline={tmp_path}"])
+
+
+def test_profile_hooks_record_metadata_once(monkeypatch, tmp_path: Path):
+    ranges: list[str | None] = []
+    monkeypatch.setattr(
+        benchmark.torch.cuda.nvtx,
+        "range_push",
+        lambda name: ranges.append(name),
+    )
+    monkeypatch.setattr(
+        benchmark.torch.cuda.nvtx,
+        "range_pop",
+        lambda: ranges.append(None),
+    )
+
+    model = torch.nn.Sequential(torch.nn.Linear(2, 2))
+    hooks = benchmark._ProfileHooks(model, tmp_path / "tensors.jsonl")
+    try:
+        model(torch.randn(1, 2))
+        model(torch.randn(1, 2))
+    finally:
+        hooks.close()
+
+    records = [
+        json.loads(line)
+        for line in (tmp_path / "tensors.jsonl").read_text().splitlines()
+    ]
+    assert [record["event"] for record in records] == ["input", "output"]
+    assert len(ranges) == 4
 
 
 def test_matrix_records_child_timeouts(monkeypatch, tmp_path: Path):

--- a/benchmark/test/test_train_precision_snn_fc_benchmark.py
+++ b/benchmark/test/test_train_precision_snn_fc_benchmark.py
@@ -1,6 +1,9 @@
 from argparse import Namespace
 from contextlib import nullcontext
+import json
+import sys
 
+import pytest
 import torch
 
 import benchmark.benchmark_train_precision_snn_fc as benchmark
@@ -72,6 +75,146 @@ def test_training_step_routes_scaled_gradients_through_scaler() -> None:
     assert scaler.update_calls == 1
 
 
+def test_profile_options_parse_and_validate(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "benchmark",
+            "--profile",
+            "--no-profile-module-hooks",
+            "--profile-steps",
+            "3",
+            "--precisions",
+            "fp8",
+            "--fp8-recipe",
+            "delayed",
+            "--fp8-fallback-dtype",
+            "fp16",
+            "--triton-storage",
+            "float8_e4m3fn",
+            "--triton-fwd",
+            "fp16",
+            "--triton-bwd",
+            "bf16",
+            "--output",
+            str(tmp_path / "profile.json"),
+        ],
+    )
+
+    args = benchmark.parse_args()
+    benchmark.validate_profile_args(args)
+
+    assert args.profile is True
+    assert args.profile_module_hooks is False
+    assert args.profile_steps == 3
+    assert args.precisions == ["fp8"]
+    assert args.fp8_recipe == "delayed"
+    assert args.fp8_fallback_dtype == "fp16"
+    assert args.triton_storage == "float8_e4m3fn"
+    assert args.triton_fwd == "fp16"
+    assert args.triton_bwd == "bf16"
+
+
+def test_profile_validation_rejects_multiple_precisions(tmp_path) -> None:
+    args = Namespace(
+        profile=True,
+        profile_steps=3,
+        precisions=["fp16", "fp8"],
+        output=tmp_path / "profile.json",
+    )
+
+    with pytest.raises(ValueError, match="exactly one precision"):
+        benchmark.validate_profile_args(args)
+
+
+def test_nvtx_training_ranges_are_balanced(monkeypatch) -> None:
+    ranges: list[tuple[str, str | None]] = []
+
+    def push(name: str) -> None:
+        ranges.append(("push", name))
+
+    def pop() -> None:
+        ranges.append(("pop", None))
+
+    monkeypatch.setattr(benchmark.torch.cuda.nvtx, "range_push", push)
+    monkeypatch.setattr(benchmark.torch.cuda.nvtx, "range_pop", pop)
+
+    model = _ToyClassifier()
+    artifacts = _ScaledArtifacts(model, _RecordingScaler())
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+    criterion = torch.nn.CrossEntropyLoss()
+    benchmark.run_training_step(
+        model,
+        artifacts,
+        optimizer,
+        criterion,
+        torch.randn(2, 3, 4),
+        torch.tensor([0, 1, 0]),
+        torch.device("cpu"),
+        nvtx_step="benchmark_step:training:0",
+    )
+
+    pushed = [name for kind, name in ranges if kind == "push"]
+    assert pushed == [
+        "benchmark_step:training:0",
+        "reset",
+        "zero_grad",
+        "forward",
+        "loss",
+        "backward",
+        "optimizer",
+    ]
+    assert len(pushed) == sum(kind == "pop" for kind, _ in ranges)
+
+
+def test_profile_hooks_write_first_tensor_metadata_and_balance_nvtx(
+    monkeypatch, tmp_path
+) -> None:
+    ranges: list[tuple[str, str | None]] = []
+    monkeypatch.setattr(
+        benchmark.torch.cuda.nvtx,
+        "range_push",
+        lambda name: ranges.append(("push", name)),
+    )
+    monkeypatch.setattr(
+        benchmark.torch.cuda.nvtx,
+        "range_pop",
+        lambda: ranges.append(("pop", None)),
+    )
+
+    model = benchmark.DeepFCSNN(
+        input_dim=4,
+        hidden_dim=4,
+        num_classes=2,
+        tau=2.0,
+        backend="torch",
+        depth=2,
+        attention_every=0,
+        num_heads=1,
+    )
+    metadata_path = tmp_path / "tensors.jsonl"
+    hooks = benchmark._ProfileHooks(model, metadata_path)
+    hooks.active = True
+    try:
+        x_seq = torch.randn(2, 3, 4, requires_grad=True)
+        benchmark.functional.reset_net(model)
+        model(x_seq).sum().backward()
+    finally:
+        hooks.close()
+
+    assert sum(kind == "push" for kind, _ in ranges) == sum(
+        kind == "pop" for kind, _ in ranges
+    )
+    records = [json.loads(line) for line in metadata_path.read_text().splitlines()]
+    assert records
+    assert {record["event"] for record in records} >= {
+        "forward_input",
+        "forward_output",
+    }
+    assert records[0]["value"]
+
+
 def test_benchmark_releases_training_state_before_inference(monkeypatch) -> None:
     created_optimizers: list[torch.optim.SGD] = []
     original_sgd = torch.optim.SGD
@@ -97,6 +240,15 @@ def test_benchmark_releases_training_state_before_inference(monkeypatch) -> None
         steps=1,
         inference_steps=1,
         batch_size=3,
+        profile=False,
+        profile_steps=10,
+        profile_module_hooks=True,
+        tensor_metadata_output=None,
+        fp8_recipe="auto",
+        fp8_fallback_dtype="bf16",
+        triton_storage=None,
+        triton_fwd="fp32",
+        triton_bwd="fp32",
     )
     base_model = benchmark.build_model(args)
     x_seq = torch.randn(2, args.batch_size, args.input_dim)

--- a/benchmark/test/test_train_precision_snn_fc_benchmark.py
+++ b/benchmark/test/test_train_precision_snn_fc_benchmark.py
@@ -156,16 +156,13 @@ def test_nvtx_training_ranges_are_balanced(monkeypatch) -> None:
     )
 
     pushed = [name for kind, name in ranges if kind == "push"]
-    assert pushed == [
-        "benchmark_step:training:0",
-        "reset",
-        "zero_grad",
-        "forward",
-        "loss",
-        "backward",
-        "optimizer",
-    ]
+    assert pushed[0] == "benchmark_step:training:0"
+    for required in ("reset", "zero_grad", "forward", "loss", "backward", "optimizer"):
+        assert required in pushed
     assert len(pushed) == sum(kind == "pop" for kind, _ in ranges)
+    assert pushed.index("reset") < pushed.index("forward")
+    assert pushed.index("forward") < pushed.index("backward")
+    assert pushed.index("backward") < pushed.index("optimizer")
 
 
 def test_profile_hooks_write_first_tensor_metadata_and_balance_nvtx(
@@ -195,6 +192,7 @@ def test_profile_hooks_write_first_tensor_metadata_and_balance_nvtx(
     )
     metadata_path = tmp_path / "tensors.jsonl"
     hooks = benchmark._ProfileHooks(model, metadata_path)
+    assert not hooks.records
     hooks.active = True
     try:
         x_seq = torch.randn(2, 3, 4, requires_grad=True)
@@ -244,7 +242,7 @@ def test_benchmark_releases_training_state_before_inference(monkeypatch) -> None
         profile_steps=10,
         profile_module_hooks=True,
         tensor_metadata_output=None,
-        fp8_recipe="auto",
+        fp8_recipe="delayed",
         fp8_fallback_dtype="bf16",
         triton_storage=None,
         triton_fwd="fp32",

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -127,6 +127,8 @@ Module: ``spikingjelly.activation_based.precision``.
 - Added ``triton_storage``, ``triton_fwd``, and ``triton_bwd`` to ``PrecisionConfig`` for
   training-time configuration of existing multi-step Triton IF, LIF, and PLIF
   nodes. Sensitive surrogate operations continue to compute locally in FP32.
+- Added ``fp8_fallback_dtype`` for CUDA operations outside converted Transformer
+  Engine modules; BF16 is the default for numerical range.
 - Transformer Engine conversion leaves Linear and pointwise Conv1d layers whose
   dimensions violate FP8 alignment in high precision and reports them as
   unsupported instead of failing during forward.

--- a/docs/source/tutorials/cn/precision.rst
+++ b/docs/source/tutorials/cn/precision.rst
@@ -415,7 +415,8 @@ Spikformer 也会加速。可以用下面的命令重新采集单卡 profile（`
       -o spikformer-fp8 \
       uv run python benchmark/benchmark_snn_single_gpu.py case \
         --model spikformer_ti --phase inference --execution eager \
-        --batch-size 64 --warmup 50 --steps 10 --profile \
+        --batch-size 64 --warmup 50 --steps 10 --profile --precision fp8 \
+        --neuron-backend triton --fp8-fallback-dtype bf16 \
         --tensor-metadata spikformer-fp8.tensors.jsonl \
         --output spikformer-fp8.json
 

--- a/docs/source/tutorials/cn/precision.rst
+++ b/docs/source/tutorials/cn/precision.rst
@@ -103,6 +103,23 @@ Transformer Engine、硬件或 recipe 不可用时，准备过程直接报错，
 的默认 recipe；需要固定数值策略时，再显式选择 ``delayed``、``current``、``block``
 或 ``mxfp8``。
 
+控制未转换算子的 dtype
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Transformer Engine 只改变已转换模块。FP8 默认给其余普通 CUDA 算子增加 BF16
+autocast，避免 Conv2d、BatchNorm 或神经元沿 FP32 边界执行：
+
+.. code-block:: python
+
+    config = PrecisionConfig(
+        mode="fp8",
+        fp8_recipe="auto",
+    )
+
+需要复现实验时，可以用 ``fp8_fallback_dtype="fp16"`` 或 ``"fp32"`` 显式覆盖。
+这里的 fallback 指未被 FP8 覆盖的算子，不是错误降级。该字段只控制普通 CUDA
+autocast 和 TE 模块输出边界，不表示这些算子已使用 FP8 kernel。
+
 部分 Transformer Engine recipe 会把 FP8 metadata 序列化为 pickle。恢复可信来源的
 checkpoint 时，需要显式设置 ``NVTE_ALLOW_UNSAFE_PICKLE_EXTRA_STATE=1``；不要为未知
 checkpoint 开启该选项。
@@ -218,13 +235,16 @@ MCore ``TransformerConfig`` 和 ``OptimizerConfig`` 设置，二者必须一致�
 FP8 何时更快
 ------------
 
-FP8 的收益来自大矩阵，不来自 dtype 名称本身。普通 FC-SNN 训练和当前
-Spikformer DDP 都没有受益；足够宽的 Linear 和 FC-SNN 推理才越过了 FP16/BF16。
+FP8 的收益来自大矩阵，不来自 dtype 名称本身。FC-SNN 是否受益取决于神经元后端和
+Linear--神经元边界；Spikformer 的卷积、BatchNorm 和神经元占比更高，目前单卡仍未
+越过 FP16/BF16。
 
-以下结果测于 2026-08-29。Linear 和 FC-SNN 使用一张 RTX 5090 32 GiB，DDP 使用
-两张；软件版本为 PyTorch 2.11.0+cu128 和 Transformer Engine 2.18.0。Linear 和
-FC-SNN 运行三次并轮换精度顺序，表中取中位数。吞吐至少提高 5% 才算有优势，计时
-不包含模型转换。
+Dense Linear 和 2 卡 DDP 的历史结果测于 2026-08-29，使用 Transformer Engine
+2.18.0；下面替换后的 FC-SNN 以及新增的单卡 Spikformer 结果测于 2026-08-30，
+使用 PyTorch 2.11.0+cu128、Transformer Engine 2.17.1 和一张 RTX 5090 32 GiB。
+后者是因为该镜像中的 TE 2.18.0 extension 无法加载，不能把两套软件栈的数字混为一谈。
+FC-SNN/Spikformer 每个稳态 case 运行三次并取独立进程 median；吞吐至少提高 5% 才算
+有优势，计时不包含模型转换。
 
 Linear/GEMM 交叉点
 ~~~~~~~~~~~~~~~~~~
@@ -275,17 +295,136 @@ FP8 也不等于固定省显存。在 4096×3200×8 的交叉点，FP8 训练/�
     * - workload
       - 训练 FP8 / FP16、BF16
       - 推理 FP8 / FP16、BF16
-    * - FC-SNN：T16, batch 256, width 4096, depth 20
-      - 0.954x / 0.942x
-      - 0.901x / 0.896x
-    * - FC-SNN：T16, batch 256, width 8192, depth 10
-      - 0.908x / 0.887x
-      - 1.310x / 1.299x
+    * - FC-SNN：T16, batch 256, width 4096, depth 20（Triton LIF，FP16 fallback）
+      - 1.533x / 1.677x
+      - 1.578x / 1.786x
+    * - FC-SNN：T16, batch 256, width 8192, depth 10（Triton LIF，FP32 fallback）
+      - 1.544x / 1.468x
+      - 1.648x / 1.471x
 
-width=8192 时，FC-SNN 推理中的大矩阵已经足以抵消 FP8 的额外开销；训练还包含反向
-和神经元计算，因此依然更慢。此时 FP8 训练显存比 FP16/BF16 高约 46%--47%。
+这里的比值仍依次为 ``FP8 / FP16`` 和 ``FP8 / BF16``，且是端到端吞吐比值。两组
+FC-SNN 都使用现有 Triton LIF；FP8 神经元 ``triton_storage`` 未启用，神经元计算仍
+保持高精度。W4096 使用 ``fp8_fallback_dtype="fp16"``，训练/推理峰值 allocated
+memory 为 4279.1/1460.3 MiB；W8192 是未启用外层 autocast 的既有结果。因此，这些
+结果说明“FP8 Linear + Triton LIF”已经在该规模上超过 FP16/BF16，而不是说明所有
+神经元都已经用 FP8，也不能据此假定 FP8 固定节省显存。
 
-2 卡 Spikformer DDP 使用 5 个计时 step：
+旧教程中的慢速 FC-SNN 数字来自 Torch LIF，只保留在 nsys 根因报告中，不再作为
+FC-SNN 的推荐 benchmark。
+
+W4096/depth20 的 requested FP8 tracked dense-MAC coverage 为 100%。
+
+复现 FC-SNN profile：
+
+.. code-block:: bash
+
+    nsys profile --capture-range=cudaProfilerApi --capture-range-end=stop \
+      --trace=cuda,nvtx,cublas,osrt --sample=none --cpuctxsw=none \
+      -o fcsnn-fp8 \
+      uv run python benchmark/benchmark_train_precision_snn_fc.py \
+        --backend triton --precisions fp8 --fp8-fallback-dtype fp16 \
+        --profile --profile-steps 10 --output fcsnn-fp8.json
+
+单卡 Spikformer
+~~~~~~~~~~~~~~~~
+
+``spikformer_ti`` 使用 ``T=4``、输入 ``224``、eager、Triton LIF，在 RTX 5090 上的
+端到端结果如下。训练行使用 1024 类仅用于满足当前 TE FP8 backward 的 16 对齐要求；
+真实 1000 类 head 的 FP8 训练会触发 ``lda % 16 == 0``，当前不支持。
+
+.. list-table::
+    :header-rows: 1
+
+    * - workload
+      - precision path
+      - step latency
+      - throughput
+      - 相对 FP16 / BF16 吞吐
+      - peak allocated
+    * - 推理：batch 64，1000 类
+      - FP16
+      - 16.220 ms
+      - 3945.7 images/s
+      - --
+      - 1974.8 MiB
+    * - 推理：batch 64，1000 类
+      - BF16
+      - 16.372 ms
+      - 3909.1 images/s
+      - --
+      - 1974.8 MiB
+    * - 推理：batch 64，1000 类
+      - FP8 + FP32 fallback
+      - 37.173 ms
+      - 1721.7 images/s
+      - 0.436x / 0.441x
+      - 3377.3 MiB
+    * - 推理：batch 64，1000 类
+      - FP8 + FP16 fallback
+      - 22.280 ms
+      - 2872.6 images/s
+      - 0.728x / 0.735x
+      - 2004.8 MiB
+    * - 推理：batch 64，1000 类
+      - FP8 + BF16 fallback（默认）
+      - 22.402 ms
+      - 2856.9 images/s
+      - 0.724x / 0.731x
+      - 2004.8 MiB
+    * - 训练：batch 32，1024 类（对齐诊断）
+      - FP16
+      - 37.869 ms
+      - 845.0 samples/s
+      - --
+      - 4508.2 MiB
+    * - 训练：batch 32，1024 类（对齐诊断）
+      - BF16
+      - 44.671 ms
+      - 716.4 samples/s
+      - --
+      - 4511.5 MiB
+    * - 训练：batch 32，1024 类（对齐诊断）
+      - FP8 + FP32 fallback
+      - 59.538 ms
+      - 537.5 samples/s
+      - 0.636x / 0.750x
+      - 7724.4 MiB
+    * - 训练：batch 32，1024 类（对齐诊断）
+      - FP8 + FP16 fallback
+      - 41.499 ms
+      - 771.1 samples/s
+      - 0.913x / 1.076x
+      - 4398.4 MiB
+    * - 训练：batch 32，1024 类（对齐诊断）
+      - FP8 + BF16 fallback（默认）
+      - 48.654 ms
+      - 657.7 samples/s
+      - 0.778x / 0.918x
+      - 4398.4 MiB
+
+nsys 显示 FP8 autocast 只覆盖 TE 的 pointwise Conv1d/Linear；patch-stem Conv2d、
+BatchNorm 和 LIF 输出都回到 FP32，产生额外的 elementwise、copy 和 layout kernel。
+所以当前 Spikformer 应选择 FP16/BF16；不要用 FC-SNN 的 Triton 结果推断
+Spikformer 也会加速。可以用下面的命令重新采集单卡 profile（``--profile``
+通过 ``cudaProfilerApi`` 限定采集区间）：
+
+.. code-block:: bash
+
+    nsys profile --capture-range=cudaProfilerApi --capture-range-end=stop \
+      --trace=cuda,nvtx,cublas,osrt --sample=none --cpuctxsw=none \
+      -o spikformer-fp8 \
+      uv run python benchmark/benchmark_snn_single_gpu.py case \
+        --model spikformer_ti --phase inference --execution eager \
+        --batch-size 64 --warmup 50 --steps 10 --profile \
+        --tensor-metadata spikformer-fp8.tensors.jsonl \
+        --output spikformer-fp8.json
+
+默认 BF16 fallback 将 FP8 训练/推理 latency 分别降低 18.3%/39.7%，但仍未跨过
+BF16。显式 FP16 fallback 更快，但动态范围较小。该模型 requested FP8 tracked
+dense-MAC coverage 为 41.98%。当前 RTX 5090 软件栈没有 FP8 Conv2d，不能用模拟
+路径声称已验证更高覆盖率。
+
+历史的 2 卡 Spikformer DDP 使用 5 个计时 step：
 
 .. list-table::
     :header-rows: 1
@@ -309,9 +448,9 @@ width=8192 时，FC-SNN 推理中的大矩阵已经足以抵消 FP8 的额外开
 如何选择
 --------
 
-默认先用 BF16。profile 显示对齐的 Linear/MLP 占主要耗时，并且矩阵维度接近表中的
-交叉区间时，再测试 FP8。CNN、神经元或通信占比较高时，FP8 通常无法弥补转换和
-metadata 开销。FP8 的显存也可能高于 BF16，不应把它当作显存优化开关。
+默认先用 BF16。FC-SNN 只有在使用 Triton LIF 且矩阵达到表中规模后才建议测试 FP8；
+Spikformer 等 CNN/神经元占比较高的模型，在完成 FP32 边界优化前继续使用 FP16/BF16。
+profile 必须以端到端 step 为准；FP8 的显存也可能高于 BF16，不应把它当作显存优化开关。
 
 使用仓库 benchmark 在目标 GPU 上重测交叉点：
 

--- a/docs/source/tutorials/en/precision.rst
+++ b/docs/source/tutorials/en/precision.rst
@@ -437,7 +437,8 @@ FC-SNN Triton result. Reproduce a single-GPU profile with:
       -o spikformer-fp8 \
       uv run python benchmark/benchmark_snn_single_gpu.py case \
         --model spikformer_ti --phase inference --execution eager \
-        --batch-size 64 --warmup 50 --steps 10 --profile \
+        --batch-size 64 --warmup 50 --steps 10 --profile --precision fp8 \
+        --neuron-backend triton --fp8-fallback-dtype bf16 \
         --tensor-metadata spikformer-fp8.tensors.jsonl \
         --output spikformer-fp8.json
 

--- a/docs/source/tutorials/en/precision.rst
+++ b/docs/source/tutorials/en/precision.rst
@@ -112,6 +112,25 @@ unavailable; it does not switch to BF16. At least one module must be convertible
 ``delayed``, ``current``, ``block``, or ``mxfp8`` when the numerical recipe must
 be fixed explicitly.
 
+Controlling unconverted operations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Transformer Engine changes only converted modules. FP8 wraps the remaining
+CUDA operations in BF16 autocast by default, avoiding a model-wide FP32 boundary
+through Conv2d, BatchNorm, or neurons:
+
+.. code-block:: python
+
+    config = PrecisionConfig(
+        mode="fp8",
+        fp8_recipe="auto",
+    )
+
+Use ``fp8_fallback_dtype="fp16"`` or ``"fp32"`` to reproduce an explicit
+experimental path. Here, fallback means operations not covered by FP8, not
+recovery from an error. The field controls ordinary CUDA autocast and TE output
+boundaries; it does not claim that those operations use FP8 kernels.
+
 Some Transformer Engine recipes serialize FP8 metadata as a pickle. Set
 ``NVTE_ALLOW_UNSAFE_PICKLE_EXTRA_STATE=1`` only when restoring a trusted
 checkpoint; do not enable it for unknown checkpoints.
@@ -230,14 +249,18 @@ configuration examples.
 When FP8 is faster
 ------------------
 
-FP8 benefits large matrices, not every low-precision workload. It does not help
-the regular FC-SNN training case or the current
-Spikformer DDP case; sufficiently wide Linear and FC-SNN inference workloads do.
+FP8 benefits large matrices, not every low-precision workload. FC-SNN depends on
+the neuron backend and the Linear-to-neuron boundary; Spikformer has a larger
+convolution, BatchNorm, and neuron share and does not cross the FP16/BF16
+baseline on one GPU yet.
 
-Measurements were taken on 2026-08-29. Linear and FC-SNN used one RTX 5090
-32 GiB GPU, while DDP used two. The software stack was PyTorch 2.11.0+cu128 and
-Transformer Engine 2.18.0. Linear and FC-SNN ran three times with rotated
-precision order, and the tables report medians. A 5% throughput increase is the
+The dense Linear and two-GPU DDP results below were measured on 2026-08-29 with
+Transformer Engine 2.18.0. The replacement FC-SNN rows and the new single-GPU
+Spikformer rows were measured on 2026-08-30 with PyTorch 2.11.0+cu128,
+Transformer Engine 2.17.1, and one 32-GiB RTX 5090. The latter used 2.17.1
+because the image's TE 2.18.0 extension could not load; the two software stacks
+must not be conflated. Each FC-SNN/Spikformer steady-state case used three
+independent processes and reports the median. A 5% throughput increase is the
 cutoff for a useful win. Model conversion is excluded from timing.
 
 Linear/GEMM crossover
@@ -291,18 +314,142 @@ End-to-end SNN and DDP
     * - workload
       - training FP8 / FP16, BF16
       - inference FP8 / FP16, BF16
-    * - FC-SNN: T16, batch 256, width 4096, depth 20
-      - 0.954x / 0.942x
-      - 0.901x / 0.896x
-    * - FC-SNN: T16, batch 256, width 8192, depth 10
-      - 0.908x / 0.887x
-      - 1.310x / 1.299x
+    * - FC-SNN: T16, batch 256, width 4096, depth 20 (Triton LIF, FP16 fallback)
+      - 1.533x / 1.677x
+      - 1.578x / 1.786x
+    * - FC-SNN: T16, batch 256, width 8192, depth 10 (Triton LIF, FP32 fallback)
+      - 1.544x / 1.468x
+      - 1.648x / 1.471x
 
-At width=8192, the inference matrices are large enough to offset the FP8 overhead.
-Training still pays for backward and neuron operations and remains slower. Its
-FP8 training memory is about 46%--47% higher than FP16/BF16.
+The ratios are end-to-end throughput ratios in the order ``FP8 / FP16`` and
+``FP8 / BF16``. Both FC-SNN cases use the existing Triton LIF; Triton neuron
+storage is not enabled and neuron computation remains high precision. W4096
+uses ``fp8_fallback_dtype="fp16"`` and its training/inference peak allocated
+memory is 4279.1/1460.3 MiB; W8192 is the earlier result without an outer
+autocast. Thus “FP8 Linear + Triton LIF” wins at these sizes, but this does not
+mean that all neuron state is FP8 or that FP8 always saves memory.
 
-The two-GPU Spikformer DDP benchmark used five timed steps:
+The slower FC-SNN numbers previously shown in this tutorial used Torch LIF and
+are retained only in the Nsight root-cause report, not as the recommended
+FC-SNN benchmark.
+
+Requested FP8 tracked dense-MAC coverage for W4096/depth20 is 100%.
+
+Reproduce the FC-SNN profile with:
+
+.. code-block:: bash
+
+    nsys profile --capture-range=cudaProfilerApi --capture-range-end=stop \
+      --trace=cuda,nvtx,cublas,osrt --sample=none --cpuctxsw=none \
+      -o fcsnn-fp8 \
+      uv run python benchmark/benchmark_train_precision_snn_fc.py \
+        --backend triton --precisions fp8 --fp8-fallback-dtype fp16 \
+        --profile --profile-steps 10 --output fcsnn-fp8.json
+
+Single-GPU Spikformer
+~~~~~~~~~~~~~~~~~~~~~
+
+For ``spikformer_ti`` with ``T=4``, input size ``224``, eager execution, and
+Triton LIF, the RTX 5090 end-to-end results are:
+
+.. list-table::
+    :header-rows: 1
+
+    * - workload
+      - precision path
+      - step latency
+      - throughput
+      - throughput vs FP16 / BF16
+      - peak allocated
+    * - Inference: batch 64, 1000 classes
+      - FP16
+      - 16.220 ms
+      - 3945.7 images/s
+      - --
+      - 1974.8 MiB
+    * - Inference: batch 64, 1000 classes
+      - BF16
+      - 16.372 ms
+      - 3909.1 images/s
+      - --
+      - 1974.8 MiB
+    * - Inference: batch 64, 1000 classes
+      - FP8 + FP32 fallback
+      - 37.173 ms
+      - 1721.7 images/s
+      - 0.436x / 0.441x
+      - 3377.3 MiB
+    * - Inference: batch 64, 1000 classes
+      - FP8 + FP16 fallback
+      - 22.280 ms
+      - 2872.6 images/s
+      - 0.728x / 0.735x
+      - 2004.8 MiB
+    * - Inference: batch 64, 1000 classes
+      - FP8 + BF16 fallback (default)
+      - 22.402 ms
+      - 2856.9 images/s
+      - 0.724x / 0.731x
+      - 2004.8 MiB
+    * - Training: batch 32, 1024 classes (alignment diagnostic)
+      - FP16
+      - 37.869 ms
+      - 845.0 samples/s
+      - --
+      - 4508.2 MiB
+    * - Training: batch 32, 1024 classes (alignment diagnostic)
+      - BF16
+      - 44.671 ms
+      - 716.4 samples/s
+      - --
+      - 4511.5 MiB
+    * - Training: batch 32, 1024 classes (alignment diagnostic)
+      - FP8 + FP32 fallback
+      - 59.538 ms
+      - 537.5 samples/s
+      - 0.636x / 0.750x
+      - 7724.4 MiB
+    * - Training: batch 32, 1024 classes (alignment diagnostic)
+      - FP8 + FP16 fallback
+      - 41.499 ms
+      - 771.1 samples/s
+      - 0.913x / 1.076x
+      - 4398.4 MiB
+    * - Training: batch 32, 1024 classes (alignment diagnostic)
+      - FP8 + BF16 fallback (default)
+      - 48.654 ms
+      - 657.7 samples/s
+      - 0.778x / 0.918x
+      - 4398.4 MiB
+
+The training row uses 1024 classes only to satisfy the current TE FP8 backward
+16-alignment requirement; an ImageNet-1000 head currently fails with
+``lda % 16 == 0``. Nsight shows that FP8 autocast covers only TE pointwise
+Conv1d/Linear modules; patch-stem Conv2d, BatchNorm, and LIF outputs fall back
+to FP32, adding elementwise, copy, and layout kernels. Choose FP16/BF16 for
+Spikformer until that boundary is fixed; do not infer a Spikformer win from the
+FC-SNN Triton result. Reproduce a single-GPU profile with:
+
+.. code-block:: bash
+
+    nsys profile --capture-range=cudaProfilerApi --capture-range-end=stop \
+      --trace=cuda,nvtx,cublas,osrt --sample=none --cpuctxsw=none \
+      -o spikformer-fp8 \
+      uv run python benchmark/benchmark_snn_single_gpu.py case \
+        --model spikformer_ti --phase inference --execution eager \
+        --batch-size 64 --warmup 50 --steps 10 --profile \
+        --tensor-metadata spikformer-fp8.tensors.jsonl \
+        --output spikformer-fp8.json
+
+The ``--profile`` flag bounds capture through ``cudaProfilerApi``.
+
+The default BF16 fallback reduces FP8 training/inference latency by 18.3%/39.7%,
+but does not cross BF16. The explicit FP16 fallback is faster but has less
+dynamic range. Requested FP8 tracked dense-MAC coverage is 41.98%. The current
+RTX 5090 stack does not expose FP8 Conv2d; an emulated path is not evidence of
+increased hardware coverage.
+
+The historical two-GPU Spikformer DDP benchmark used five timed steps:
 
 .. list-table::
     :header-rows: 1
@@ -327,11 +474,11 @@ this workload.
 Choosing a mode
 ---------------
 
-Start with BF16. Try FP8 after profiling shows that aligned Linear/MLP operations
-dominate runtime and the matrix dimensions approach the measured crossover. FP8
-usually cannot recover its conversion and metadata overhead when CNN, neuron, or
-communication work dominates. Its memory use may also exceed BF16, so it is not a
-memory-optimization switch.
+Start with BF16. Try FP8 for FC-SNN only with Triton LIF and matrix sizes near
+the table's crossover. For CNN/neuron-heavy models such as Spikformer, continue
+with FP16/BF16 until the FP32 boundary is optimized. Profile against the
+end-to-end step; FP8 memory may exceed BF16 and is not a memory-optimization
+switch.
 
 Run the crossover benchmark on the target GPU:
 

--- a/spikingjelly/activation_based/precision/api.py
+++ b/spikingjelly/activation_based/precision/api.py
@@ -31,6 +31,7 @@ def _resolve_policy(config: PrecisionConfig, device: torch.device) -> PrecisionP
     return Float8TransformerEnginePolicy(
         device_type=device_type,
         fp8_recipe=config.fp8_recipe,
+        fp8_fallback_dtype=config.fp8_fallback_dtype,
     )
 
 

--- a/spikingjelly/activation_based/precision/config.py
+++ b/spikingjelly/activation_based/precision/config.py
@@ -8,7 +8,6 @@ from typing import Literal, Optional
 class PrecisionConfig:
     mode: Literal["fp32", "fp16", "bf16", "fp8"] = "fp32"
     fp8_recipe: Literal["auto", "delayed", "current", "block", "mxfp8"] = "auto"
-    fp8_fallback_dtype: Literal["fp32", "fp16", "bf16"] = "bf16"
     triton_storage: Optional[
         Literal[
             "fp32",
@@ -20,6 +19,7 @@ class PrecisionConfig:
     ] = None
     triton_fwd: Literal["fp8", "fp16", "bf16", "fp32"] = "fp32"
     triton_bwd: Literal["fp8", "fp16", "bf16", "fp32"] = "fp32"
+    fp8_fallback_dtype: Literal["fp32", "fp16", "bf16"] = "bf16"
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "mode", str(self.mode).lower())
@@ -144,9 +144,6 @@ PrecisionConfig.__init__.__doc__ = r"""Configure model and Triton-neuron precisi
 :type mode: Literal["fp32", "fp16", "bf16", "fp8"]
 :param fp8_recipe: Transformer Engine FP8 recipe；仅 ``mode="fp8"`` 有效。
 :type fp8_recipe: Literal["auto", "delayed", "current", "block", "mxfp8"]
-:param fp8_fallback_dtype: 未由 Transformer Engine 转换的普通 CUDA 算子使用的
-    fallback autocast dtype，默认为 ``bf16``；``fp32`` 表示不启用外层 autocast。
-:type fp8_fallback_dtype: Literal["fp32", "fp16", "bf16"]
 :param triton_storage: Triton 神经元状态 storage dtype；``None`` 禁用 mixed path。
 :type triton_storage: Optional[Literal["fp32", "fp16", "bf16",
     "float8_e4m3fn", "float8_e5m2"]]
@@ -154,6 +151,9 @@ PrecisionConfig.__init__.__doc__ = r"""Configure model and Triton-neuron precisi
 :type triton_fwd: Literal["fp8", "fp16", "bf16", "fp32"]
 :param triton_bwd: Triton 神经元反向算术 dtype。
 :type triton_bwd: Literal["fp8", "fp16", "bf16", "fp32"]
+:param fp8_fallback_dtype: 未由 Transformer Engine 转换的普通 CUDA 算子使用的
+    fallback autocast dtype，默认为 ``bf16``；``fp32`` 表示不启用外层 autocast。
+:type fp8_fallback_dtype: Literal["fp32", "fp16", "bf16"]
 :raises ValueError: mode、recipe 或 Triton dtype 组合无效。
 
 ----
@@ -172,10 +172,6 @@ changes neuron backends nor silently falls back.
 :type mode: Literal["fp32", "fp16", "bf16", "fp8"]
 :param fp8_recipe: Transformer Engine FP8 recipe, valid only for ``mode="fp8"``.
 :type fp8_recipe: Literal["auto", "delayed", "current", "block", "mxfp8"]
-:param fp8_fallback_dtype: Fallback autocast dtype for ordinary CUDA operations
-    not converted by Transformer Engine. The default is ``bf16``; ``fp32``
-    disables the outer autocast.
-:type fp8_fallback_dtype: Literal["fp32", "fp16", "bf16"]
 :param triton_storage: Triton neuron-state storage dtype; ``None`` disables the
     mixed path.
 :type triton_storage: Optional[Literal["fp32", "fp16", "bf16",
@@ -184,5 +180,9 @@ changes neuron backends nor silently falls back.
 :type triton_fwd: Literal["fp8", "fp16", "bf16", "fp32"]
 :param triton_bwd: Triton-neuron backward arithmetic dtype.
 :type triton_bwd: Literal["fp8", "fp16", "bf16", "fp32"]
+:param fp8_fallback_dtype: Fallback autocast dtype for ordinary CUDA operations
+    not converted by Transformer Engine. The default is ``bf16``; ``fp32``
+    disables the outer autocast.
+:type fp8_fallback_dtype: Literal["fp32", "fp16", "bf16"]
 :raises ValueError: If a mode, recipe, or Triton dtype combination is invalid.
 """

--- a/spikingjelly/activation_based/precision/config.py
+++ b/spikingjelly/activation_based/precision/config.py
@@ -8,6 +8,7 @@ from typing import Literal, Optional
 class PrecisionConfig:
     mode: Literal["fp32", "fp16", "bf16", "fp8"] = "fp32"
     fp8_recipe: Literal["auto", "delayed", "current", "block", "mxfp8"] = "auto"
+    fp8_fallback_dtype: Literal["fp32", "fp16", "bf16"] = "bf16"
     triton_storage: Optional[
         Literal[
             "fp32",
@@ -23,6 +24,9 @@ class PrecisionConfig:
     def __post_init__(self) -> None:
         object.__setattr__(self, "mode", str(self.mode).lower())
         object.__setattr__(self, "fp8_recipe", str(self.fp8_recipe).lower())
+        object.__setattr__(
+            self, "fp8_fallback_dtype", str(self.fp8_fallback_dtype).lower()
+        )
         if self.triton_storage is not None:
             object.__setattr__(
                 self,
@@ -37,6 +41,10 @@ class PrecisionConfig:
             raise ValueError("Unsupported fp8_recipe.")
         if self.mode != "fp8" and self.fp8_recipe != "auto":
             raise ValueError("fp8_recipe is only valid when mode='fp8'.")
+        if self.fp8_fallback_dtype not in {"fp32", "fp16", "bf16"}:
+            raise ValueError("Unsupported fp8_fallback_dtype.")
+        if self.mode != "fp8" and self.fp8_fallback_dtype != "bf16":
+            raise ValueError("fp8_fallback_dtype is only valid when mode='fp8'.")
         if self.triton_storage is None and (
             self.triton_fwd != "fp32" or self.triton_bwd != "fp32"
         ):
@@ -136,6 +144,9 @@ PrecisionConfig.__init__.__doc__ = r"""Configure model and Triton-neuron precisi
 :type mode: Literal["fp32", "fp16", "bf16", "fp8"]
 :param fp8_recipe: Transformer Engine FP8 recipe；仅 ``mode="fp8"`` 有效。
 :type fp8_recipe: Literal["auto", "delayed", "current", "block", "mxfp8"]
+:param fp8_fallback_dtype: 未由 Transformer Engine 转换的普通 CUDA 算子使用的
+    fallback autocast dtype，默认为 ``bf16``；``fp32`` 表示不启用外层 autocast。
+:type fp8_fallback_dtype: Literal["fp32", "fp16", "bf16"]
 :param triton_storage: Triton 神经元状态 storage dtype；``None`` 禁用 mixed path。
 :type triton_storage: Optional[Literal["fp32", "fp16", "bf16",
     "float8_e4m3fn", "float8_e5m2"]]
@@ -161,6 +172,10 @@ changes neuron backends nor silently falls back.
 :type mode: Literal["fp32", "fp16", "bf16", "fp8"]
 :param fp8_recipe: Transformer Engine FP8 recipe, valid only for ``mode="fp8"``.
 :type fp8_recipe: Literal["auto", "delayed", "current", "block", "mxfp8"]
+:param fp8_fallback_dtype: Fallback autocast dtype for ordinary CUDA operations
+    not converted by Transformer Engine. The default is ``bf16``; ``fp32``
+    disables the outer autocast.
+:type fp8_fallback_dtype: Literal["fp32", "fp16", "bf16"]
 :param triton_storage: Triton neuron-state storage dtype; ``None`` disables the
     mixed path.
 :type triton_storage: Optional[Literal["fp32", "fp16", "bf16",

--- a/spikingjelly/activation_based/precision/float8_te.py
+++ b/spikingjelly/activation_based/precision/float8_te.py
@@ -21,8 +21,17 @@ _SUPPORTED_TE_RECIPES = {"auto", "delayed", "current", "block", "mxfp8"}
 
 
 @contextmanager
-def _cuda_device_autocast_context(device: torch.device, autocast_context):
-    with torch.cuda.device(device), autocast_context:
+def _cuda_device_autocast_context(
+    device: torch.device,
+    autocast_context,
+    amp_dtype: torch.dtype | None = None,
+):
+    amp_context = (
+        torch.amp.autocast(device.type, dtype=amp_dtype)
+        if amp_dtype is not None
+        else nullcontext()
+    )
+    with torch.cuda.device(device), amp_context, autocast_context:
         yield
 
 
@@ -442,10 +451,50 @@ class Float8TransformerEnginePolicy(PrecisionPolicy):
         self,
         device_type: str = "cuda",
         fp8_recipe: str = "auto",
-    ):
+        fp8_fallback_dtype: str = "bf16",
+    ) -> None:
+        r"""
+        **API Language** - :ref:`中文 <Float8TransformerEnginePolicy.__init__-cn>` | :ref:`English <Float8TransformerEnginePolicy.__init__-en>`
+
+        ----
+
+        .. _Float8TransformerEnginePolicy.__init__-cn:
+
+        * **中文**
+
+        配置 Transformer Engine FP8 policy。未转换的 CUDA 算子使用
+        ``fp8_fallback_dtype`` 指定的外层 autocast dtype。
+
+        :param device_type: 设备类型，通常为 ``"cuda"``。
+        :type device_type: str
+        :param fp8_recipe: Transformer Engine FP8 recipe 名称。
+        :type fp8_recipe: str
+        :param fp8_fallback_dtype: 未由 Transformer Engine 转换的 CUDA 算子使用的
+            fallback autocast dtype。
+        :type fp8_fallback_dtype: str
+
+        ----
+
+        .. _Float8TransformerEnginePolicy.__init__-en:
+
+        * **English**
+
+        Configure the Transformer Engine FP8 policy. CUDA operations not
+        converted by Transformer Engine use the outer autocast dtype selected by
+        ``fp8_fallback_dtype``.
+
+        :param device_type: Device type, normally ``"cuda"``.
+        :type device_type: str
+        :param fp8_recipe: Transformer Engine FP8 recipe name.
+        :type fp8_recipe: str
+        :param fp8_fallback_dtype: Fallback autocast dtype for CUDA operations
+            not converted by Transformer Engine.
+        :type fp8_fallback_dtype: str
+        """
         super().__init__()
         self.device_type = device_type
         self.fp8_recipe = fp8_recipe
+        self.fp8_fallback_dtype = fp8_fallback_dtype
         self._resolved_recipe_name: str | None = None
         self._resolved_recipe = None
         self._recipe_resolved = False
@@ -457,6 +506,7 @@ class Float8TransformerEnginePolicy(PrecisionPolicy):
             "backend": "transformer-engine",
             "device_type": self.device_type,
             "fp8_recipe": self.fp8_recipe,
+            "fp8_fallback_dtype": self.fp8_fallback_dtype,
             "resolved_fp8_recipe": self._resolved_recipe_name,
             "autocast": True,
             "grad_scaler": False,
@@ -555,7 +605,16 @@ class Float8TransformerEnginePolicy(PrecisionPolicy):
     def autocast_context(self, group=None):
         context = self._te_autocast_context(group)
         if self._target_device is not None and self._target_device.type == "cuda":
-            return _cuda_device_autocast_context(self._target_device, context)
+            amp_dtype = {
+                "fp32": None,
+                "fp16": torch.float16,
+                "bf16": torch.bfloat16,
+            }[self.fp8_fallback_dtype]
+            return _cuda_device_autocast_context(
+                self._target_device,
+                context,
+                amp_dtype,
+            )
         return context
 
     def _te_autocast_context(self, group=None):

--- a/spikingjelly/activation_based/precision/float8_te.py
+++ b/spikingjelly/activation_based/precision/float8_te.py
@@ -18,6 +18,11 @@ from .float8_conv import (
 from .policy import PrecisionPolicy
 
 _SUPPORTED_TE_RECIPES = {"auto", "delayed", "current", "block", "mxfp8"}
+_FP8_FALLBACK_AMP_DTYPES = {
+    "fp32": None,
+    "fp16": torch.float16,
+    "bf16": torch.bfloat16,
+}
 
 
 @contextmanager
@@ -494,7 +499,9 @@ class Float8TransformerEnginePolicy(PrecisionPolicy):
         super().__init__()
         self.device_type = device_type
         self.fp8_recipe = fp8_recipe
-        self.fp8_fallback_dtype = fp8_fallback_dtype
+        self.fp8_fallback_dtype = str(fp8_fallback_dtype).lower()
+        if self.fp8_fallback_dtype not in _FP8_FALLBACK_AMP_DTYPES:
+            raise ValueError("Unsupported fp8_fallback_dtype.")
         self._resolved_recipe_name: str | None = None
         self._resolved_recipe = None
         self._recipe_resolved = False
@@ -605,11 +612,7 @@ class Float8TransformerEnginePolicy(PrecisionPolicy):
     def autocast_context(self, group=None):
         context = self._te_autocast_context(group)
         if self._target_device is not None and self._target_device.type == "cuda":
-            amp_dtype = {
-                "fp32": None,
-                "fp16": torch.float16,
-                "bf16": torch.bfloat16,
-            }[self.fp8_fallback_dtype]
+            amp_dtype = _FP8_FALLBACK_AMP_DTYPES[self.fp8_fallback_dtype]
             return _cuda_device_autocast_context(
                 self._target_device,
                 context,

--- a/spikingjelly/activation_based/precision/float8_te.py
+++ b/spikingjelly/activation_based/precision/float8_te.py
@@ -34,7 +34,7 @@ def _cuda_device_autocast_context(
     amp_context = (
         torch.amp.autocast(device.type, dtype=amp_dtype)
         if amp_dtype is not None
-        else nullcontext()
+        else torch.amp.autocast(device.type, enabled=False)
     )
     with torch.cuda.device(device), amp_context, autocast_context:
         yield

--- a/test/activation_based/test_precision_conversion.py
+++ b/test/activation_based/test_precision_conversion.py
@@ -899,8 +899,8 @@ def test_float8_policy_nests_default_cuda_autocast(monkeypatch):
         yield
 
     @contextmanager
-    def fake_autocast(device_type, dtype):
-        entered.append(("autocast", device_type, dtype))
+    def fake_autocast(device_type, dtype=None, enabled=True):
+        entered.append(("autocast", device_type, dtype, enabled))
         yield
 
     monkeypatch.setattr(torch.cuda, "device", fake_device)
@@ -916,7 +916,7 @@ def test_float8_policy_nests_default_cuda_autocast(monkeypatch):
 
     assert entered == [
         ("device", "cuda:0"),
-        ("autocast", "cuda", torch.bfloat16),
+        ("autocast", "cuda", torch.bfloat16, True),
     ]
 
 
@@ -927,6 +927,40 @@ def test_float8_policy_rejects_invalid_fallback_dtype():
 
     with pytest.raises(ValueError, match="Unsupported fp8_fallback_dtype"):
         Float8TransformerEnginePolicy(fp8_fallback_dtype="int8")
+
+
+def test_float8_policy_disables_ambient_autocast_for_fp32(monkeypatch):
+    from spikingjelly.activation_based.precision.float8_te import (
+        Float8TransformerEnginePolicy,
+    )
+
+    entered = []
+
+    @contextmanager
+    def fake_device(device):
+        entered.append(("device", str(device)))
+        yield
+
+    @contextmanager
+    def fake_autocast(device_type, dtype=None, enabled=True):
+        entered.append(("autocast", device_type, dtype, enabled))
+        yield
+
+    monkeypatch.setattr(torch.cuda, "device", fake_device)
+    monkeypatch.setattr(torch.amp, "autocast", fake_autocast)
+    policy = Float8TransformerEnginePolicy(fp8_fallback_dtype="fp32")
+    policy._target_device = torch.device("cuda", 0)
+    monkeypatch.setattr(
+        policy, "_te_autocast_context", lambda _group=None: nullcontext()
+    )
+
+    with policy.autocast_context():
+        pass
+
+    assert entered == [
+        ("device", "cuda:0"),
+        ("autocast", "cuda", None, False),
+    ]
 
 
 def test_transformer_engine_sdpa_adapter_accepts_flattened_te_output(monkeypatch):

--- a/test/activation_based/test_precision_conversion.py
+++ b/test/activation_based/test_precision_conversion.py
@@ -920,6 +920,15 @@ def test_float8_policy_nests_default_cuda_autocast(monkeypatch):
     ]
 
 
+def test_float8_policy_rejects_invalid_fallback_dtype():
+    from spikingjelly.activation_based.precision.float8_te import (
+        Float8TransformerEnginePolicy,
+    )
+
+    with pytest.raises(ValueError, match="Unsupported fp8_fallback_dtype"):
+        Float8TransformerEnginePolicy(fp8_fallback_dtype="int8")
+
+
 def test_transformer_engine_sdpa_adapter_accepts_flattened_te_output(monkeypatch):
     _install_fake_te(monkeypatch)
     adapter = TransformerEngineDotProductAttentionAdapter(

--- a/test/activation_based/test_precision_conversion.py
+++ b/test/activation_based/test_precision_conversion.py
@@ -1,4 +1,5 @@
 import copy
+from contextlib import contextmanager, nullcontext
 import sys
 import types
 
@@ -883,6 +884,40 @@ def test_transformer_engine_sdpa_adapter_matches_torch_sdpa(monkeypatch):
     out = adapter(query, key, value)
     assert out.shape == query.shape
     torch.testing.assert_close(out, expected)
+
+
+def test_float8_policy_nests_default_cuda_autocast(monkeypatch):
+    from spikingjelly.activation_based.precision.float8_te import (
+        Float8TransformerEnginePolicy,
+    )
+
+    entered = []
+
+    @contextmanager
+    def fake_device(device):
+        entered.append(("device", str(device)))
+        yield
+
+    @contextmanager
+    def fake_autocast(device_type, dtype):
+        entered.append(("autocast", device_type, dtype))
+        yield
+
+    monkeypatch.setattr(torch.cuda, "device", fake_device)
+    monkeypatch.setattr(torch.amp, "autocast", fake_autocast)
+    policy = Float8TransformerEnginePolicy()
+    policy._target_device = torch.device("cuda", 0)
+    monkeypatch.setattr(
+        policy, "_te_autocast_context", lambda _group=None: nullcontext()
+    )
+
+    with policy.autocast_context():
+        pass
+
+    assert entered == [
+        ("device", "cuda:0"),
+        ("autocast", "cuda", torch.bfloat16),
+    ]
 
 
 def test_transformer_engine_sdpa_adapter_accepts_flattened_te_output(monkeypatch):

--- a/test/activation_based/test_precision_core.py
+++ b/test/activation_based/test_precision_core.py
@@ -46,6 +46,10 @@ def test_precision_config_normalizes_triton_fields():
         ({"mode": "fp8-te"}, "mode"),
         ({"mode": "fp8-torchao"}, "mode"),
         ({"mode": "bf16", "fp8_recipe": "delayed"}, "fp8_recipe"),
+        (
+            {"mode": "bf16", "fp8_fallback_dtype": "fp16"},
+            "mode='fp8'",
+        ),
         ({"triton_fwd": "bf16"}, "triton_storage"),
         (
             {"triton_storage": "bf16", "triton_bwd": "fp8"},
@@ -63,6 +67,20 @@ def test_precision_config_from_dict_rejects_removed_fields():
         PrecisionConfig.from_any({"mode": "fp32", "strictness": "warn"})
     with pytest.raises(TypeError, match="unexpected keyword"):
         PrecisionConfig.from_any({"mode": "fp32", "device": "cpu"})
+    with pytest.raises(TypeError, match="unexpected keyword"):
+        PrecisionConfig.from_any({"mode": "fp8", "fp8_autocast_dtype": "bf16"})
+
+
+def test_precision_config_defaults_to_bf16_fallback():
+    config = PrecisionConfig(mode="fp8")
+
+    assert config.fp8_fallback_dtype == "bf16"
+
+
+def test_precision_config_accepts_fp8_fallback_override():
+    config = PrecisionConfig(mode="fp8", fp8_fallback_dtype="fp16")
+
+    assert config.fp8_fallback_dtype == "fp16"
 
 
 def test_prepare_fp32_returns_public_artifacts():

--- a/test/activation_based/test_precision_core.py
+++ b/test/activation_based/test_precision_core.py
@@ -77,6 +77,16 @@ def test_precision_config_defaults_to_bf16_fallback():
     assert config.fp8_fallback_dtype == "bf16"
 
 
+def test_precision_config_preserves_positional_fields():
+    config = PrecisionConfig("fp8", "auto", "bf16", "fp16", "bf16")
+
+    assert (config.triton_storage, config.triton_fwd, config.triton_bwd) == (
+        "bf16",
+        "fp16",
+        "bf16",
+    )
+
+
 def test_precision_config_accepts_fp8_fallback_override():
     config = PrecisionConfig(mode="fp8", fp8_fallback_dtype="fp16")
 

--- a/test/activation_based/test_precision_fp8_hardware.py
+++ b/test/activation_based/test_precision_fp8_hardware.py
@@ -367,7 +367,8 @@ def test_fp8_backend_snn_boundary_spike_mismatch_is_bounded():
     assert mismatch_ratio <= 0.01
 
 
-def test_tiny_spikformer_fp8_trains_and_runs_inference():
+@pytest.mark.parametrize("fp8_fallback_dtype", ["fp32", "fp16", "bf16"])
+def test_tiny_spikformer_fp8_trains_and_runs_inference(fp8_fallback_dtype):
     mode = "fp8"
     device = _cuda_device_or_skip(mode)
     torch.manual_seed(20260719)
@@ -387,7 +388,7 @@ def test_tiny_spikformer_fp8_trains_and_runs_inference():
     artifacts = prepare_model_for_precision(
         model,
         device,
-        PrecisionConfig(mode=mode),
+        PrecisionConfig(mode=mode, fp8_fallback_dtype=fp8_fallback_dtype),
     )
     assert artifacts.config.mode == mode
     model = artifacts.model


### PR DESCRIPTION
## Summary
- Add end-to-end FP8 precision controls for FC-SNN and single-GPU SNN benchmarks.
- Use BF16 as the default FP8 fallback dtype, with explicit FP16/FP32 overrides.
- Add weighted requested FP8 dense-MAC coverage and bounded NVTX/CUDA profiler capture.
- Document FC-SNN and Spikformer results, bottlenecks, and reproducible nsys commands.
- Keep benchmark helpers private and record profile tensor metadata once per module.

## Validation
- `uv run --active --no-sync pytest -q`: 1498 passed, 384 skipped, 29 warnings.
- Ruff check and format check passed.
- `python tools/generate_changelog_rst.py --check` passed.
- Sphinx HTML build passed.

## Scope notes
- Coverage is explicitly reported as requested dense-MAC coverage; nsys remains the authority for actual FP8 kernel execution.
- The current RTX 5090 stack has no usable FP8 Conv2d or FP8 DPA backend, so no emulated coverage claim is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable FP8 fallback precision, defaulting to BF16, with FP16 and FP32 options.
  * Expanded precision benchmarks with selectable neuron backends, FP8 recipes, profiling, NVTX tracing, and coverage reporting.
  * Added FP8 coverage metrics for fused and supported layers.

* **Documentation**
  * Updated English and Chinese precision guides with fallback configuration, benchmark results, and mode-selection recommendations.

* **Tests**
  * Added coverage for fallback validation, profiling metadata, NVTX tracing, and FP8 execution metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->