### PR TITLE
perf(distributed): overlap vision inference and checkpoint I/O

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,23 @@ Module: `spikingjelly.activation_based.base`.
   conversions, so `reset()` no longer restores tensors on the previous device or
   with the previous dtype.
 
+#### Distributed Training
+
+Module: `spikingjelly.activation_based.distributed.vision`.
+
+- Vision training now stages checkpoints on the writer rank and overlaps their
+  filesystem upload with subsequent work, while bounding each writer to one
+  in-flight checkpoint and reporting failures before the next save or return.
+
+#### Distributed Inference
+
+Module: `spikingjelly.activation_based.distributed.vision`.
+
+- Removed per-batch CUDA synchronization from Vision evaluation and prediction;
+  evaluation timing now uses CUDA events and padding is filtered on the CPU.
+- Vision prediction now uses bounded pinned-memory transfers and a background
+  HDF5 shard writer to overlap output work where execution dependencies allow.
+
 ## 2.0.0rc1 - 2026-08-29
 
 ### Features

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -27,6 +27,25 @@ Module: ``spikingjelly.activation_based.base``.
   conversions, so ``reset()`` no longer restores tensors on the previous device or
   with the previous dtype.
 
+Distributed Training
+^^^^^^^^^^^^^^^^^^^^
+
+Module: ``spikingjelly.activation_based.distributed.vision``.
+
+- Vision training now stages checkpoints on the writer rank and overlaps their
+  filesystem upload with subsequent work, while bounding each writer to one
+  in-flight checkpoint and reporting failures before the next save or return.
+
+Distributed Inference
+^^^^^^^^^^^^^^^^^^^^^
+
+Module: ``spikingjelly.activation_based.distributed.vision``.
+
+- Removed per-batch CUDA synchronization from Vision evaluation and prediction;
+  evaluation timing now uses CUDA events and padding is filtered on the CPU.
+- Vision prediction now uses bounded pinned-memory transfers and a background
+  HDF5 shard writer to overlap output work where execution dependencies allow.
+
 2.0.0rc1 - 2026-08-29
 ---------------------
 

--- a/spikingjelly/activation_based/distributed/vision/inference.py
+++ b/spikingjelly/activation_based/distributed/vision/inference.py
@@ -4,7 +4,8 @@ import functools
 import importlib
 import json
 import os
-import time
+from collections import deque
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any, Literal, Optional
@@ -69,11 +70,11 @@ def _load_checkpoint_model(
     set_model_state_dict(model, state["model"], options=options)
 
 
-def _sync_rank_zero_error(
+def _sync_error(
     error: Optional[BaseException], device: torch.device, message: str
 ) -> None:
     failed = torch.tensor(int(error is not None), dtype=torch.uint8, device=device)
-    dist.broadcast(failed, src=0)
+    dist.all_reduce(failed)
     if failed.item():
         if error is not None:
             raise error
@@ -198,9 +199,7 @@ def export_inference_artifact(checkpoint: Path, output: Path) -> None:
                 error = exception
                 if temporary.exists():
                     temporary.unlink()
-        _sync_rank_zero_error(
-            error, device, "Rank 0 could not export the inference artifact."
-        )
+        _sync_error(error, device, "Rank 0 could not export the inference artifact.")
         dist.barrier()
     finally:
         if initialized_here and dist.is_initialized():
@@ -257,6 +256,15 @@ class _IndexedDataset(Dataset):
         else:
             image, target, has_target = item, -1, False
         return image, target, source_index, valid, has_target
+
+
+def _valid_indices(
+    valid: torch.Tensor, has_target: Optional[torch.Tensor] = None
+) -> torch.Tensor:
+    selected = valid.to(torch.bool)
+    if has_target is not None:
+        selected = selected & has_target.to(torch.bool)
+    return selected.nonzero().flatten()
 
 
 def _build_loader(
@@ -316,6 +324,103 @@ def _append_predictions(
         handle[name].resize(tuple(shape))
     handle["index"][start:end] = indices.numpy()
     handle["logits"][start:end] = logits.float().numpy()
+
+
+class _PredictionWriter:
+    def __init__(
+        self,
+        path: Path,
+        *,
+        device: torch.device,
+        batch_size: int,
+        num_classes: int,
+        reuse_output: bool,
+    ) -> None:
+        self._path = path
+        self._num_classes = num_classes
+        self._reuse_output = reuse_output
+        self._copy_stream = torch.cuda.Stream(device=device)
+        # A slot is reusable only after the future consuming its buffer completes.
+        self._buffer_slots = deque(
+            (
+                None,
+                torch.empty(
+                    batch_size,
+                    num_classes,
+                    device="cpu",
+                    dtype=torch.float32,
+                    pin_memory=True,
+                ),
+            )
+            for _ in range(2)
+        )
+        self._executor = ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="spikingjelly-prediction"
+        )
+        self._handle = None
+        self._closed = False
+
+    def _write(
+        self,
+        completed: torch.cuda.Event,
+        indices: torch.Tensor,
+        logits: torch.Tensor,
+    ) -> None:
+        if self._handle is None:
+            self._handle = _open_prediction_shard(self._path, self._num_classes)
+        completed.synchronize()
+        _append_predictions(self._handle, indices, logits)
+
+    def submit(self, indices: torch.Tensor, logits: torch.Tensor) -> None:
+        if not logits.shape[0]:
+            return
+        finished, buffer = self._buffer_slots.popleft()
+        if finished is not None:
+            finished.result()
+        source = logits.detach().float()
+        target = buffer[: source.shape[0]]
+        current_stream = torch.cuda.current_stream(source.device)
+        self._copy_stream.wait_stream(current_stream)
+        with torch.cuda.stream(self._copy_stream):
+            target.copy_(source, non_blocking=True)
+            completed = torch.cuda.Event()
+            completed.record()
+            source.record_stream(self._copy_stream)
+        if self._reuse_output:
+            # CUDA Graph replay overwrites its static output buffer.
+            current_stream.wait_stream(self._copy_stream)
+        future = self._executor.submit(
+            self._write, completed, indices.detach().clone(), target
+        )
+        self._buffer_slots.append((future, buffer))
+
+    def _close(self) -> None:
+        if self._handle is None:
+            self._handle = _open_prediction_shard(self._path, self._num_classes)
+        self._handle.close()
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        error = None
+        for future, _ in self._buffer_slots:
+            if future is None:
+                continue
+            try:
+                future.result()
+            except BaseException as exception:
+                if error is None:
+                    error = exception
+        try:
+            self._executor.submit(self._close).result()
+        except BaseException as exception:
+            if error is None:
+                error = exception
+        finally:
+            self._executor.shutdown(wait=True)
+        if error is not None:
+            raise error
 
 
 def _merge_prediction_shards(
@@ -453,7 +558,7 @@ def _run_classification(
     initialized_here = not dist.is_initialized()
     if initialized_here:
         dist.init_process_group("nccl", device_id=device)
-    prediction_shard = None
+    prediction_writer = None
     shard_path = None
     try:
         world_size = dist.get_world_size()
@@ -573,8 +678,12 @@ def _run_classification(
             shard_path = output.with_name(f".{output.name}.rank-{rank:05d}.h5")
             if shard_path.exists():
                 raise FileExistsError(f"Prediction shard already exists: {shard_path}")
-            prediction_shard = _open_prediction_shard(
-                shard_path, model_config.num_classes
+            prediction_writer = _PredictionWriter(
+                shard_path,
+                device=device,
+                batch_size=config.batch_size,
+                num_classes=model_config.num_classes,
+                reuse_output=config.execution_mode == "cuda_graph",
             )
 
         def execute_model(images: torch.Tensor) -> torch.Tensor:
@@ -637,39 +746,65 @@ def _run_classification(
             torch.cuda.reset_peak_memory_stats(device)
         dist.barrier()
         elapsed_seconds = 0.0
+        timing_events = []
         with torch.inference_mode():
             for batch in loader:
-                batch_started = time.perf_counter() if evaluate else 0.0
+                if evaluate:
+                    batch_started = torch.cuda.Event(enable_timing=True)
+                    batch_started.record()
                 logits, targets, indices, valid, has_target = forward_batch(batch)
                 if output_rank:
-                    valid_device = valid.to(device=device, dtype=torch.bool)
                     if evaluate:
-                        target_device = has_target.to(device=device, dtype=torch.bool)
-                        selected = valid_device & target_device
-                        if selected.any():
-                            count = selected.sum()
-                            loss = loss_function(logits[selected], targets[selected])
+                        selected_cpu = _valid_indices(valid, has_target)
+                        count = selected_cpu.numel()
+                        if count:
+                            if count == valid.numel():
+                                selected_logits = logits
+                                selected_targets = targets
+                            else:
+                                selected = selected_cpu.to(device)
+                                selected_logits = logits.index_select(0, selected)
+                                selected_targets = targets.index_select(0, selected)
+                            loss = loss_function(selected_logits, selected_targets)
                             totals[0] += loss.double() * count
                             totals[1] += (
-                                logits[selected].argmax(1) == targets[selected]
+                                selected_logits.argmax(1) == selected_targets
                             ).sum()
                             totals[2] += count
-                    if prediction_shard is not None:
-                        selected_cpu = valid.to(torch.bool)
-                        _append_predictions(
-                            prediction_shard,
-                            indices[selected_cpu],
-                            logits[selected_cpu.to(device)].detach().float().cpu(),
+                    if prediction_writer is not None:
+                        selected_cpu = _valid_indices(valid)
+                        selected_logits = (
+                            logits
+                            if selected_cpu.numel() == valid.numel()
+                            else logits.index_select(0, selected_cpu.to(device))
                         )
-                torch.cuda.synchronize(device)
+                        prediction_writer.submit(
+                            indices[selected_cpu],
+                            selected_logits,
+                        )
                 if evaluate:
-                    elapsed_seconds += time.perf_counter() - batch_started
-        if prediction_shard is not None:
-            prediction_shard.close()
-            prediction_shard = None
-
+                    batch_finished = torch.cuda.Event(enable_timing=True)
+                    batch_finished.record()
+                    timing_events.append((batch_started, batch_finished))
+        if timing_events:
+            timing_events[-1][1].synchronize()
+            elapsed_seconds = (
+                sum(
+                    started.elapsed_time(finished)
+                    for started, finished in timing_events
+                )
+                / 1000.0
+            )
         if not evaluate:
-            dist.barrier()
+            error = None
+            if prediction_writer is not None:
+                try:
+                    prediction_writer.close()
+                except BaseException as exception:
+                    error = exception
+                prediction_writer = None
+            _sync_error(error, device, "Another rank could not write predictions.")
+
             error = None
             if rank == 0:
                 try:
@@ -700,9 +835,7 @@ def _run_classification(
                     )
                 except BaseException as exception:
                     error = exception
-            _sync_rank_zero_error(
-                error, device, "Rank 0 could not merge prediction shards."
-            )
+            _sync_error(error, device, "Rank 0 could not merge prediction shards.")
             return None
 
         elapsed = torch.tensor(elapsed_seconds, device=device)
@@ -744,8 +877,8 @@ def _run_classification(
             )
         return result
     finally:
-        if prediction_shard is not None:
-            prediction_shard.close()
+        if prediction_writer is not None:
+            prediction_writer.close()
         if shard_path is not None and shard_path.exists():
             shard_path.unlink()
         if initialized_here and dist.is_initialized():
@@ -753,20 +886,43 @@ def _run_classification(
 
 
 def evaluate_classification(config: EvaluationConfig) -> dict[str, float]:
-    r"""Evaluate one distributed vision classification dataset.
+    r"""
+    **API Language** - :ref:`中文 <evaluate_classification-cn>` | :ref:`English <evaluate_classification-en>`
 
-    **中文：** 对 dataset builder 返回的 ``(image, target)`` 数据集计算
-    全局 loss、accuracy 和性能指标。
+    ----
 
-    **English:** Compute global loss, accuracy, and performance metrics for the
-    ``(image, target)`` dataset returned by the configured builder.
+    .. _evaluate_classification-cn:
 
-    :param config: 推理配置。 / Inference configuration.
+    * **中文**
+
+    对 dataset builder 返回的 ``(image, target)`` 数据集计算
+    全局 loss、accuracy 和性能指标。``inference_seconds`` 是各 batch
+    从输入搬运到指标计算结束的 CUDA Event 时间之和，不包含数据加载和最终
+    分布式归约。
+
+    :param config: 推理配置。
     :type config: spikingjelly.activation_based.distributed.vision.EvaluationConfig
-    :return: 全局评测与性能指标。 / Global evaluation and performance metrics.
+    :return: 全局评测与性能指标。
     :rtype: dict[str, float]
-    :raises TypeError: ``config`` 不是 :class:`EvaluationConfig`。 / If ``config``
-        is not :class:`EvaluationConfig`.
+    :raises TypeError: ``config`` 不是 :class:`EvaluationConfig`。
+
+    ----
+
+    .. _evaluate_classification-en:
+
+    * **English**
+
+    Compute global loss, accuracy, and performance metrics for the
+    ``(image, target)`` dataset returned by the configured builder.
+    ``inference_seconds`` sums CUDA Event durations from input transfer through
+    metric computation for each batch; it excludes data loading and final
+    distributed reductions.
+
+    :param config: Inference configuration.
+    :type config: spikingjelly.activation_based.distributed.vision.EvaluationConfig
+    :return: Global evaluation and performance metrics.
+    :rtype: dict[str, float]
+    :raises TypeError: If ``config`` is not :class:`EvaluationConfig`.
     """
     if not isinstance(config, EvaluationConfig):
         raise TypeError("evaluate_classification requires EvaluationConfig.")
@@ -774,24 +930,48 @@ def evaluate_classification(config: EvaluationConfig) -> dict[str, float]:
 
 
 def predict_classification(config: PredictionConfig, output: Path) -> None:
-    r"""Predict one distributed vision dataset and write one ordered HDF5 file.
+    r"""
+    **API Language** - :ref:`中文 <predict_classification-cn>` | :ref:`English <predict_classification-en>`
 
-    **中文：** 按 dataset index 保存 logits。dataset 可以返回 image 或
-    ``(image, target)``；target 被忽略，函数不计算或返回评测指标。填充样本
-    不会写入结果。
+    ----
 
-    **English:** Save logits by dataset index. The dataset may return an image or
-    ``(image, target)``; targets are ignored and no evaluation metrics are
-    computed or returned. Padded samples are excluded.
+    .. _predict_classification-cn:
 
-    :param config: 推理配置。 / Inference configuration.
+    * **中文**
+
+    按 dataset index 保存 logits。dataset 可以返回 image 或
+    ``(image, target)``；target 被忽略，函数不计算或返回评测指标。填充样本不会
+    写入结果。每个输出 rank 使用两个 pinned-memory buffer 和后台 writer；
+    eager/compile 模式将 logits 搬运与 HDF5 写入和下一 batch 重叠；CUDA Graph
+    在复用静态输出前等待搬运完成，但仍会重叠 HDF5 写入。函数返回前会完成全部
+    写入并传播错误。
+
+    :param config: 推理配置。
     :type config: spikingjelly.activation_based.distributed.vision.PredictionConfig
-    :param output: 新 HDF5 文件。 / New HDF5 file.
+    :param output: 新 HDF5 文件。
     :type output: pathlib.Path
-    :return: 无。 / None.
-    :rtype: None
     :raises TypeError: ``config`` 不是 :class:`PredictionConfig`，或是
-        :class:`EvaluationConfig`。 / If ``config`` is not a prediction-only
+        :class:`EvaluationConfig`。
+
+    ----
+
+    .. _predict_classification-en:
+
+    * **English**
+
+    Save logits by dataset index. The dataset may return an image or
+    ``(image, target)``; targets are ignored and no evaluation metrics are
+    computed or returned. Padded samples are excluded. Each output rank uses two
+    pinned-memory buffers and a background writer. Eager/compile execution overlaps
+    logits transfers and HDF5 writes with the next batch; CUDA Graph waits for the
+    transfer before reusing static output but still overlaps the HDF5 write. All
+    writes finish and errors propagate before the function returns.
+
+    :param config: Inference configuration.
+    :type config: spikingjelly.activation_based.distributed.vision.PredictionConfig
+    :param output: New HDF5 file.
+    :type output: pathlib.Path
+    :raises TypeError: If ``config`` is not a prediction-only
         :class:`PredictionConfig`.
     """
     if not isinstance(config, PredictionConfig) or isinstance(config, EvaluationConfig):

--- a/spikingjelly/activation_based/distributed/vision/inference.py
+++ b/spikingjelly/activation_based/distributed/vision/inference.py
@@ -358,6 +358,7 @@ class _PredictionWriter:
             max_workers=1, thread_name_prefix="spikingjelly-prediction"
         )
         self._handle = None
+        self._error = None
         self._closed = False
 
     def _write(
@@ -376,7 +377,11 @@ class _PredictionWriter:
             return
         finished, buffer = self._buffer_slots.popleft()
         if finished is not None:
-            finished.result()
+            try:
+                finished.result()
+            except Exception as exception:
+                if self._error is None:
+                    self._error = exception
         source = logits.detach().float()
         target = buffer[: source.shape[0]]
         current_stream = torch.cuda.current_stream(source.device)
@@ -403,7 +408,7 @@ class _PredictionWriter:
         if self._closed:
             return
         self._closed = True
-        error = None
+        error = self._error
         for future, _ in self._buffer_slots:
             if future is None:
                 continue

--- a/spikingjelly/activation_based/distributed/vision/training.py
+++ b/spikingjelly/activation_based/distributed/vision/training.py
@@ -596,11 +596,12 @@ def train_classification(config: TrainingConfig) -> dict[str, float]:
                 if rank == checkpoint_rank:
                     checkpoint_group = group
                     cleanup.callback(dist.destroy_process_group, group)
-            cleanup.callback(
-                lambda: checkpoint_future.result()
-                if checkpoint_future is not None
-                else None
-            )
+
+            def finish_pending_checkpoint() -> None:
+                if checkpoint_future is not None:
+                    checkpoint_future.result()
+
+            cleanup.callback(finish_pending_checkpoint)
         if dp_size > 1 and config.tensor_parallel_size > 1:
             stage_group = None
             for pipeline_rank in range(config.pipeline_parallel_size):

--- a/spikingjelly/activation_based/distributed/vision/training.py
+++ b/spikingjelly/activation_based/distributed/vision/training.py
@@ -7,6 +7,8 @@ import os
 import random
 import time
 from collections.abc import Callable
+from concurrent.futures import Future
+from contextlib import ExitStack
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any, Optional
@@ -116,7 +118,8 @@ def _save_checkpoint(
     tp_rank: int,
     pp_rank: int,
     dp_rank: int,
-) -> None:
+    process_group: Optional[ProcessGroup] = None,
+) -> Future:
     import torch.distributed.checkpoint as dcp
     from torch.distributed.checkpoint.state_dict import get_state_dict
 
@@ -163,12 +166,30 @@ def _save_checkpoint(
         },
     }
     if dp_rank == 0:
-        dcp.save(
+        future = dcp.async_save(
             state,
             checkpoint_id=path / f"pp_{pp_rank:04d}_tp_{tp_rank:04d}",
-            no_dist=True,
+            process_group=process_group,
         )
+    else:
+        future = Future()
+        future.set_result(None)
     dist.barrier()
+    return future
+
+
+def _finish_checkpoint(future: Future, device: torch.device) -> None:
+    error = None
+    try:
+        future.result()
+    except BaseException as exception:
+        error = exception
+    failed = torch.tensor(int(error is not None), device=device)
+    dist.all_reduce(failed)
+    if failed.item():
+        if error is not None:
+            raise error
+        raise RuntimeError("A distributed checkpoint writer failed.")
 
 
 def _load_checkpoint(
@@ -457,18 +478,43 @@ def build_imagefolder_datasets(
 
 
 def train_classification(config: TrainingConfig) -> dict[str, float]:
-    r"""Train a vision SNN with native PyTorch distributed execution.
+    r"""
+    **API Language** - :ref:`中文 <train_classification-cn>` | :ref:`English <train_classification-en>`
 
-    **API Language** - 中文 | English
+    ----
 
-    **中文：** 从可序列化 config 构建数据和 architecture-specific 模型，初始化
+    .. _train_classification-cn:
+
+    * **中文**
+
+    从可序列化 config 构建数据和 architecture-specific 模型，初始化
     ``DP × PP × TP`` DeviceMesh，使用配置的 loss 函数运行 DDP 或 FSDP2
     图像分类训练。单步模式显式循环 ``T`` 次，多步模式一次处理完整时间序列；
     ``input_layout`` 显式选择静态 ``[N, C, H, W]`` 或 batch-first 时序
     ``[N, T, C, H, W]`` 输入。每个 batch 后重置 SNN 状态。所有 TP rank 使用
     同一个 DP sampler rank。rank 0 在每个 epoch 后输出一行 JSON 训练与验证指标。
+    checkpoint 在 writer rank 上暂存后于后台写入文件系统；每个 writer 最多
+    保留一个在途 checkpoint，并在下一次保存或函数返回前完成写入和传播错误。
+    暂存会在 writer rank 上临时占用约一份 checkpoint 大小的 CPU 内存。
 
-    **English:** Build data and an architecture-specific model from a serializable
+    :param config: 可直接运行的训练配置。
+    :type config: TrainingConfig
+    :return: 最终 loss、accuracy、step、训练 step 吞吐和跨 rank 峰值显存；吞吐
+        不含数据加载、验证与 checkpoint。
+    :rtype: dict[str, float]
+    :raises RuntimeError: CUDA、NCCL、checkpoint 所需的 Gloo 或 FSDP2 不可用。
+    :raises ImportError: 配置的模块无法导入。
+    :raises AttributeError: 配置的导入对象不存在。
+    :raises TypeError: model builder 或 loss 函数无效。
+    :raises ValueError: world size、验证集划分、模型输出、loss 输出或输入布局无效。
+
+    ----
+
+    .. _train_classification-en:
+
+    * **English**
+
+    Build data and an architecture-specific model from a serializable
     config, initialize a ``DP × PP × TP`` DeviceMesh, run DDP or FSDP2 image
     classification with the configured loss function. Single-step mode calls the
     model explicitly for each of ``T`` steps, while multi-step mode processes the
@@ -476,23 +522,24 @@ def train_classification(config: TrainingConfig) -> dict[str, float]:
     ``[N, C, H, W]`` or batch-first temporal ``[N, T, C, H, W]`` input. SNN state
     is reset after every batch. TP peers share the same DP sampler rank. Rank zero
     emits one JSON line of training and validation metrics after every epoch.
+    Checkpoints are staged on each writer rank and uploaded to the filesystem in
+    the background. Each writer keeps at most one checkpoint in flight and finishes
+    it, propagating errors, before the next save or function return. Staging
+    temporarily uses roughly one checkpoint of CPU memory on each writer rank.
 
-    :param config: 可直接运行的训练配置。 / Train-ready configuration.
+    :param config: Train-ready configuration.
     :type config: TrainingConfig
-    :return: 最终 loss、accuracy、step、训练 step 吞吐和跨 rank 峰值显存；吞吐不含
-        数据加载、验证与 checkpoint。 / Final loss, accuracy, step, training-step
-        throughput, and maximum peak memory across ranks; throughput excludes data
-        loading, validation, and checkpointing.
+    :return: Final loss, accuracy, step, training-step throughput, and maximum
+        peak memory across ranks; throughput excludes data loading, validation,
+        and checkpointing.
     :rtype: dict[str, float]
-    :raises RuntimeError: CUDA、NCCL 或 FSDP2 不可用。 / If CUDA, NCCL, or FSDP2 is unavailable.
-    :raises ImportError: 配置的模块无法导入。 / If a configured module cannot be imported.
-    :raises AttributeError: 配置的导入对象不存在。 / If a configured imported object
-        does not exist.
-    :raises TypeError: model builder 或 loss 函数无效。 / If the model builder or
-        loss function is invalid.
-    :raises ValueError: world size、验证集划分、模型输出、loss 输出或输入布局无效。 /
-        If world size, validation partitioning, model output, loss output, or input
-        layout is invalid.
+    :raises RuntimeError: If CUDA, NCCL, Gloo required by checkpointing, or FSDP2
+        is unavailable.
+    :raises ImportError: If a configured module cannot be imported.
+    :raises AttributeError: If a configured import object does not exist.
+    :raises TypeError: If the model builder or loss function is invalid.
+    :raises ValueError: If world size, validation partitioning, model output,
+        loss output, or input layout is invalid.
     """
     if not torch.cuda.is_available():
         raise RuntimeError("Distributed vision training requires CUDA.")
@@ -501,9 +548,13 @@ def train_classification(config: TrainingConfig) -> dict[str, float]:
     torch.cuda.set_device(local_rank)
     device = torch.device("cuda", local_rank)
     initialized_here = not dist.is_initialized()
+    cleanup = ExitStack()
     if initialized_here:
         dist.init_process_group("nccl", device_id=device)
+        cleanup.callback(dist.destroy_process_group)
 
+    checkpoint_future = None
+    checkpoint_group = None
     try:
         world_size = dist.get_world_size()
         rank = dist.get_rank()
@@ -539,6 +590,17 @@ def train_classification(config: TrainingConfig) -> dict[str, float]:
         dp_group = dp_mesh.get_group() if dp_size > 1 else None
         pp_group = pp_mesh.get_group() if config.pipeline_parallel_size > 1 else None
         tp_group = tp_mesh.get_group() if config.tensor_parallel_size > 1 else None
+        if config.checkpoint_interval:
+            for checkpoint_rank in range(model_parallel_size):
+                group = dist.new_group(ranks=[checkpoint_rank], backend="gloo")
+                if rank == checkpoint_rank:
+                    checkpoint_group = group
+                    cleanup.callback(dist.destroy_process_group, group)
+            cleanup.callback(
+                lambda: checkpoint_future.result()
+                if checkpoint_future is not None
+                else None
+            )
         if dp_size > 1 and config.tensor_parallel_size > 1:
             stage_group = None
             for pipeline_rank in range(config.pipeline_parallel_size):
@@ -822,7 +884,9 @@ def train_classification(config: TrainingConfig) -> dict[str, float]:
                     config.checkpoint_interval
                     and global_step % config.checkpoint_interval == 0
                 ):
-                    _save_checkpoint(
+                    if checkpoint_future is not None:
+                        _finish_checkpoint(checkpoint_future, device)
+                    checkpoint_future = _save_checkpoint(
                         config.checkpoint_dir / f"step_{global_step:08d}",
                         device=device,
                         config=config,
@@ -836,6 +900,7 @@ def train_classification(config: TrainingConfig) -> dict[str, float]:
                         tp_rank=tp_rank,
                         pp_rank=pp_rank,
                         dp_rank=dp_rank,
+                        process_group=checkpoint_group,
                     )
                 if config.max_steps is not None and global_step >= config.max_steps:
                     stop = True
@@ -924,6 +989,10 @@ def train_classification(config: TrainingConfig) -> dict[str, float]:
                 )
                 model.train()
 
+        if checkpoint_future is not None:
+            _finish_checkpoint(checkpoint_future, device)
+            checkpoint_future = None
+
         local_metrics = torch.tensor(
             [
                 training_seconds,
@@ -973,5 +1042,4 @@ def train_classification(config: TrainingConfig) -> dict[str, float]:
             )
         return result
     finally:
-        if initialized_here:
-            dist.destroy_process_group()
+        cleanup.close()

--- a/spikingjelly/activation_based/distributed/vision/training.py
+++ b/spikingjelly/activation_based/distributed/vision/training.py
@@ -182,7 +182,7 @@ def _finish_checkpoint(future: Future, device: torch.device) -> None:
     error = None
     try:
         future.result()
-    except BaseException as exception:
+    except Exception as exception:
         error = exception
     failed = torch.tensor(int(error is not None), device=device)
     dist.all_reduce(failed)

--- a/test/activation_based/test_distributed_vision.py
+++ b/test/activation_based/test_distributed_vision.py
@@ -1,6 +1,7 @@
 import json
 import subprocess
 import sys
+from concurrent.futures import Future
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -187,6 +188,60 @@ def test_vision_prediction_writes_only_ordered_outputs(tmp_path):
             predictions["logits"][:],
             [[0.0, 1.0], [1.0, 2.0], [2.0, 3.0]],
         )
+
+
+def test_vision_valid_indices_filter_padding_and_missing_targets():
+    valid = torch.tensor([True, False, True, True])
+    has_target = torch.tensor([True, True, False, True])
+
+    assert torch.equal(inference._valid_indices(valid), torch.tensor([0, 2, 3]))
+    assert torch.equal(
+        inference._valid_indices(valid, has_target), torch.tensor([0, 3])
+    )
+    assert torch.equal(valid, torch.tensor([True, False, True, True]))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_vision_prediction_writer_preserves_submission_order(tmp_path):
+    output = tmp_path / "predictions.h5"
+    writer = inference._PredictionWriter(
+        output,
+        device=torch.device("cuda"),
+        batch_size=2,
+        num_classes=2,
+        reuse_output=False,
+    )
+
+    writer.submit(torch.tensor([2, 0]), torch.tensor([[2.0, 3.0], [0.0, 1.0]]).cuda())
+    writer.submit(torch.tensor([1]), torch.tensor([[1.0, 2.0]]).cuda())
+    writer.close()
+
+    with h5py.File(output, "r") as predictions:
+        np.testing.assert_array_equal(predictions["index"][:], [2, 0, 1])
+        np.testing.assert_array_equal(
+            predictions["logits"][:],
+            [[2.0, 3.0], [0.0, 1.0], [1.0, 2.0]],
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_vision_prediction_writer_propagates_write_errors(tmp_path, monkeypatch):
+    def fail(*_args):
+        raise RuntimeError("write failed")
+
+    writer = inference._PredictionWriter(
+        tmp_path / "predictions.h5",
+        device=torch.device("cuda"),
+        batch_size=1,
+        num_classes=2,
+        reuse_output=False,
+    )
+    monkeypatch.setattr(inference, "_append_predictions", fail)
+
+    writer.submit(torch.tensor([0]), torch.ones(1, 2, device="cuda"))
+
+    with pytest.raises(RuntimeError, match="write failed"):
+        writer.close()
 
 
 def test_vision_prediction_merge_cleans_failed_temporary_file(tmp_path):
@@ -594,26 +649,26 @@ def test_vision_inference_rejects_single_step_pipeline_artifact(monkeypatch):
         inference._run_classification(config, mode="evaluate")
 
 
-def test_vision_rank_zero_error_is_broadcast(monkeypatch):
-    broadcasts = []
+def test_vision_distributed_error_is_reduced(monkeypatch):
+    reductions = []
     monkeypatch.setattr(
         inference.dist,
-        "broadcast",
-        lambda tensor, **_kwargs: broadcasts.append(tensor.item()),
+        "all_reduce",
+        lambda tensor, **_kwargs: reductions.append(tensor.item()),
     )
 
     with pytest.raises(OSError, match="merge failed"):
-        inference._sync_rank_zero_error(
+        inference._sync_error(
             OSError("merge failed"), torch.device("cpu"), "remote failure"
         )
 
-    assert broadcasts == [1]
+    assert reductions == [1]
 
     monkeypatch.setattr(
-        inference.dist, "broadcast", lambda tensor, **_kwargs: tensor.fill_(1)
+        inference.dist, "all_reduce", lambda tensor, **_kwargs: tensor.fill_(1)
     )
     with pytest.raises(RuntimeError, match="remote failure"):
-        inference._sync_rank_zero_error(None, torch.device("cpu"), "remote failure")
+        inference._sync_error(None, torch.device("cpu"), "remote failure")
 
 
 def test_vision_inference_rejects_wrong_config_before_runtime():
@@ -830,7 +885,7 @@ def test_vision_checkpoint_restores_rng(tmp_path, monkeypatch, legacy_precision)
     )
 
     checkpoint = tmp_path / "checkpoint"
-    training._save_checkpoint(
+    future = training._save_checkpoint(
         checkpoint,
         device=torch.device("cpu"),
         config=config,
@@ -845,6 +900,7 @@ def test_vision_checkpoint_restores_rng(tmp_path, monkeypatch, legacy_precision)
         pp_rank=0,
         dp_rank=0,
     )
+    future.result()
     if legacy_precision:
         recipe_path = checkpoint / "config.json"
         recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
@@ -941,6 +997,15 @@ def test_vision_checkpoint_broadcasts_rank_zero_creation_failure(tmp_path, monke
 
     assert broadcasts == [0, 1]
     assert not barrier_called
+
+
+def test_vision_async_checkpoint_propagates_write_failure(monkeypatch):
+    future = Future()
+    future.set_exception(RuntimeError("write failed"))
+    monkeypatch.setattr(torch.distributed, "all_reduce", lambda _tensor: None)
+
+    with pytest.raises(RuntimeError, match="write failed"):
+        training._finish_checkpoint(future, torch.device("cpu"))
 
 
 def test_spikformer_pipeline_keeps_every_transformer_block():

--- a/test/activation_based/test_distributed_vision.py
+++ b/test/activation_based/test_distributed_vision.py
@@ -225,7 +225,9 @@ def test_vision_prediction_writer_preserves_submission_order(tmp_path):
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
-def test_vision_prediction_writer_propagates_write_errors(tmp_path, monkeypatch):
+def test_vision_prediction_writer_defers_write_errors_until_close(
+    tmp_path, monkeypatch
+):
     def fail(*_args):
         raise RuntimeError("write failed")
 
@@ -238,7 +240,8 @@ def test_vision_prediction_writer_propagates_write_errors(tmp_path, monkeypatch)
     )
     monkeypatch.setattr(inference, "_append_predictions", fail)
 
-    writer.submit(torch.tensor([0]), torch.ones(1, 2, device="cuda"))
+    for index in range(3):
+        writer.submit(torch.tensor([index]), torch.ones(1, 2, device="cuda"))
 
     with pytest.raises(RuntimeError, match="write failed"):
         writer.close()
@@ -1006,6 +1009,23 @@ def test_vision_async_checkpoint_propagates_write_failure(monkeypatch):
 
     with pytest.raises(RuntimeError, match="write failed"):
         training._finish_checkpoint(future, torch.device("cpu"))
+
+
+def test_vision_async_checkpoint_does_not_collect_interrupts(monkeypatch):
+    future = Future()
+    future.set_exception(KeyboardInterrupt())
+    all_reduce_called = False
+
+    def all_reduce(_tensor):
+        nonlocal all_reduce_called
+        all_reduce_called = True
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", all_reduce)
+
+    with pytest.raises(KeyboardInterrupt):
+        training._finish_checkpoint(future, torch.device("cpu"))
+
+    assert not all_reduce_called
 
 
 def test_spikformer_pipeline_keeps_every_transformer_block():


### PR DESCRIPTION
## Summary

- remove per-batch CUDA synchronization from Vision evaluation and keep padding metadata on the CPU
- overlap prediction D2H transfers and ordered HDF5 writes with subsequent batches using two bounded pinned buffers
- stage Vision checkpoints on writer ranks and overlap filesystem upload with later training or validation
- propagate prediction-writer and checkpoint-writer failures across ranks before barriers or merge

No public configuration or function signature changes are introduced.

## Performance

- RTX 5090 evaluation process wall time: about 8.8% lower
- RTX 5090 sustained prediction wall time: about 11.1% lower; short runs were neutral
- RTX 4090 checkpoint-enabled training wall time: about 5.6% to 6.6% lower

Copy-stream training input prefetch, CUDA-event training timing, CuPy stream changes, and QCFS reduction changes were tested and omitted because they did not meet the performance gate.

## Validation

- `pytest -q test/activation_based/test_distributed_vision.py`: 64 passed, 2 skipped locally
- same test file on RTX 4090 with PyTorch 2.7.1/CUDA 11.8: 66 passed
- same test file on Vast.ai RTX 4090 with PyTorch 2.11/CUDA 12.8: 66 passed
- baseline/candidate prediction outputs and checkpoint resume results matched
- two-rank Gloo checkpoint writer/non-writer control flow passed
- Ruff, formatting, Change Log generation check, and Sphinx HTML build passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Distributed training checkpoints now upload asynchronously with bounded in-flight saves and clearer failure reporting.
  - Distributed inference reduces unnecessary synchronization during evaluation and prediction.
  - Evaluation timing is more efficient, with padded samples filtered appropriately.
  - Prediction output uses buffered transfers and background shard writing for improved throughput.
  - Distributed errors are surfaced consistently across participating processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->