### PR TITLE
Move tensor reset values with the module in MemoryModule._apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ For older releases, see the historical fatal-bug record in
 [bugs.md](https://github.com/fangwei123456/spikingjelly/blob/master/bugs.md)
 and the archived documentation linked from the project README.
 
+## Unreleased
+
+### Improvements
+
+#### Stateful Modules
+
+Module: `spikingjelly.activation_based.base`.
+
+- Fixed `MemoryModule` tensor reset values to follow module device and dtype
+  conversions, so `reset()` no longer restores tensors on the previous device or
+  with the previous dtype.
+
 ## 2.0.0rc1 - 2026-08-29
 
 ### Features
@@ -77,14 +89,6 @@ Module: `spikingjelly.activation_based.op_counter`.
   one memory access.
 
 ### Improvements
-
-#### Stateful Modules
-
-Module: `spikingjelly.activation_based.base`.
-
-- Fixed `MemoryModule` tensor reset values to follow module device and dtype
-  conversions, so `reset()` no longer restores tensors on the previous device or
-  with the previous dtype.
 
 #### Monitoring
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,14 @@ Module: `spikingjelly.activation_based.op_counter`.
 
 ### Improvements
 
+#### Stateful Modules
+
+Module: `spikingjelly.activation_based.base`.
+
+- Fixed `MemoryModule` tensor reset values to follow module device and dtype
+  conversions, so `reset()` no longer restores tensors on the previous device or
+  with the previous dtype.
+
 #### Monitoring
 
 Module: `spikingjelly.activation_based.monitor`.

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -91,6 +91,15 @@ Module: ``spikingjelly.activation_based.op_counter``.
 Improvements
 ~~~~~~~~~~~~
 
+Stateful Modules
+^^^^^^^^^^^^^^^^
+
+Module: ``spikingjelly.activation_based.base``.
+
+- Fixed ``MemoryModule`` tensor reset values to follow module device and dtype
+  conversions, so ``reset()`` no longer restores tensors on the previous device or
+  with the previous dtype.
+
 Monitoring
 ^^^^^^^^^^
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,6 +12,21 @@ For older releases, see the historical fatal-bug record in
 `bugs.md <https://github.com/fangwei123456/spikingjelly/blob/master/bugs.md>`__
 and the archived documentation linked from the project README.
 
+Unreleased
+----------
+
+Improvements
+~~~~~~~~~~~~
+
+Stateful Modules
+^^^^^^^^^^^^^^^^
+
+Module: ``spikingjelly.activation_based.base``.
+
+- Fixed ``MemoryModule`` tensor reset values to follow module device and dtype
+  conversions, so ``reset()`` no longer restores tensors on the previous device or
+  with the previous dtype.
+
 2.0.0rc1 - 2026-08-29
 ---------------------
 
@@ -90,15 +105,6 @@ Module: ``spikingjelly.activation_based.op_counter``.
 
 Improvements
 ~~~~~~~~~~~~
-
-Stateful Modules
-^^^^^^^^^^^^^^^^
-
-Module: ``spikingjelly.activation_based.base``.
-
-- Fixed ``MemoryModule`` tensor reset values to follow module device and dtype
-  conversions, so ``reset()`` no longer restores tensors on the previous device or
-  with the previous dtype.
 
 Monitoring
 ^^^^^^^^^^

--- a/spikingjelly/activation_based/base.py
+++ b/spikingjelly/activation_based/base.py
@@ -1117,6 +1117,12 @@ class MemoryModule(nn.Module, StepModule):
         for key, value in self._memories.items():
             if isinstance(value, torch.Tensor):
                 self._memories[key] = fn(value)
+        # Move tensor reset values with the module as well; otherwise
+        # .to()/.cuda()/.half() would leave them on the old device/dtype
+        # and the next reset() would restore the state there.
+        for key, value in self._memories_rv.items():
+            if isinstance(value, torch.Tensor):
+                self._memories_rv[key] = fn(value)
         return super()._apply(fn)
 
     def _replicate_for_data_parallel(self):

--- a/test/activation_based/test_memory.py
+++ b/test/activation_based/test_memory.py
@@ -558,3 +558,45 @@ def test_to_functional_forward_fallback_restores_state_after_error():
         functional_forward((torch.tensor(1.0),), (torch.tensor(3.0),))
 
     torch.testing.assert_close(module.state, torch.tensor(7.0))
+
+
+def test_apply_moves_tensor_reset_values_dtype():
+    """.half()/.double() must move tensor reset values too, so a later
+    reset() restores the state in the module's current dtype rather than
+    the dtype the reset value had when it was registered."""
+
+    class Node(base.MemoryModule):
+        def __init__(self):
+            super().__init__()
+            self.register_memory("s", torch.zeros(4))
+
+        def single_step_forward(self, x):
+            self.s = self.s + x
+            return self.s
+
+    net = Node().double()
+    net.reset()
+    assert net.s.dtype == torch.float64
+
+    net = Node()
+    net.set_reset_value("s", torch.zeros(4))
+    net.half()
+    net.reset()
+    assert net.s.dtype == torch.float16
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_apply_moves_tensor_reset_values_device():
+    class Node(base.MemoryModule):
+        def __init__(self):
+            super().__init__()
+            self.register_memory("s", torch.zeros(4))
+
+        def single_step_forward(self, x):
+            self.s = self.s + x
+            return self.s
+
+    net = Node().cuda()
+    net.reset()
+    assert net.s.is_cuda
+    net(torch.ones(4, device="cuda"))  # no cross-device RuntimeError


### PR DESCRIPTION
## What

`MemoryModule._apply()` moves every tensor in `self._memories` when the module is
cast with `.to()` / `.cuda()` / `.half()` / `.float()`, but it does **not** move
the tensor reset values in `self._memories_rv`. A later `reset()` then restores
the state from a reset value that is still on the module's *old* device/dtype.

Result:

- `.cuda()` (or `.to(device)`) then `reset()` → state comes back on CPU → the next
  forward raises `RuntimeError: Expected all tensors to be on the same device`.
- `.half()` / `.double()` then `reset()` → state comes back in the old dtype → a
  silent up/down-cast on the next forward (defeats AMP / breaks double-precision
  pipelines).

Only reset values that are **tensors** are affected — the common scalar
(`0.` / `None`) case is unchanged.

## Reproduce (no CUDA needed)

```python
import torch
from spikingjelly.activation_based import base

class Node(base.MemoryModule):
    def __init__(self):
        super().__init__()
        self.register_memory("s", torch.zeros(4))
    def single_step_forward(self, x):
        self.s = self.s + x
        return self.s

net = Node().double()
net.reset()
print(net.s.dtype)          # master: torch.float32   (want float64)
```

```
### Before (master)
  Node().double().reset()  ->  state dtype: torch.float32
  Node().cuda().reset()    ->  state device: cpu
  forward on cuda          ->  RuntimeError: Expected all tensors to be on the same device ...

### After (this PR)
  Node().double().reset()  ->  state dtype: torch.float64
  Node().cuda().reset()    ->  state device: cuda:0
  forward on cuda          ->  OK
```

## Fix

`_apply()` now applies `fn` to the tensor values in `_memories_rv` as well, using
the same `isinstance(value, torch.Tensor)` guard, so scalar / `None` reset values
(and the scalar-sentinel semantics `reset()` relies on) are untouched.

```diff
     def _apply(self, fn):
         for key, value in self._memories.items():
             if isinstance(value, torch.Tensor):
                 self._memories[key] = fn(value)
+        # Move tensor reset values with the module as well; otherwise
+        # .to()/.cuda()/.half() would leave them on the old device/dtype
+        # and the next reset() would restore the state there.
+        for key, value in self._memories_rv.items():
+            if isinstance(value, torch.Tensor):
+                self._memories_rv[key] = fn(value)
         return super()._apply(fn)
```

## Tests

Adds to `test/activation_based/test_memory.py`:

- `test_apply_moves_tensor_reset_values_dtype` — `.double()` / `.half()` then
  `reset()` keeps the module's dtype. **Fails on master, passes with this change.**
- `test_apply_moves_tensor_reset_values_device` — CUDA-gated device version.

`pytest test/activation_based/test_memory.py -q` → all pass. `ruff format --check`
and `ruff check` clean on the changed files.

*(Developed with AI assistance; I reproduced the bug, verified the fix and the
regression against `master`, and reviewed every line.)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tensor reset values now follow module dtype and device conversions, ensuring state resets correctly after operations such as `half()`, `double()`, or `cuda()`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->