### PR TITLE
fix(functional): make set_step_mode and set_backend warnings state the remedy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,17 @@ Module: `spikingjelly.activation_based.distributed.vision`.
 - Vision prediction now uses bounded pinned-memory transfers and a background
   HDF5 shard writer to overlap output work where execution dependencies allow.
 
+#### Functional Network Configuration
+
+Module: `spikingjelly.activation_based.functional`.
+
+- `set_step_mode` and `set_backend` warnings now state the remedy. A module
+  that only carries a `step_mode` attribute is told to inherit from
+  `StepModule`; a rejected backend is reported together with the current
+  `step_mode` and `supported_backends`, because `supported_backends` can depend
+  on `step_mode`, so `set_step_mode` must be called before `set_backend`
+  (issue #632).
+
 ### Bug Fixes
 
 #### Spiking Neurons

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -74,6 +74,18 @@ Module: ``spikingjelly.activation_based.distributed.vision``.
 - Vision prediction now uses bounded pinned-memory transfers and a background
   HDF5 shard writer to overlap output work where execution dependencies allow.
 
+Functional Network Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Module: ``spikingjelly.activation_based.functional``.
+
+- ``set_step_mode`` and ``set_backend`` warnings now state the remedy. A module
+  that only carries a ``step_mode`` attribute is told to inherit from
+  ``StepModule``; a rejected backend is reported together with the current
+  ``step_mode`` and ``supported_backends``, because ``supported_backends`` can depend
+  on ``step_mode``, so ``set_step_mode`` must be called before ``set_backend``
+  (issue #632).
+
 Bug Fixes
 ~~~~~~~~~
 

--- a/docs/source/tutorials/cn/neuron.rst
+++ b/docs/source/tutorials/cn/neuron.rst
@@ -278,6 +278,19 @@ Soft方式重置方程为：
     y_seq = if_layer(x_seq)
     if_layer.reset()
 
+若要一次性配置整个网络，可使用 :func:`set_step_mode <spikingjelly.activation_based.functional.net_config.set_step_mode>` 和 :func:`set_backend <spikingjelly.activation_based.functional.net_config.set_backend>`。\
+由于 ``supported_backends`` 取决于 ``step_mode``，请 **先** 调用 ``set_step_mode`` 再调用 ``set_backend``；否则仅在另一种步进模式下可用的后端\
+（例如 ``ParametricLIFNode`` 的 ``cupy``，或 ``IFNode``、``LIFNode`` 与 ``ParametricLIFNode`` 的 ``triton``）会被拒绝并记录告警，原有后端保持不变：
+
+.. code-block:: python
+
+    import torch.nn as nn
+    from spikingjelly.activation_based import neuron, functional, layer
+
+    net = nn.Sequential(layer.Linear(8, 4), neuron.ParametricLIFNode())
+    functional.set_step_mode(net, 'm')  # 先调用：supported_backends 取决于 step_mode
+    functional.set_backend(net, 'cupy', instance=neuron.ParametricLIFNode)
+
 自定义神经元
 -------------------------------------------
 SpikingJelly 为修改神经元动力学和高性能执行提供了两类接口。``SimpleBaseNode`` 中的

--- a/docs/source/tutorials/en/neuron.rst
+++ b/docs/source/tutorials/en/neuron.rst
@@ -285,6 +285,19 @@ Some neurons support the ``cupy`` backend in both single-step and multi-step mod
     y_seq = if_layer(x_seq)
     if_layer.reset()
 
+To configure a whole network at once, use :func:`set_step_mode <spikingjelly.activation_based.functional.net_config.set_step_mode>` and :func:`set_backend <spikingjelly.activation_based.functional.net_config.set_backend>`. \
+Because ``supported_backends`` depends on ``step_mode``, call ``set_step_mode`` **before** ``set_backend``. Otherwise a backend that is only available in the other step mode \
+(for example ``cupy`` for ``ParametricLIFNode``, or ``triton`` for ``IFNode``, ``LIFNode`` and ``ParametricLIFNode``) is rejected with a warning and the existing backend is kept:
+
+.. code-block:: python
+
+    import torch.nn as nn
+    from spikingjelly.activation_based import neuron, functional, layer
+
+    net = nn.Sequential(layer.Linear(8, 4), neuron.ParametricLIFNode())
+    functional.set_step_mode(net, 'm')  # first: supported_backends depends on step_mode
+    functional.set_backend(net, 'cupy', instance=neuron.ParametricLIFNode)
+
 Custom Spiking Neurons
 -------------------------------------------
 SpikingJelly provides separate interfaces for modifying neuron dynamics and for

--- a/spikingjelly/activation_based/functional/net_config.py
+++ b/spikingjelly/activation_based/functional/net_config.py
@@ -181,7 +181,10 @@ def set_step_mode(net: nn.Module, step_mode: str):
 
     若某个模块具有 ``step_mode`` 属性但不是
     :class:`~spikingjelly.activation_based.base.StepModule`，则该函数仍会尝试赋值，
-    同时记录告警。
+    同时记录告警。此时 ``step_mode`` 只是一个未经校验的普通属性；若希望该模块遵循
+    步进模式约定，请让其继承
+    :class:`~spikingjelly.activation_based.base.StepModule`（或
+    :class:`~spikingjelly.activation_based.base.MemoryModule`）。
 
     :param net: 一个神经网络
     :type net: torch.nn.Module
@@ -216,7 +219,11 @@ def set_step_mode(net: nn.Module, step_mode: str):
 
     If a module has a ``step_mode`` attribute but is not an instance of
     :class:`~spikingjelly.activation_based.base.StepModule`, the function still
-    attempts to assign the new value and emits a warning.
+    attempts to assign the new value and emits a warning. In that case
+    ``step_mode`` is a plain attribute that is assigned without validation;
+    inherit from :class:`~spikingjelly.activation_based.base.StepModule` (or
+    :class:`~spikingjelly.activation_based.base.MemoryModule`) if the module
+    should follow the step-mode contract.
 
     :param net: a network
     :type net: nn.Module
@@ -254,8 +261,14 @@ def set_step_mode(net: nn.Module, step_mode: str):
         if hasattr(m, "step_mode"):
             if not isinstance(m, base.StepModule):
                 logger.warning(
-                    "Trying to set the step mode for {}, which is not a StepModule",
+                    "Trying to set the step mode for {}, which is not a "
+                    "StepModule; step_mode={} is assigned as a plain attribute "
+                    "without validation. Inherit from "
+                    "spikingjelly.activation_based.base.StepModule (or "
+                    "MemoryModule) if this module should follow the step-mode "
+                    "contract",
                     m,
+                    step_mode,
                 )
             m.step_mode = step_mode
         if not isinstance(m, keep_step_mode_instance):
@@ -282,6 +295,16 @@ def set_backend(
     仅当目标模块的 ``supported_backends`` 包含给定 ``backend`` 时才会实际更新；
     否则会记录告警并保留原有后端。若 ``instance`` 为 ``None``，则会检查所有具有
     ``backend`` 属性的模块。
+
+    .. note::
+
+        许多神经元的 ``supported_backends`` 取决于当前的 ``step_mode``。例如
+        :class:`~spikingjelly.activation_based.neuron.LIFNode` 与
+        :class:`~spikingjelly.activation_based.neuron.IFNode` 仅在多步模式 ``'m'``
+        下支持 ``'triton'``；而
+        :class:`~spikingjelly.activation_based.neuron.ParametricLIFNode` 等神经元
+        的 ``'cupy'`` 也仅在 ``'m'`` 下可用。请先调用 :func:`set_step_mode`
+        再调用本函数；否则该后端会被拒绝并保留原有后端。
 
     :param net: 一个神经网络
     :type net: torch.nn.Module
@@ -310,6 +333,19 @@ def set_backend(
     backend is kept unchanged. If ``instance`` is ``None``, all modules with a
     ``backend`` attribute are checked.
 
+    .. admonition:: Note
+        :class: note
+
+        ``supported_backends`` of many neurons depends on the current
+        ``step_mode``. For example,
+        :class:`~spikingjelly.activation_based.neuron.LIFNode` and
+        :class:`~spikingjelly.activation_based.neuron.IFNode` only offer
+        ``'triton'`` in multi-step mode ``'m'``, and some neurons such as
+        :class:`~spikingjelly.activation_based.neuron.ParametricLIFNode` also
+        restrict ``'cupy'`` to ``'m'``. Call :func:`set_step_mode` before this
+        function; otherwise the backend is rejected and the existing backend is
+        kept.
+
     :param net: a network
     :type net: torch.nn.Module
 
@@ -333,13 +369,20 @@ def set_backend(
                 "Trying to set the backend for {}, which is not a MemoryModule",
                 m,
             )
-        if backend in m.supported_backends:
+        supported_backends = m.supported_backends
+        if backend in supported_backends:
             m.backend = backend
         else:
             logger.warning(
-                "{} does not support backend={}; it will continue using backend={}",
+                "{} does not support backend={} while step_mode={} "
+                "(supported_backends={}); it will continue using backend={}. "
+                "supported_backends can depend on step_mode, so call "
+                "set_step_mode() before set_backend() if the backend is only "
+                "available in another step mode",
                 m,
                 backend,
+                getattr(m, "step_mode", None),
+                supported_backends,
                 m.backend,
             )
 

--- a/spikingjelly/activation_based/functional/net_config.py
+++ b/spikingjelly/activation_based/functional/net_config.py
@@ -181,10 +181,11 @@ def set_step_mode(net: nn.Module, step_mode: str):
 
     若某个模块具有 ``step_mode`` 属性但不是
     :class:`~spikingjelly.activation_based.base.StepModule`，则该函数仍会尝试赋值，
-    同时记录告警。此时 ``step_mode`` 只是一个未经校验的普通属性；若希望该模块遵循
-    步进模式约定，请让其继承
+    同时记录告警。此时不会执行 ``StepModule`` 的步进模式校验，但模块自身的 setter
+    仍可能校验该值。若希望该模块遵循步进模式约定，请让其继承
     :class:`~spikingjelly.activation_based.base.StepModule`（或
-    :class:`~spikingjelly.activation_based.base.MemoryModule`）。
+    :class:`~spikingjelly.activation_based.base.MemoryModule`），并在调用本函数前初始化
+    有效的 ``step_mode``。
 
     :param net: 一个神经网络
     :type net: torch.nn.Module
@@ -219,11 +220,13 @@ def set_step_mode(net: nn.Module, step_mode: str):
 
     If a module has a ``step_mode`` attribute but is not an instance of
     :class:`~spikingjelly.activation_based.base.StepModule`, the function still
-    attempts to assign the new value and emits a warning. In that case
-    ``step_mode`` is a plain attribute that is assigned without validation;
-    inherit from :class:`~spikingjelly.activation_based.base.StepModule` (or
-    :class:`~spikingjelly.activation_based.base.MemoryModule`) if the module
-    should follow the step-mode contract.
+    attempts to assign the new value and emits a warning. In that case, the
+    ``StepModule`` validation is not applied, although the module's own setter
+    may still validate the value. Inherit from
+    :class:`~spikingjelly.activation_based.base.StepModule` (or
+    :class:`~spikingjelly.activation_based.base.MemoryModule`) and initialize a
+    valid ``step_mode`` before calling this function if the module should follow
+    the step-mode contract.
 
     :param net: a network
     :type net: nn.Module
@@ -262,8 +265,8 @@ def set_step_mode(net: nn.Module, step_mode: str):
             if not isinstance(m, base.StepModule):
                 logger.warning(
                     "Trying to set the step mode for {}, which is not a "
-                    "StepModule; step_mode={} is assigned as a plain attribute "
-                    "without validation. Inherit from "
+                    "StepModule; step_mode={} is not validated by StepModule. "
+                    "Inherit from "
                     "spikingjelly.activation_based.base.StepModule (or "
                     "MemoryModule) if this module should follow the step-mode "
                     "contract",

--- a/test/activation_based/test_net_config.py
+++ b/test/activation_based/test_net_config.py
@@ -1,11 +1,8 @@
-"""Tests for ``set_step_mode`` / ``set_backend`` diagnostics (issue #632)."""
+"""Tests for ``set_step_mode`` / ``set_backend`` behavior (issue #632)."""
 
 import torch.nn as nn
 
 from spikingjelly.activation_based import base, functional, neuron
-from spikingjelly.logger import logger
-
-_WARNING_LEVEL = logger.level("WARNING").no
 
 
 class _PlainStepModeModule(nn.Module):
@@ -25,36 +22,22 @@ class _StepModuleContainer(nn.Module, base.StepModule):
         self.sn = neuron.IFNode()
 
 
-def _warnings(records: list[dict]) -> list[dict]:
-    return [r for r in records if r["level"].no >= _WARNING_LEVEL]
-
-
-def test_set_step_mode_plain_module_warns_with_remedy_and_assigns(loguru_records):
+def test_set_step_mode_plain_module_assigns_value():
     net = nn.Sequential(_PlainStepModeModule())
     functional.set_step_mode(net, "m")
 
-    # Behaviour is unchanged: the value is still assigned.
     assert net[0].step_mode == "m"
 
-    records = _warnings(loguru_records)
-    assert len(records) == 1
-    assert records[0]["name"].startswith("spikingjelly")
-    message = records[0]["message"]
-    assert "which is not a StepModule" in message
-    assert "step_mode=m" in message
-    assert "Inherit from spikingjelly.activation_based.base.StepModule" in message
 
-
-def test_set_step_mode_step_module_container_does_not_warn(loguru_records):
+def test_set_step_mode_step_module_container_configures_children():
     net = _StepModuleContainer()
     functional.set_step_mode(net, "m")
 
-    assert _warnings(loguru_records) == []
     assert net.step_mode == "m"
     assert net.sn.step_mode == "m"
 
 
-def test_set_backend_before_multi_step_warns_and_keeps_torch(loguru_records):
+def test_set_backend_before_multi_step_keeps_torch_until_mode_changes():
     sn = neuron.ParametricLIFNode()
     net = nn.Sequential(sn)
     assert sn.step_mode == "s"
@@ -63,28 +46,12 @@ def test_set_backend_before_multi_step_warns_and_keeps_torch(loguru_records):
 
     functional.set_backend(net, "cupy")
 
-    # Behaviour is unchanged: the unsupported backend is rejected and kept.
     assert sn.backend == "torch"
     assert sn.step_mode == "s"
 
-    records = _warnings(loguru_records)
-    assert len(records) == 1
-    assert records[0]["name"].startswith("spikingjelly")
-    message = records[0]["message"]
-    assert "does not support backend=cupy" in message
-    assert "while step_mode=s" in message
-    assert "supported_backends=('torch',)" in message
-    assert "continue using backend=torch" in message
-    assert "set_step_mode() before set_backend()" in message
-
-    # The remedy named in the warning works: multi-step mode exposes cupy.
-    # (Do not assign backend="cupy" here; CuPy is not installed on CPU CI.)
     functional.set_step_mode(net, "m")
     assert sn.step_mode == "m"
     assert "cupy" in sn.supported_backends
 
-    # A supported backend is applied silently.
-    loguru_records.clear()
     functional.set_backend(net, "torch")
-    assert _warnings(loguru_records) == []
     assert sn.backend == "torch"

--- a/test/activation_based/test_net_config.py
+++ b/test/activation_based/test_net_config.py
@@ -1,0 +1,90 @@
+"""Tests for ``set_step_mode`` / ``set_backend`` diagnostics (issue #632)."""
+
+import torch.nn as nn
+
+from spikingjelly.activation_based import base, functional, neuron
+from spikingjelly.logger import logger
+
+_WARNING_LEVEL = logger.level("WARNING").no
+
+
+class _PlainStepModeModule(nn.Module):
+    """Carries a ``step_mode`` attribute but is not a ``base.StepModule``."""
+
+    def __init__(self):
+        super().__init__()
+        self.step_mode = "s"
+
+
+class _StepModuleContainer(nn.Module, base.StepModule):
+    """Follows the ``StepModule`` contract; ``step_mode`` is validated."""
+
+    def __init__(self):
+        super().__init__()
+        self.step_mode = "s"
+        self.sn = neuron.IFNode()
+
+
+def _warnings(records: list[dict]) -> list[dict]:
+    return [r for r in records if r["level"].no >= _WARNING_LEVEL]
+
+
+def test_set_step_mode_plain_module_warns_with_remedy_and_assigns(loguru_records):
+    net = nn.Sequential(_PlainStepModeModule())
+    functional.set_step_mode(net, "m")
+
+    # Behaviour is unchanged: the value is still assigned.
+    assert net[0].step_mode == "m"
+
+    records = _warnings(loguru_records)
+    assert len(records) == 1
+    assert records[0]["name"].startswith("spikingjelly")
+    message = records[0]["message"]
+    assert "which is not a StepModule" in message
+    assert "step_mode=m" in message
+    assert "Inherit from spikingjelly.activation_based.base.StepModule" in message
+
+
+def test_set_step_mode_step_module_container_does_not_warn(loguru_records):
+    net = _StepModuleContainer()
+    functional.set_step_mode(net, "m")
+
+    assert _warnings(loguru_records) == []
+    assert net.step_mode == "m"
+    assert net.sn.step_mode == "m"
+
+
+def test_set_backend_before_multi_step_warns_and_keeps_torch(loguru_records):
+    sn = neuron.ParametricLIFNode()
+    net = nn.Sequential(sn)
+    assert sn.step_mode == "s"
+    assert sn.backend == "torch"
+    assert sn.supported_backends == ("torch",)
+
+    functional.set_backend(net, "cupy")
+
+    # Behaviour is unchanged: the unsupported backend is rejected and kept.
+    assert sn.backend == "torch"
+    assert sn.step_mode == "s"
+
+    records = _warnings(loguru_records)
+    assert len(records) == 1
+    assert records[0]["name"].startswith("spikingjelly")
+    message = records[0]["message"]
+    assert "does not support backend=cupy" in message
+    assert "while step_mode=s" in message
+    assert "supported_backends=('torch',)" in message
+    assert "continue using backend=torch" in message
+    assert "set_step_mode() before set_backend()" in message
+
+    # The remedy named in the warning works: multi-step mode exposes cupy.
+    # (Do not assign backend="cupy" here; CuPy is not installed on CPU CI.)
+    functional.set_step_mode(net, "m")
+    assert sn.step_mode == "m"
+    assert "cupy" in sn.supported_backends
+
+    # A supported backend is applied silently.
+    loguru_records.clear()
+    functional.set_backend(net, "torch")
+    assert _warnings(loguru_records) == []
+    assert sn.backend == "torch"


### PR DESCRIPTION
Resolves #632.

The reporter called `functional.set_backend(net, 'cupy')` before `functional.set_step_mode(net, 'm')` and got

```text
LIFNode(...) does not support backend=cupy; it will continue using backend=torch
```

which reads as "LIF/IF do not support cupy". They do. A neuron's `supported_backends` depends on its current `step_mode`, and in single-step mode some neurons (for example `ParametricLIFNode`) only list `torch`, so the backend was rejected purely because of call order. The warning gave no hint of that. The other warning from the same setup, `Trying to set the step mode for X, which is not a StepModule`, likewise did not say what that implies or how to fix it.

This PR makes both warnings state the remedy. No behaviour change: assignments, rejections and log sites are unchanged.

## Changes

- `set_backend`: the warning now includes the module's current `step_mode` and its `supported_backends`, and says to call `set_step_mode()` before `set_backend()` when the backend is only available in another step mode. `step_mode` is read with `getattr` so duck-typed modules without one keep working.
- `set_step_mode`: the warning now names the assigned `step_mode`, states that it is assigned as a plain attribute without validation, and points to the `StepModule` / `MemoryModule` contract.
- zh/en docstrings for both functions document the ordering. `triton` is multi-step-only for `LIFNode`/`IFNode`; `cupy` is multi-step-only for `ParametricLIFNode`. The zh/en neuron tutorials gain a short `set_step_mode` then `set_backend` example.
- New `test/activation_based/test_net_config.py` (3 tests): a plain module with a `step_mode` attribute warns with the remedy and still gets the value; a `StepModule` container is silent; `set_backend('cupy')` on a single-step `ParametricLIFNode` warns with `step_mode` / `supported_backends`, keeps `torch`, and `cupy` is offered after `set_step_mode('m')`. Warnings are captured with the shared `loguru_records` fixture.
- Changelog entry under Unreleased / Improvements; `docs/source/changelog.rst` regenerated.

## Before / after

```text
- ...) does not support backend=cupy; it will continue using backend=torch
+ ...) does not support backend=cupy while step_mode=s (supported_backends=('torch',)); it will continue using backend=torch. supported_backends can depend on step_mode, so call set_step_mode() before set_backend() if the backend is only available in another step mode

- Trying to set the step mode for PlainStepModeModule(), which is not a StepModule
+ Trying to set the step mode for PlainStepModeModule(), which is not a StepModule; step_mode=m is assigned as a plain attribute without validation. Inherit from spikingjelly.activation_based.base.StepModule (or MemoryModule) if this module should follow the step-mode contract
```

## Testing

- `pytest test/activation_based/test_net_config.py test/test_logging_policy.py test/activation_based/test_functional.py test/activation_based/test_functional_layer.py test/activation_based/test_memory.py test/activation_based/test_noisy_and_misc.py`
- Reproduced the issue's call order on CPU with `LIFNode`, `IFNode` and `ParametricLIFNode`: the new warning appears, and after `set_step_mode('m')` the neurons list `cupy` / `triton` and a T=4 multi-step forward runs. CuPy and Triton were not installed, so the accelerated backends themselves were not exercised.
- `ruff check` / `ruff format --check`, `markdownlint` on `CHANGELOG.md`, `tools/generate_changelog_rst.py --check`, and a Sphinx build with no new warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warnings for unsupported backends and step-mode configuration.
  * Warnings now show the active step mode, supported backends, and recommend setting the step mode before selecting a backend.
  * Modules with a `step_mode` attribute but without the recommended inheritance receive clearer guidance.

* **Documentation**
  * Added English and Chinese tutorial guidance for configuring an entire network’s step mode and backend.
  * Updated the changelog with configuration behavior and ordering details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
