### PR TITLE
fix(benchmark): pass time_steps to _debug_snn_outputs in spikezip ViT ANN2SNN

### DIFF
--- a/benchmark/benchmark_ann2snn_spikezip_vit_qann.py
+++ b/benchmark/benchmark_ann2snn_spikezip_vit_qann.py
@@ -655,11 +655,14 @@ def main() -> None:
         )
         snn_outputs = _debug_snn_outputs(
             (
-                index % len(converted.blocks),
-                value,
-            )
-            for index, value in enumerate(snn_features)
-            if len(converted.blocks) > 0
+                (
+                    index % len(converted.blocks),
+                    value,
+                )
+                for index, value in enumerate(snn_features)
+                if len(converted.blocks) > 0
+            ),
+            args.time_steps,
         )
         debug["debug_batches"] = debug_batches
         debug["block_max_abs_diff"] = _debug_block_diffs(qann_outputs, snn_outputs)


### PR DESCRIPTION
### Problem

`benchmark/benchmark_ann2snn_spikezip_vit_qann.py` defines

```python
def _debug_snn_outputs(features, time_steps: int) -> dict[int, list[torch.Tensor]]:
```

but the only call site (guarded by `--debug-blocks`) passes just the generator:

```python
snn_outputs = _debug_snn_outputs(
    (index % len(converted.blocks), value)
    for index, value in enumerate(snn_features)
    if len(converted.blocks) > 0
)
```

So running the benchmark with `--debug-blocks` fails immediately:

```
TypeError: _debug_snn_outputs() missing 1 required positional argument: 'time_steps'
```

`time_steps` is genuinely used in the body (`value.shape[0] == time_steps`,
`len(values) == time_steps`), so the argument can't just be dropped — the sibling
`_debug_qann_outputs(features)` legitimately takes only one arg.

### Fix

Pass `args.time_steps` (the same value already fed into the converter recipe a few
lines above) to the call. The generator is wrapped in parentheses so a second
argument is syntactically valid.

Verified with `inspect.Signature.bind`: the old call raises the missing-argument
`TypeError`, the new call binds cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved debug output collection for converted models by safely mapping feature indexes to available blocks.
  * Prevented debug processing when no converted blocks are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->