### PR TITLE
Fix DSpike search network: remove .cuda() hardcoding and fix surrogate regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and the archived documentation linked from the project README.
 
 ### Improvements
 
+#### DSpike Search Network
+
+Module: `spikingjelly.activation_based.model.spike_dhs`.
+
+- Restored `DSpike` construction after the surrogate-function base API change.
+- Made DGS search parameters follow the module device and dtype across
+  construction, conversion, and stage initialization.
+
 #### Stateful Modules
 
 Module: `spikingjelly.activation_based.base`.

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -18,6 +18,15 @@ Unreleased
 Improvements
 ~~~~~~~~~~~~
 
+DSpike Search Network
+^^^^^^^^^^^^^^^^^^^^^
+
+Module: ``spikingjelly.activation_based.model.spike_dhs``.
+
+- Restored ``DSpike`` construction after the surrogate-function base API change.
+- Made DGS search parameters follow the module device and dtype across
+  construction, conversion, and stage initialization.
+
 Stateful Modules
 ^^^^^^^^^^^^^^^^
 

--- a/spikingjelly/activation_based/model/spike_dhs.py
+++ b/spikingjelly/activation_based/model/spike_dhs.py
@@ -135,7 +135,7 @@ class DSpike(SurrogateFunctionBase):
 
         DSpike surrogate gradient function.
         """
-        super().__init__(alpha, spiking)
+        super().__init__(spiking=spiking, alpha=alpha)
         assert alpha > 0, "alpha must be lager than 0."
 
     @staticmethod
@@ -348,7 +348,9 @@ class SearchSpikingConv2d_stem(nn.Module):
 
         self.is_DGS = False
 
-        self.dgs_alpha = nn.Parameter(1e-3 * torch.ones(3).cuda(), requires_grad=True)
+        self.dgs_alpha = nn.Parameter(
+            1e-3 * torch.ones(3, device=self.conv_m.weight.device), requires_grad=True
+        )
         self.dgs_step = 0.2
 
     def dgs_init_stage(self):
@@ -366,7 +368,9 @@ class SearchSpikingConv2d_stem(nn.Module):
             self.spike_m.surrogate_function.alpha + self.dgs_step
         )
 
-        self.dgs_alpha = nn.Parameter(1e-3 * torch.ones(3).cuda(), requires_grad=True)
+        self.dgs_alpha = nn.Parameter(
+            1e-3 * torch.ones(3, device=self.conv_m.weight.device), requires_grad=True
+        )
 
         for value in self.parameters():
             value.requires_grad_(True)
@@ -459,7 +463,9 @@ class SearchSpikingConv2d_cell(nn.Module):
 
         self.is_DGS = False
 
-        self.dgs_alpha = nn.Parameter(1e-3 * torch.ones(3).cuda(), requires_grad=True)
+        self.dgs_alpha = nn.Parameter(
+            1e-3 * torch.ones(3, device=self.conv1_m.weight.device), requires_grad=True
+        )
         self.dgs_step = 0.2
 
     def dgs_init_stage(self):
@@ -483,7 +489,9 @@ class SearchSpikingConv2d_cell(nn.Module):
             self.spike_m.surrogate_function.alpha + self.dgs_step
         )
 
-        self.dgs_alpha = nn.Parameter(1e-3 * torch.ones(3).cuda(), requires_grad=True)
+        self.dgs_alpha = nn.Parameter(
+            1e-3 * torch.ones(3, device=self.conv1_m.weight.device), requires_grad=True
+        )
 
         for value in self.parameters():
             value.requires_grad_(True)

--- a/spikingjelly/activation_based/model/spike_dhs.py
+++ b/spikingjelly/activation_based/model/spike_dhs.py
@@ -348,9 +348,7 @@ class SearchSpikingConv2d_stem(nn.Module):
 
         self.is_DGS = False
 
-        self.dgs_alpha = nn.Parameter(
-            1e-3 * torch.ones(3, device=self.conv_m.weight.device), requires_grad=True
-        )
+        self.dgs_alpha = nn.Parameter(self.conv_m.weight.new_full((3,), 1e-3))
         self.dgs_step = 0.2
 
     def dgs_init_stage(self):
@@ -368,9 +366,8 @@ class SearchSpikingConv2d_stem(nn.Module):
             self.spike_m.surrogate_function.alpha + self.dgs_step
         )
 
-        self.dgs_alpha = nn.Parameter(
-            1e-3 * torch.ones(3, device=self.conv_m.weight.device), requires_grad=True
-        )
+        with torch.no_grad():
+            self.dgs_alpha.fill_(1e-3)
 
         for value in self.parameters():
             value.requires_grad_(True)
@@ -463,9 +460,7 @@ class SearchSpikingConv2d_cell(nn.Module):
 
         self.is_DGS = False
 
-        self.dgs_alpha = nn.Parameter(
-            1e-3 * torch.ones(3, device=self.conv1_m.weight.device), requires_grad=True
-        )
+        self.dgs_alpha = nn.Parameter(self.conv1_m.weight.new_full((3,), 1e-3))
         self.dgs_step = 0.2
 
     def dgs_init_stage(self):
@@ -489,9 +484,8 @@ class SearchSpikingConv2d_cell(nn.Module):
             self.spike_m.surrogate_function.alpha + self.dgs_step
         )
 
-        self.dgs_alpha = nn.Parameter(
-            1e-3 * torch.ones(3, device=self.conv1_m.weight.device), requires_grad=True
-        )
+        with torch.no_grad():
+            self.dgs_alpha.fill_(1e-3)
 
         for value in self.parameters():
             value.requires_grad_(True)


### PR DESCRIPTION
## Problem

`SearchSpikingConv2d_stem` and `SearchSpikingConv2d_cell` (in `spike_dhs.py`) create the learnable `dgs_alpha` parameter with `torch.ones(3).cuda()`, which:

1. Hardcodes the CUDA backend — crashes on any non-CUDA accelerator (Ascend NPU, Apple MPS, CPU-only builds) with `AssertionError: Torch not compiled with CUDA enabled`.
2. Breaks `model.double()`/dtype preservation since the parameter is forced to CUDA with default float32 regardless of the module's device.

Additionally, `DSpike.__init__` calls `super().__init__(alpha, spiking)` positionally, but `SurrogateFunctionBase` (refactored in PR #743) now has the signature `__init__(self, spiking=True, **kwargs)`. This raises:
```
TypeError: SurrogateFunctionBase.__init__() takes from 1 to 2 positional arguments but 3 were given
```
making the module uninstantiable even on CPU.

## Root Cause

- `.cuda()` hardcodes CUDA-specific device assignment.
- `super().__init__(alpha, spiking)` passes alpha as a positional argument to a base that no longer accepts it positionally.

## Fix

1. **Device-agnostic parameter creation**: Replace `torch.ones(3).cuda()` with `torch.ones(3, device=self.conv_m.weight.device)` (or `self.conv1_m.weight.device` for the cell class). The parameter now follows the module's device (CPU, CUDA, NPU, MPS, ...).

2. **Surrogate call fix**: Change `super().__init__(alpha, spiking)` to `super().__init__(spiking=spiking, alpha=alpha)` so alpha is passed as keyword argument accepted by the base class.

## Verification

Tested on Ascend NPU (torch_npu, CUDA unavailable):
- `torch.cuda.is_available() == False`, `.cuda()` raises `AssertionError: Torch not compiled with CUDA enabled`
- After fix, both `SearchSpikingConv2d_stem` and `SearchSpikingConv2d_cell` instantiate on NPU with `dgs_alpha.device == npu:0`
- `forward()` produces correct output shape `[2, 16, 32, 32]`
- `dgs_init_stage()` correctly re-creates the parameter on the NPU device
- CPU-only instantiation also works (the old code would crash without CUDA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored construction of DSpike search networks.
  * Improved compatibility for configurable spiking activation parameters.
  * Ensured convolution search parameters preserve the device and data type of their associated layer weights during construction, conversion, and reinitialization.

* **Documentation**
  * Added changelog entries describing DSpike search network support and device/data type consistency improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->