### PR TITLE
Add RAFNode: resonate-and-fire neuron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and the archived documentation linked from the project README.
 
 ## Unreleased
 
+### Features
+
+#### Spiking Neurons
+
+Module: `spikingjelly.activation_based.neuron`.
+
+- Added the torch-only `RAFNode` resonate-and-fire neuron with fixed oscillator
+  parameters, real-valued states, and single-step and multi-step execution.
+
 ### Improvements
 
 #### Stateful Modules

--- a/docs/source/APIs/spikingjelly.activation_based.functional.rst
+++ b/docs/source/APIs/spikingjelly.activation_based.functional.rst
@@ -113,6 +113,8 @@ remains a ``MemoryModule`` responsibility, so backend-specific functions identif
      - One ParametricLIF state update.
    * - :func:`izhikevich_step <spikingjelly.activation_based.functional.neuron.izhikevich_step>`
      - One Izhikevich voltage and adaptation-current update.
+   * - :func:`raf_step <spikingjelly.activation_based.functional.neuron.raf_step>`
+     - One resonate-and-fire state update.
    * - :func:`klif_step <spikingjelly.activation_based.functional.neuron.klif_step>`
      - One KLIF state update.
    * - :func:`cuba_lif_step <spikingjelly.activation_based.functional.neuron.cuba_lif_step>`

--- a/docs/source/APIs/spikingjelly.activation_based.neuron.research.rst
+++ b/docs/source/APIs/spikingjelly.activation_based.neuron.research.rst
@@ -43,6 +43,15 @@ Nonlinear Integrate-and-fire Neurons
    :show-inheritance:
    :exclude-members: supported_backends, extra_repr
 
+Resonate-and-Fire Neurons
+--------------------------------------------------
+
+.. automodule:: spikingjelly.activation_based.neuron.resonate
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :exclude-members: supported_backends, extra_repr
+
 LIF Variants
 --------------------------------------------------
 

--- a/docs/source/APIs/spikingjelly.activation_based.neuron.rst
+++ b/docs/source/APIs/spikingjelly.activation_based.neuron.rst
@@ -144,6 +144,14 @@ Nonlinear Integrate-and-fire Neurons
    * - :class:`EIFNode <spikingjelly.activation_based.neuron.nonlinear_if.EIFNode>`
      - Exponential Integrate-and-Fire (EIF) neuron.
 
+Resonate-and-Fire Neurons
+--------------------------------------------------
+
+.. list-table::
+
+   * - :class:`RAFNode <spikingjelly.activation_based.neuron.resonate.RAFNode>`
+     - Resonate-and-Fire (RAF) neuron.
+
 LIF Variants
 --------------------------------------------------
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -15,6 +15,17 @@ and the archived documentation linked from the project README.
 Unreleased
 ----------
 
+Features
+~~~~~~~~
+
+Spiking Neurons
+^^^^^^^^^^^^^^^
+
+Module: ``spikingjelly.activation_based.neuron``.
+
+- Added the torch-only ``RAFNode`` resonate-and-fire neuron with fixed oscillator
+  parameters, real-valued states, and single-step and multi-step execution.
+
 Improvements
 ~~~~~~~~~~~~
 

--- a/spikingjelly/activation_based/functional/neuron.py
+++ b/spikingjelly/activation_based/functional/neuron.py
@@ -36,6 +36,7 @@ functions here execute an already selected path.
 
 from __future__ import annotations
 
+import math
 from typing import Callable, Optional
 
 import torch
@@ -52,6 +53,7 @@ __all__ = [
     "ilif_step",
     "plif_step",
     "izhikevich_step",
+    "raf_step",
     "klif_step",
     "cuba_lif_step",
     "if_step_cupy",
@@ -1220,6 +1222,137 @@ def izhikevich_step(
     else:
         v_next = (1.0 - spike_d) * v_charged + spike * v_reset
     return spike, v_next, w_next + b * spike
+
+
+def raf_step(
+    x: torch.Tensor,
+    u: torch.Tensor,
+    v: torch.Tensor,
+    b: float,
+    omega: float,
+    dt: float,
+    v_threshold: float,
+    v_reset: Optional[float],
+    surrogate_function: SurrogateFunction,
+    detach_reset: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    r"""
+    **API Language** - :ref:`中文 <raf_step-cn>` | :ref:`English <raf_step-en>`
+
+    ----
+
+    .. _raf_step-cn:
+
+    * **中文**
+
+    执行 resonate-and-fire (RAF) 神经元的一次显式状态更新。
+
+    RAF 神经元（Izhikevich, *Resonate-and-fire neurons*, Neural Networks 14
+    (2001) 883-894）是一个二维线性阈下系统，状态可等价看作复数 :math:`z = u + iv`，
+    按固定的衰减率 :math:`b < 0` 和固有角频率 :math:`\omega` 旋转衰减：
+
+    .. math::
+
+        z[t] = z[t-1] \cdot \exp((b + i\omega)\,dt) + x[t]
+
+    real 分量 :math:`u` 接收输入电流；imaginary 分量 :math:`v` 是放电分量，
+    对应阈下阻尼振荡，在阈值附近对输入频率有选择性响应。展开为两个实数状态：
+
+    .. math::
+
+        u[t] &= \alpha (u[t-1]\cos\theta - v[t-1]\sin\theta) + x[t] \\
+        v[t] &= \alpha (u[t-1]\sin\theta + v[t-1]\cos\theta)
+
+    其中 :math:`\alpha = \exp(b\,dt)`，:math:`\theta = \omega\,dt`。放电后只重置
+    :math:`v`（放电分量），:math:`u` 不受影响，这正是产生放电后反弹
+    （post-inhibitory rebound）的原因。
+
+    :param x: 当前输入张量，shape 为 ``[N, *]``
+    :type x: torch.Tensor
+    :param u: 当前实部状态（接收输入的分量），shape、dtype 和 device 与 ``x`` 兼容
+    :type u: torch.Tensor
+    :param v: 当前虚部状态（放电分量）
+    :type v: torch.Tensor
+    :param b: 衰减率，须为负数
+    :type b: float
+    :param omega: 固有角频率，须为正数
+    :type omega: float
+    :param dt: 积分步长，须为正数
+    :type dt: float
+    :param v_threshold: 放电阈值
+    :type v_threshold: float
+    :param v_reset: 重置电位；``None`` 表示 soft reset
+    :type v_reset: Optional[float]
+    :param surrogate_function: 替代梯度函数
+    :type surrogate_function: Callable[[torch.Tensor], torch.Tensor]
+    :param detach_reset: 是否在重置分支中分离脉冲梯度
+    :type detach_reset: bool
+    :return: ``(spike, u_next, v_next)``
+    :rtype: tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+
+    ----
+
+    .. _raf_step-en:
+
+    * **English**
+
+    Run one explicit state update of a resonate-and-fire (RAF) neuron.
+
+    The RAF neuron (Izhikevich, *Resonate-and-fire neurons*, Neural Networks
+    14 (2001) 883-894) is a 2-D linear subthreshold system, equivalently a
+    complex state :math:`z = u + iv` that rotates and decays at a fixed rate
+    :math:`b < 0` and intrinsic angular frequency :math:`\omega`:
+
+    .. math::
+
+        z[t] = z[t-1] \cdot \exp((b + i\omega)\,dt) + x[t]
+
+    The real component :math:`u` receives the input current; the imaginary
+    component :math:`v` is the firing component, giving damped subthreshold
+    oscillations and a preferential response to input near :math:`\omega`.
+    Expanded into two real states:
+
+    .. math::
+
+        u[t] &= \alpha (u[t-1]\cos\theta - v[t-1]\sin\theta) + x[t] \\
+        v[t] &= \alpha (u[t-1]\sin\theta + v[t-1]\cos\theta)
+
+    where :math:`\alpha = \exp(b\,dt)` and :math:`\theta = \omega\,dt`. Only
+    :math:`v` (the firing component) is reset after a spike; :math:`u` is left
+    untouched, which is what produces post-inhibitory rebound.
+
+    :param x: Current input tensor, shape ``[N, *]``
+    :type x: torch.Tensor
+    :param u: Current real-part state (receives the input), shape, dtype and
+        device compatible with ``x``
+    :type u: torch.Tensor
+    :param v: Current imaginary-part state (the firing component)
+    :type v: torch.Tensor
+    :param b: Decay rate, must be negative
+    :type b: float
+    :param omega: Intrinsic angular frequency, must be positive
+    :type omega: float
+    :param dt: Integration step size, must be positive
+    :type dt: float
+    :param v_threshold: Firing threshold
+    :type v_threshold: float
+    :param v_reset: Reset voltage; ``None`` means soft reset
+    :type v_reset: Optional[float]
+    :param surrogate_function: Surrogate-gradient function
+    :type surrogate_function: Callable[[torch.Tensor], torch.Tensor]
+    :param detach_reset: Whether to detach spike in the voltage-reset branch
+    :type detach_reset: bool
+    :return: ``(spike, u_next, v_next)``
+    :rtype: tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+    """
+    alpha = math.exp(b * dt)
+    cos_theta = math.cos(omega * dt)
+    sin_theta = math.sin(omega * dt)
+    u_charged = alpha * (u * cos_theta - v * sin_theta) + x
+    v_charged = alpha * (u * sin_theta + v * cos_theta)
+    spike = surrogate_function(v_charged - v_threshold)
+    v_next = voltage_reset(v_charged, spike, v_threshold, v_reset, detach_reset)
+    return spike, u_charged, v_next
 
 
 def klif_step(

--- a/spikingjelly/activation_based/functional/neuron.py
+++ b/spikingjelly/activation_based/functional/neuron.py
@@ -1271,7 +1271,7 @@ def raf_step(
     :type x: torch.Tensor
     :param u: 当前实部状态（接收输入的分量），shape、dtype 和 device 与 ``x`` 兼容
     :type u: torch.Tensor
-    :param v: 当前虚部状态（放电分量）
+    :param v: 当前虚部状态（放电分量），shape、dtype 和 device 与 ``x`` 兼容
     :type v: torch.Tensor
     :param b: 衰减率，须为负数
     :type b: float
@@ -1326,7 +1326,8 @@ def raf_step(
     :param u: Current real-part state (receives the input), shape, dtype and
         device compatible with ``x``
     :type u: torch.Tensor
-    :param v: Current imaginary-part state (the firing component)
+    :param v: Current imaginary-part state (the firing component), shape, dtype
+        and device compatible with ``x``
     :type v: torch.Tensor
     :param b: Decay rate, must be negative
     :type b: float

--- a/spikingjelly/activation_based/neuron/__init__.py
+++ b/spikingjelly/activation_based/neuron/__init__.py
@@ -7,6 +7,7 @@ from .plif import *
 from .psn import *
 from .adapt import *
 from .nonlinear_if import *
+from .resonate import *
 from .flexsn import *
 from .few_spike import *
 

--- a/spikingjelly/activation_based/neuron/resonate.py
+++ b/spikingjelly/activation_based/neuron/resonate.py
@@ -1,0 +1,219 @@
+from typing import Optional
+
+import torch
+
+from .. import functional, surrogate
+from .base_node import BaseNode
+
+
+__all__ = ["RAFNode"]
+
+
+class RAFNode(BaseNode):
+    def __init__(
+        self,
+        b: float = -0.2,
+        omega: float = 1.0,
+        dt: float = 1.0,
+        v_threshold: float = 1.0,
+        v_reset: Optional[float] = 0.0,
+        surrogate_function: surrogate.SurrogateFunctionBase = surrogate.Sigmoid(),
+        detach_reset: bool = False,
+        step_mode="s",
+        backend="torch",
+        store_v_seq: bool = False,
+    ):
+        """
+        **API Language** - :ref:`中文 <RAFNode.__init__-cn>` | :ref:`English <RAFNode.__init__-en>`
+
+        ----
+
+        .. _RAFNode.__init__-cn:
+
+        * **中文**
+
+        Resonate-and-fire (RAF) 神经元的构造函数（Izhikevich, *Resonate-and-fire
+        neurons*, Neural Networks 14 (2001) 883-894）。
+
+        与积分发放（IF/LIF/QIF/EIF/Izhikevich）神经元家族不同，RAF 神经元是一个
+        二维线性阈下*振荡*系统，而非积分器：等价于一个以固定衰减率 :math:`b < 0`
+        和固有角频率 :math:`\\omega` 旋转衰减的复数状态 :math:`z = u + iv`，因此对
+        接近 :math:`\\omega` 的输入频率有选择性响应，并表现出阈下阻尼振荡。
+
+        **阈下动力学方程**
+
+        .. math::
+
+            u[t] &= \\alpha (u[t-1]\\cos\\theta - v[t-1]\\sin\\theta) + x[t] \\\\
+            v[t] &= \\alpha (u[t-1]\\sin\\theta + v[t-1]\\cos\\theta)
+
+        其中 :math:`\\alpha = \\exp(b\\,dt)`，:math:`\\theta = \\omega\\,dt`。状态
+        由两个实数张量 ``self.u``（实部，接收输入）和 ``self.v``（虚部，放电分量）
+        表示，而非复数张量。放电依据 ``self.v`` 相对 ``v_threshold`` 判定；放电后
+        只重置 ``self.v``（复用 :class:`BaseNode` 的 soft/hard reset 规则），
+        ``self.u`` 不受影响 —— 这正是产生放电后反弹（post-inhibitory rebound）
+        的原因。
+
+        本次实现固定 :math:`b`、:math:`\\omega`、:math:`dt`（不可学习），仅支持
+        ``'torch'`` 后端；可学习参数与其它后端留作后续工作。
+
+        :param b: 衰减率，须为负数
+        :type b: float
+        :param omega: 固有角频率，须为正数
+        :type omega: float
+        :param dt: 积分步长，须为正数
+        :type dt: float
+        :param v_threshold: 神经元的放电阈值
+        :type v_threshold: float
+        :param v_reset: 神经元的重置电压。若不为 ``None``，放电后 ``self.v``
+            将被重置为 ``v_reset``；若为 ``None``，则放电后 ``self.v`` 减去
+            ``v_threshold``。``self.u`` 在任一情况下都不重置
+        :type v_reset: Optional[float]
+        :param surrogate_function: 反向传播中用于近似阶跃函数梯度的替代函数
+        :type surrogate_function: surrogate.SurrogateFunctionBase
+        :param detach_reset: 是否在反向传播时将 reset 过程从计算图中分离
+        :type detach_reset: bool
+        :param step_mode: 步进模式，可选 ``'s'`` （单步）或 ``'m'`` （多步）
+        :type step_mode: str
+        :param backend: 计算后端。目前仅支持 ``'torch'``
+        :type backend: str
+        :param store_v_seq: 当 ``step_mode = 'm'`` 且输入形状为 ``[T, N, *]`` 时，
+            是否保存所有时间步的放电分量序列 ``self.v_seq``（形状为
+            ``[T, N, *]``）。若为 ``False``，仅保留最后一个时间步的 ``self.v``
+            （形状为 ``[N, *]``），以降低内存开销
+        :type store_v_seq: bool
+
+        ----
+
+        .. _RAFNode.__init__-en:
+
+        * **English**
+
+        Constructor of the resonate-and-fire (RAF) neuron (Izhikevich,
+        *Resonate-and-fire neurons*, Neural Networks 14 (2001) 883-894).
+
+        Unlike the integrate-and-fire family (IF/LIF/QIF/EIF/Izhikevich), the
+        RAF neuron is a 2-D linear subthreshold *oscillator*, not an
+        integrator: it is equivalent to a complex state :math:`z = u + iv`
+        that rotates and decays at a fixed rate :math:`b < 0` and intrinsic
+        angular frequency :math:`\\omega`, so it responds preferentially to
+        input near :math:`\\omega` and shows damped subthreshold oscillations.
+
+        **Sub-threshold neuronal dynamics**
+
+        .. math::
+
+            u[t] &= \\alpha (u[t-1]\\cos\\theta - v[t-1]\\sin\\theta) + x[t] \\\\
+            v[t] &= \\alpha (u[t-1]\\sin\\theta + v[t-1]\\cos\\theta)
+
+        where :math:`\\alpha = \\exp(b\\,dt)` and :math:`\\theta = \\omega\\,dt`.
+        State is two real-valued tensors, ``self.u`` (real part, receives the
+        input) and ``self.v`` (imaginary part, the firing component), not a
+        complex tensor. Firing is decided from ``self.v`` against
+        ``v_threshold``; only ``self.v`` is reset after a spike (reusing
+        :class:`BaseNode`'s soft/hard reset rule) — ``self.u`` is left
+        untouched, which is what produces post-inhibitory rebound.
+
+        This implementation fixes :math:`b`, :math:`\\omega`, :math:`dt`
+        (not learnable) and supports the ``'torch'`` backend only; learnable
+        parameters and other backends are left for future work.
+
+        :param b: Decay rate, must be negative
+        :type b: float
+        :param omega: Intrinsic angular frequency, must be positive
+        :type omega: float
+        :param dt: Integration step size, must be positive
+        :type dt: float
+        :param v_threshold: Firing threshold of the neuron
+        :type v_threshold: float
+        :param v_reset: Reset voltage of the neuron. If not ``None``,
+            ``self.v`` will be reset to ``v_reset`` after firing; if ``None``,
+            ``v_threshold`` will be subtracted from ``self.v``. ``self.u`` is
+            never reset either way
+        :type v_reset: Optional[float]
+        :param surrogate_function: surrogate function used to approximate the
+            gradient of the Heaviside step function during backpropagation
+        :type surrogate_function: surrogate.SurrogateFunctionBase
+        :param detach_reset: whether to detach the reset operation from the
+            computation graph
+        :type detach_reset: bool
+        :param step_mode: step mode, either ``'s'`` (single-step) or ``'m'``
+            (multi-step)
+        :type step_mode: str
+        :param backend: backend for this neuron. Only ``'torch'`` is
+            currently supported
+        :type backend: str
+        :param store_v_seq: when ``step_mode = 'm'`` and input shape is
+            ``[T, N, *]``, whether to store the firing component at all time
+            steps in ``self.v_seq``. If ``False``, only the final ``self.v``
+            is kept, to reduce memory usage
+        :type store_v_seq: bool
+        """
+        assert isinstance(b, float) and b < 0.0
+        assert isinstance(omega, float) and omega > 0.0
+        assert isinstance(dt, float) and dt > 0.0
+
+        super().__init__(
+            v_threshold,
+            v_reset,
+            surrogate_function,
+            detach_reset,
+            step_mode,
+            backend,
+            store_v_seq,
+        )
+        self.register_memory("u", 0.0)
+        self.b = b
+        self.omega = omega
+        self.dt = dt
+
+    def extra_repr(self):
+        return super().extra_repr() + f", b={self.b}, omega={self.omega}, dt={self.dt}"
+
+    def materialize_states(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        step_mode: str,
+    ) -> tuple[object, ...]:
+        states = super().materialize_states(inputs, states, step_mode)
+        x = states[0]
+        u = states[-1]
+        if isinstance(u, float):
+            u = torch.full_like(x, u, requires_grad=False)
+        elif isinstance(u, torch.Tensor):
+            if u.shape != x.shape:
+                u = torch.full_like(x, 0.0, requires_grad=False)
+            elif u.dtype != x.dtype or u.device != x.device:
+                u = u.to(dtype=x.dtype, device=x.device)
+        return (*states[:-1], u)
+
+    def single_step_functional_forward(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        states: tuple[object, ...],
+        **kwargs: object,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[object, ...]]:
+        x = inputs[0]
+        v = states[0]
+        u = states[-1]
+        spike, u, v = functional.raf_step(
+            x,
+            u,
+            v,
+            self.b,
+            self.omega,
+            self.dt,
+            self.v_threshold,
+            self.v_reset,
+            self.surrogate_function,
+            self.detach_reset,
+        )
+        return (spike,), (v, u)
+
+    @property
+    def supported_backends(self):
+        if self.step_mode in ("s", "m"):
+            return ("torch",)
+        else:
+            raise ValueError(self.step_mode)

--- a/spikingjelly/activation_based/neuron/resonate.py
+++ b/spikingjelly/activation_based/neuron/resonate.py
@@ -19,11 +19,11 @@ class RAFNode(BaseNode):
         v_reset: Optional[float] = 0.0,
         surrogate_function: surrogate.SurrogateFunctionBase = surrogate.Sigmoid(),
         detach_reset: bool = False,
-        step_mode="s",
-        backend="torch",
+        step_mode: str = "s",
+        backend: str = "torch",
         store_v_seq: bool = False,
-    ):
-        """
+    ) -> None:
+        r"""
         **API Language** - :ref:`中文 <RAFNode.__init__-cn>` | :ref:`English <RAFNode.__init__-en>`
 
         ----
@@ -37,24 +37,24 @@ class RAFNode(BaseNode):
 
         与积分发放（IF/LIF/QIF/EIF/Izhikevich）神经元家族不同，RAF 神经元是一个
         二维线性阈下*振荡*系统，而非积分器：等价于一个以固定衰减率 :math:`b < 0`
-        和固有角频率 :math:`\\omega` 旋转衰减的复数状态 :math:`z = u + iv`，因此对
-        接近 :math:`\\omega` 的输入频率有选择性响应，并表现出阈下阻尼振荡。
+        和固有角频率 :math:`\omega` 旋转衰减的复数状态 :math:`z = u + iv`，因此对
+        接近 :math:`\omega` 的输入频率有选择性响应，并表现出阈下阻尼振荡。
 
         **阈下动力学方程**
 
         .. math::
 
-            u[t] &= \\alpha (u[t-1]\\cos\\theta - v[t-1]\\sin\\theta) + x[t] \\\\
-            v[t] &= \\alpha (u[t-1]\\sin\\theta + v[t-1]\\cos\\theta)
+            u[t] &= \alpha (u[t-1]\cos\theta - v[t-1]\sin\theta) + x[t] \\
+            v[t] &= \alpha (u[t-1]\sin\theta + v[t-1]\cos\theta)
 
-        其中 :math:`\\alpha = \\exp(b\\,dt)`，:math:`\\theta = \\omega\\,dt`。状态
+        其中 :math:`\alpha = \exp(b\,dt)`，:math:`\theta = \omega\,dt`。状态
         由两个实数张量 ``self.u``（实部，接收输入）和 ``self.v``（虚部，放电分量）
         表示，而非复数张量。放电依据 ``self.v`` 相对 ``v_threshold`` 判定；放电后
         只重置 ``self.v``（复用 :class:`BaseNode` 的 soft/hard reset 规则），
         ``self.u`` 不受影响 —— 这正是产生放电后反弹（post-inhibitory rebound）
         的原因。
 
-        本次实现固定 :math:`b`、:math:`\\omega`、:math:`dt`（不可学习），仅支持
+        本次实现固定 :math:`b`、:math:`\omega`、:math:`dt`（不可学习），仅支持
         ``'torch'`` 后端；可学习参数与其它后端留作后续工作。
 
         :param b: 衰减率，须为负数
@@ -96,17 +96,17 @@ class RAFNode(BaseNode):
         RAF neuron is a 2-D linear subthreshold *oscillator*, not an
         integrator: it is equivalent to a complex state :math:`z = u + iv`
         that rotates and decays at a fixed rate :math:`b < 0` and intrinsic
-        angular frequency :math:`\\omega`, so it responds preferentially to
-        input near :math:`\\omega` and shows damped subthreshold oscillations.
+        angular frequency :math:`\omega`, so it responds preferentially to
+        input near :math:`\omega` and shows damped subthreshold oscillations.
 
         **Sub-threshold neuronal dynamics**
 
         .. math::
 
-            u[t] &= \\alpha (u[t-1]\\cos\\theta - v[t-1]\\sin\\theta) + x[t] \\\\
-            v[t] &= \\alpha (u[t-1]\\sin\\theta + v[t-1]\\cos\\theta)
+            u[t] &= \alpha (u[t-1]\cos\theta - v[t-1]\sin\theta) + x[t] \\
+            v[t] &= \alpha (u[t-1]\sin\theta + v[t-1]\cos\theta)
 
-        where :math:`\\alpha = \\exp(b\\,dt)` and :math:`\\theta = \\omega\\,dt`.
+        where :math:`\alpha = \exp(b\,dt)` and :math:`\theta = \omega\,dt`.
         State is two real-valued tensors, ``self.u`` (real part, receives the
         input) and ``self.v`` (imaginary part, the firing component), not a
         complex tensor. Firing is decided from ``self.v`` against
@@ -114,7 +114,7 @@ class RAFNode(BaseNode):
         :class:`BaseNode`'s soft/hard reset rule) — ``self.u`` is left
         untouched, which is what produces post-inhibitory rebound.
 
-        This implementation fixes :math:`b`, :math:`\\omega`, :math:`dt`
+        This implementation fixes :math:`b`, :math:`\omega`, :math:`dt`
         (not learnable) and supports the ``'torch'`` backend only; learnable
         parameters and other backends are left for future work.
 
@@ -167,7 +167,7 @@ class RAFNode(BaseNode):
         self.omega = omega
         self.dt = dt
 
-    def extra_repr(self):
+    def extra_repr(self) -> str:
         return super().extra_repr() + f", b={self.b}, omega={self.omega}, dt={self.dt}"
 
     def materialize_states(
@@ -212,7 +212,7 @@ class RAFNode(BaseNode):
         return (spike,), (v, u)
 
     @property
-    def supported_backends(self):
+    def supported_backends(self) -> tuple[str, ...]:
         if self.step_mode in ("s", "m"):
             return ("torch",)
         else:

--- a/test/activation_based/test_functional_neuron.py
+++ b/test/activation_based/test_functional_neuron.py
@@ -513,6 +513,89 @@ def test_izhikevich_step_matches_module():
     _assert_close(w_next, module.w)
 
 
+@pytest.mark.parametrize("v_reset", [0.0, None])
+@pytest.mark.parametrize("detach_reset", [False, True])
+def test_raf_step_matches_module(v_reset, detach_reset):
+    x = torch.randn(2, 3)
+    u = torch.randn(2, 3) * 0.3
+    v = torch.randn(2, 3) * 0.3
+    function_surrogate = _surrogate()
+    module = neuron.RAFNode(
+        b=-0.2,
+        omega=1.3,
+        dt=0.5,
+        v_threshold=0.5,
+        v_reset=v_reset,
+        surrogate_function=_surrogate(),
+        detach_reset=detach_reset,
+    )
+    module.u = u.clone()
+    module.v = v.clone()
+
+    spike, u_next, v_next = functional.raf_step(
+        x,
+        u,
+        v,
+        -0.2,
+        1.3,
+        0.5,
+        0.5,
+        v_reset,
+        function_surrogate,
+        detach_reset,
+    )
+    module_spike = module(x)
+
+    _assert_close(spike, module_spike)
+    _assert_close(u_next, module.u)
+    _assert_close(v_next, module.v)
+
+
+def test_raf_reset_only_touches_v():
+    # a spike must hard/soft-reset v but leave u exactly as the charge step
+    # produced it -- that is what gives post-inhibitory rebound.
+    for v_reset in (0.0, None):
+        module = neuron.RAFNode(
+            b=-0.2, omega=1.0, dt=1.0, v_threshold=0.3, v_reset=v_reset
+        )
+        module.u = torch.tensor([2.0])
+        module.v = torch.tensor([2.0])
+
+        reference = neuron.RAFNode(
+            b=-0.2, omega=1.0, dt=1.0, v_threshold=1e9, v_reset=v_reset
+        )
+        reference.u = torch.tensor([2.0])
+        reference.v = torch.tensor([2.0])
+
+        spike = module(torch.tensor([0.0]))
+        reference(torch.tensor([0.0]))
+
+        assert spike.item() == 1.0
+        _assert_close(module.u, reference.u)
+
+
+def test_raf_single_step_multi_step_equivalence():
+    torch.manual_seed(0)
+    x_seq = torch.randn(6, 2, 3)
+
+    single_step = neuron.RAFNode(b=-0.15, omega=0.8, dt=0.5, v_threshold=0.4)
+    single_spikes, single_u_steps, single_v_steps = [], [], []
+    for x in x_seq:
+        single_spikes.append(single_step(x))
+        single_u_steps.append(single_step.u.clone())
+        single_v_steps.append(single_step.v.clone())
+
+    multi_step = neuron.RAFNode(
+        b=-0.15, omega=0.8, dt=0.5, v_threshold=0.4, step_mode="m", store_v_seq=True
+    )
+    multi_spikes = multi_step(x_seq)
+
+    _assert_close(multi_spikes, torch.stack(single_spikes))
+    _assert_close(multi_step.v_seq, torch.stack(single_v_steps))
+    _assert_close(multi_step.v, single_step.v)
+    _assert_close(multi_step.u, single_step.u)
+
+
 @pytest.mark.parametrize("scale_reset", [False, True])
 def test_klif_step_matches_module(scale_reset):
     x = torch.randn(2, 3)

--- a/test/activation_based/test_functional_neuron.py
+++ b/test/activation_based/test_functional_neuron.py
@@ -572,6 +572,10 @@ def test_raf_reset_only_touches_v():
 
         assert spike.item() == 1.0
         _assert_close(module.u, reference.u)
+        if v_reset is None:
+            _assert_close(module.v, reference.v - module.v_threshold)
+        else:
+            _assert_close(module.v, torch.full_like(reference.v, v_reset))
 
 
 def test_raf_single_step_multi_step_equivalence():


### PR DESCRIPTION
Closes #746.

## What this adds

`RAFNode` — a resonate-and-fire neuron (Izhikevich, *Resonate-and-fire neurons*, Neural Networks 14 (2001) 883-894) — per the design agreed in #746:

- `RAFNode` as the class name
- fixed `b` (decay rate), `omega` (angular frequency), `dt` — not learnable
- fires on the imaginary/voltage component (`self.v`)
- two real-valued states, `self.u` and `self.v` — not a complex tensor
- a single, clearly documented reset rule: reuses `BaseNode`'s soft/hard reset on `self.v` only; `self.u` is **never** reset, which is what produces post-inhibitory rebound
- `'torch'` backend only

## Sub-threshold dynamics

The real-valued expansion of `z <- z * exp((b + i*omega)*dt) + x` for `z = u + i*v`:

```
u[t] = alpha*(u[t-1]*cos(theta) - v[t-1]*sin(theta)) + x[t]
v[t] = alpha*(u[t-1]*sin(theta) + v[t-1]*cos(theta))
```

where `alpha = exp(b*dt)`, `theta = omega*dt`.

## How it fits the current architecture

Follows the `single_step_functional_forward` / explicit-state contract described in your comment on #746: `RAFNode(BaseNode)` implements `single_step_functional_forward` on explicit `(v, u)` state, overrides `materialize_states` to shape the second state `u` (same pattern `AdaptBaseNode` already uses for its adaptation current `w`), and reuses `BaseNode`'s generic multi-step path as-is — no override needed.

`functional.raf_step` is the explicit state-transition function, matching the `qif_step` / `izhikevich_step` house pattern (bilingual CN/EN docstring, same call shape).

## What I checked

- `test_raf_step_matches_module` — `functional.raf_step` output matches `RAFNode(...)` forward, parametrized over `v_reset` and `detach_reset`.
- `test_raf_reset_only_touches_v` — a spike leaves `self.u` exactly as the charge step produced it (proves the reset rule is scoped to `v`).
- `test_raf_single_step_multi_step_equivalence` — `step_mode="s"` run one step at a time vs `step_mode="m"` run on the whole sequence produce identical spikes, `v_seq`, and final `(u, v)`.
- Manually verified the model does real physics, not just passes shape checks: driving a `RAFNode(omega=1.0)` at its resonant frequency builds ~40x more subthreshold amplitude than driving it off-resonance (`omega=2.5`); gradients flow through backprop.
- `uvx ruff==0.15.22 check .` and `format --check` both clean on the changed files.
- Full `test/activation_based/` suite: 1223 passed. The 68 failures in this environment (triton kernels, GPU monitor) are pre-existing — verified identical via `git stash` against an unmodified checkout; this machine has no triton and no CUDA-visible GPU.

## How did AI help

AI (Claude, via Claude Code) implemented the neuron and tests from the design agreed in #746, after reading `BaseNode`/`AdaptBaseNode`/`IzhikevichNode`/`QIFNode` to match the current architecture rather than the older `neuronal_charge`/`neuronal_fire` pattern in my original issue sketch. I reviewed the math, the reset semantics, and the test coverage, and ran the resonance/rebound/gradient checks above myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added resonate-and-fire (RAF) neuron support through `RAFNode`.
  - Added RAF state transitions for single-step and multi-step processing.
  - Supports configurable thresholds, reset behavior, surrogate functions, and oscillator parameters.
  - Supports the Torch backend and sequence processing.

- **Documentation**
  - Added RAF neuron and functional API documentation.
  - Added the feature to the unreleased changelog.

- **Tests**
  - Expanded coverage for RAF reset behavior, including voltage state handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->